### PR TITLE
Add expose instruction to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ ARG TAG=dev
 RUN CGO_ENABLED=0 go build -ldflags "-s -w -X main.version=$TAG"  -o dozzle
 
 FROM scratch
+EXPOSE 8080
 
 ENV PATH=/bin
 


### PR DESCRIPTION
Adding expose instruction to Dockerfile as its needed for service discovery by reverse proxy (like Traefik)