### PR TITLE
[WIP][don't merge] settings: add option to hide timestamps

### DIFF
--- a/assets/pages/Settings.vue
+++ b/assets/pages/Settings.vue
@@ -19,7 +19,7 @@
       <div class="has-underline">
         <h2 class="title is-4">Display</h2>
       </div>
-      <div class="item">
+      <div class="item">hiddenTimestamps
         <b-switch v-model="search">
           Enable searching with Dozzle using <code>command+f</code> or <code>ctrl+f</code>
         </b-switch>
@@ -28,6 +28,12 @@
       <div class="item">
         <b-switch v-model="smallerScrollbars">
           Use smaller scrollbars
+        </b-switch>
+      </div>
+
+      <div class="item">
+        <b-switch v-model="hiddenTimestamps">
+          Hide timestamps
         </b-switch>
       </div>
 
@@ -89,7 +95,7 @@ export default {
   },
   computed: {
     ...mapState(["settings"]),
-    ...["search", "size", "smallerScrollbars"].reduce((map, name) => {
+    ...["search", "size", "smallerScrollbars", "hiddenTimestamps"].reduce((map, name) => {
       map[name] = {
         get() {
           return this.settings[name];

--- a/assets/store/settings.js
+++ b/assets/store/settings.js
@@ -4,4 +4,5 @@ export const DEFAULT_SETTINGS = {
   size: "medium",
   menuWidth: 15,
   smallerScrollbars: false,
+  hiddenTimestamps: false,
 };

--- a/docker/client.go
+++ b/docker/client.go
@@ -199,7 +199,7 @@ func (d *dockerClient) ContainerLogsBetweenDates(ctx context.Context, id string,
 	options := types.ContainerLogsOptions{
 		ShowStdout: true,
 		ShowStderr: true,
-		Timestamps: true,
+		Timestamps: fale,
 		Since:      strconv.FormatInt(from.Unix(), 10),
 		Until:      strconv.FormatInt(to.Unix(), 10),
 	}


### PR DESCRIPTION
Add an option in settings to disable timestamps in the log viewer.
This is needed beause for example, log4j logs creates new lines with tabs to ease redability. Showing timestamp on each line will make it harder to read again.