### PR TITLE
Change page scroll icon to chevrons-down

### DIFF
--- a/assets/components/ScrollableView.vue
+++ b/assets/components/ScrollableView.vue
@@ -14,7 +14,7 @@
     <div class="is-scrollbar-notification">
       <transition name="fade">
         <button class="button" :class="hasMore ? 'has-more' : ''" @click="scrollToBottom('instant')" v-show="paused">
-          <icon name="download"></icon>
+          <icon name="chevrons-down"></icon>
         </button>
       </transition>
     </div>


### PR DESCRIPTION
Hey, been using this app for a bit in my Docker setup. So far it seems like a great alternative to Docker Desktop GUI!

Here's a PR for fixing the page down icon to use the chevrons one instead. I think it's more fitting than the download icon, what do you think?

<img width="87" alt="image" src="https://user-images.githubusercontent.com/3276350/136314540-96688e56-2d75-4551-9c67-c988e23fd3ab.png">
