### PR TITLE
Updated dockerfile to node 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build assets
-FROM node:13-alpine as node
+FROM node:14-alpine as node
 
 RUN apk add --no-cache git openssh python make g++ util-linux
 


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

Node 13 becomes EOL on 1st June 2020, updating to Node 14 which is supported until 30th April 2023.
Excellent project keep up the good work.