### PR TITLE
Preserve whitespace

### DIFF
--- a/assets/pages/Container.vue
+++ b/assets/pages/Container.vue
@@ -93,6 +93,6 @@ export default {
 }
 
 .text {
-  white-space: pre;
+  white-space: pre-wrap;
 }
 </style>

--- a/assets/pages/Container.vue
+++ b/assets/pages/Container.vue
@@ -2,7 +2,7 @@
   <div class="is-fullheight">
     <ul ref="events" class="events">
       <li v-for="item in messages" class="event" :key="item.key">
-        <span class="date">{{ item.dateRelative }}</span> <span class="text">{{ item.message }}</span>
+        <span class="date">{{ item.dateRelative }}</span> <span class="text item-message">{{ item.message }}</span>
       </li>
     </ul>
     <scrollbar-notification :messages="messages"></scrollbar-notification>
@@ -90,5 +90,9 @@ export default {
 
 .is-fullheight {
   min-height: 100vh;
+}
+
+.item-message {
+  white-space: pre;
 }
 </style>

--- a/assets/pages/Container.vue
+++ b/assets/pages/Container.vue
@@ -2,7 +2,7 @@
   <div class="is-fullheight">
     <ul ref="events" class="events">
       <li v-for="item in messages" class="event" :key="item.key">
-        <span class="date">{{ item.dateRelative }}</span> <span class="text item-message">{{ item.message }}</span>
+        <span class="date">{{ item.dateRelative }}</span> <span class="text">{{ item.message }}</span>
       </li>
     </ul>
     <scrollbar-notification :messages="messages"></scrollbar-notification>
@@ -92,7 +92,7 @@ export default {
   min-height: 100vh;
 }
 
-.item-message {
+.text {
   white-space: pre;
 }
 </style>


### PR DESCRIPTION
Here are some comparison screenshots: https://imgur.com/a/LZ3OyL4. Using `white-space: pre-wrap` fixes the line wrap issue while preserving whitespace.