### PR TITLE
Add sample Nginx config to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Dozzle follows the [12-factor](https://12factor.net/) model. Configurations can 
 | `--tailSize` | `DOZZLE_TAILSIZE`    | `300`   |
 | `--filter`   | `DOZZLE_FILTER`      | `""`    |
 
-### Troubleshooting
+## Troubleshooting
 
-## Sample Nginx config
+### Sample Nginx config
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,23 @@ then you can override by using `--base /foobar`. See env variables below for usi
 
 dozzle will be available at [http://localhost:8080/foobar/](http://localhost:8080/foobar/).
 
-### Sample Nginx config
+#### Environment variables and configuration
+
+Dozzle follows the [12-factor](https://12factor.net/) model. Configurations can use the CLI flags or enviroment variables. The table below outlines all supported options and their respective env vars.
+
+| Flag         | Env Variable         | Default |
+| ------------ | -------------------- | ------- |
+| `--addr`     | `DOZZLE_ADDR`        | `:8080` |
+| `--base`     | `DOZZLE_BASE`        | `/`     |
+| `--level`    | `DOZZLE_LEVEL`       | `info`  |
+| `--showAll`  | `DOZZLE_SHOWALL`     | `false` |
+| n/a          | `DOCKER_API_VERSION` | not set |
+| `--tailSize` | `DOZZLE_TAILSIZE`    | `300`   |
+| `--filter`   | `DOZZLE_FILTER`      | `""`    |
+
+### Troubleshooting
+
+## Sample Nginx config
 
 ```
 
@@ -106,21 +122,6 @@ dozzle will be available at [http://localhost:8080/foobar/](http://localhost:808
     }
 
 ```
-
-
-#### Environment variables and configuration
-
-Dozzle follows the [12-factor](https://12factor.net/) model. Configurations can use the CLI flags or enviroment variables. The table below outlines all supported options and their respective env vars.
-
-| Flag         | Env Variable         | Default |
-| ------------ | -------------------- | ------- |
-| `--addr`     | `DOZZLE_ADDR`        | `:8080` |
-| `--base`     | `DOZZLE_BASE`        | `/`     |
-| `--level`    | `DOZZLE_LEVEL`       | `info`  |
-| `--showAll`  | `DOZZLE_SHOWALL`     | `false` |
-| n/a          | `DOCKER_API_VERSION` | not set |
-| `--tailSize` | `DOZZLE_TAILSIZE`    | `300`   |
-| `--filter`   | `DOZZLE_FILTER`      | `""`    |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,42 @@ then you can override by using `--base /foobar`. See env variables below for usi
 
 dozzle will be available at [http://localhost:8080/foobar/](http://localhost:8080/foobar/).
 
+### Sample Nginx config
+
+```
+
+    server {
+        listen                          80;
+        server_name                     <example.com>;
+        return                          301 https://<example.com>$request_uri;
+    }
+
+    server {
+        listen                          443 ssl http2;
+        server_name                     <example.com>;
+
+        ssl_certificate                 </path/to/your/certificate>;
+        ssl_certificate_key             </path/to/your/key>;
+
+        location / {
+            proxy_pass                  http://<dozzle.container.ip.address>:8080;
+        }
+
+        location /api {
+            proxy_pass                  http://<dozzle.container.ip.address>:8080;
+
+            proxy_http_version          1.1;
+            proxy_set_header            Connection "";
+            proxy_buffering             off;
+            proxy_cache                 off;
+
+            chunked_transfer_encoding   off;
+        }
+    }
+
+```
+
+
 #### Environment variables and configuration
 
 Dozzle follows the [12-factor](https://12factor.net/) model. Configurations can use the CLI flags or enviroment variables. The table below outlines all supported options and their respective env vars.


### PR DESCRIPTION
This pull request adds a minimal sample Nginx config to the README.md file with the options that are required for getting Dozzle to work over HTTPS.