### PR TITLE
Fix #581: use DOZZLE_BASE when calling /api/logs?id=...

### DIFF
--- a/assets/components/LogEventSource.vue
+++ b/assets/components/LogEventSource.vue
@@ -62,7 +62,7 @@ export default {
       const delta = to - last;
       const from = new Date(to.getTime() + delta);
       const logs = await (
-        await fetch(`/api/logs?id=${this.id}&from=${from.toISOString()}&to=${to.toISOString()}`)
+        await fetch(`${config.base}/api/logs?id=${this.id}&from=${from.toISOString()}&to=${to.toISOString()}`)
       ).text();
       if (logs) {
         const newMessages = logs


### PR DESCRIPTION
Small fix, rebuilt docker image locally to verify, this fix seems to solve it #581