### PR TITLE
added --showAll flag that will show all containers (default: false)

### DIFF
--- a/.reflex
+++ b/.reflex
@@ -1,1 +1,1 @@
--r '\.go$' -R '^node_modules/' -R '^static/' -R '^.cache/' -G '*_test.go' -s -- go run main.go --level debug
+-r '\.go$' -R '^node_modules/' -R '^static/' -R '^.cache/' -G '*_test.go' -s -- go run main.go --level debug --showAll

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Dozzle follows the [12-factor](https://12factor.net/) model. Configurations can 
 | `--addr` | `DOZZLE_ADDR` | `:8080` |
 | `--base` | `DOZZLE_BASE` | `/` |
 | `--level` | `DOZZLE_LEVEL` | `info` |
+| `--showAll` | `DOZZLE_SHOWALL` | `false` |
 | n/a | `DOCKER_API_VERSION` | `1.38` |
 | `--tailSize` | `DOZZLE_TAILSIZE` | `300` |
 | `--filter` | `DOZZLE_FILTER` | `""` |

--- a/docker/client.go
+++ b/docker/client.go
@@ -30,7 +30,7 @@ type dockerProxy interface {
 
 // Client is a proxy around the docker client
 type Client interface {
-	ListContainers() ([]Container, error)
+	ListContainers(showAll bool) ([]Container, error)
 	FindContainer(string) (Container, error)
 	ContainerLogs(context.Context, string, int) (<-chan string, <-chan error)
 	Events(context.Context) (<-chan events.Message, <-chan error)
@@ -61,7 +61,7 @@ func NewClientWithFilters(f map[string]string) Client {
 
 func (d *dockerClient) FindContainer(id string) (Container, error) {
 	var container Container
-	containers, err := d.ListContainers()
+	containers, err := d.ListContainers(true)
 	if err != nil {
 		return container, err
 	}
@@ -81,9 +81,10 @@ func (d *dockerClient) FindContainer(id string) (Container, error) {
 	return container, nil
 }
 
-func (d *dockerClient) ListContainers() ([]Container, error) {
+func (d *dockerClient) ListContainers(showAll bool) ([]Container, error) {
 	containerListOptions := types.ContainerListOptions{
 		Filters: d.filters,
+		All: showAll,
 	}
 	list, err := d.cli.ContainerList(context.Background(), containerListOptions)
 	if err != nil {

--- a/docker/client_test.go
+++ b/docker/client_test.go
@@ -44,7 +44,7 @@ func Test_dockerClient_ListContainers_null(t *testing.T) {
 	proxy.On("ContainerList", mock.Anything, mock.Anything).Return(nil, nil)
 	client := &dockerClient{proxy, filters.NewArgs()}
 
-	list, err := client.ListContainers()
+	list, err := client.ListContainers(true)
 	assert.Empty(t, list, "list should be empty")
 	require.NoError(t, err, "error should not return an error.")
 
@@ -56,7 +56,7 @@ func Test_dockerClient_ListContainers_error(t *testing.T) {
 	proxy.On("ContainerList", mock.Anything, mock.Anything).Return(nil, errors.New("test"))
 	client := &dockerClient{proxy, filters.NewArgs()}
 
-	list, err := client.ListContainers()
+	list, err := client.ListContainers(true)
 	assert.Nil(t, list, "list should be nil")
 	require.Error(t, err, "test.")
 
@@ -79,7 +79,7 @@ func Test_dockerClient_ListContainers_happy(t *testing.T) {
 	proxy.On("ContainerList", mock.Anything, mock.Anything).Return(containers, nil)
 	client := &dockerClient{proxy, filters.NewArgs()}
 
-	list, err := client.ListContainers()
+	list, err := client.ListContainers(true)
 	require.NoError(t, err, "error should not return an error.")
 
 	assert.Equal(t, list, []Container{

--- a/main_test.go
+++ b/main_test.go
@@ -32,7 +32,7 @@ func (m *MockedClient) FindContainer(id string) (docker.Container, error) {
 	return container, args.Error(1)
 }
 
-func (m *MockedClient) ListContainers() ([]docker.Container, error) {
+func (m *MockedClient) ListContainers(showAll bool) ([]docker.Container, error) {
 	args := m.Called()
 	containers, ok := args.Get(0).([]docker.Container)
 	if !ok {
@@ -246,7 +246,7 @@ func Test_createRoutes_index(t *testing.T) {
 	box := packr.NewBox("./virtual")
 	require.NoError(t, box.AddString("index.html", "index page"), "AddString should have no error.")
 
-	handler := createRoutes("/", &handler{mockedClient, box})
+	handler := createRoutes("/", &handler{mockedClient, true, box})
 	req, err := http.NewRequest("GET", "/", nil)
 	require.NoError(t, err, "NewRequest should not return an error.")
 	rr := httptest.NewRecorder()
@@ -259,7 +259,7 @@ func Test_createRoutes_redirect(t *testing.T) {
 	mockedClient := new(MockedClient)
 	box := packr.NewBox("./virtual")
 
-	handler := createRoutes("/foobar", &handler{mockedClient, box})
+	handler := createRoutes("/foobar", &handler{mockedClient, true,box})
 	req, err := http.NewRequest("GET", "/foobar", nil)
 	require.NoError(t, err, "NewRequest should not return an error.")
 	rr := httptest.NewRecorder()
@@ -273,7 +273,7 @@ func Test_createRoutes_foobar(t *testing.T) {
 	box := packr.NewBox("./virtual")
 	require.NoError(t, box.AddString("index.html", "foo page"), "AddString should have no error.")
 
-	handler := createRoutes("/foobar", &handler{mockedClient, box})
+	handler := createRoutes("/foobar", &handler{mockedClient, true, box})
 	req, err := http.NewRequest("GET", "/foobar/", nil)
 	require.NoError(t, err, "NewRequest should not return an error.")
 	rr := httptest.NewRecorder()
@@ -287,7 +287,7 @@ func Test_createRoutes_foobar_file(t *testing.T) {
 	box := packr.NewBox("./virtual")
 	require.NoError(t, box.AddString("/test", "test page"), "AddString should have no error.")
 
-	handler := createRoutes("/foobar", &handler{mockedClient, box})
+	handler := createRoutes("/foobar", &handler{mockedClient, true, box})
 	req, err := http.NewRequest("GET", "/foobar/test", nil)
 	require.NoError(t, err, "NewRequest should not return an error.")
 	rr := httptest.NewRecorder()
@@ -300,7 +300,7 @@ func Test_createRoutes_version(t *testing.T) {
 	mockedClient := new(MockedClient)
 	box := packr.NewBox("./virtual")
 
-	handler := createRoutes("/", &handler{mockedClient, box})
+	handler := createRoutes("/", &handler{mockedClient, true, box})
 	req, err := http.NewRequest("GET", "/version", nil)
 	require.NoError(t, err, "NewRequest should not return an error.")
 	rr := httptest.NewRecorder()


### PR DESCRIPTION
Sometimes is quite handy to look upon `down` container logs, this PR make it possible.
It creates a `--showAll` flag, which by default set to `false`.

It will not break anything.