### PR TITLE
Improve setup documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 static
 dozzle
 coverage
+.pnpm-debug.log

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ Dozzle has a [special route](https://github.com/amir20/dozzle/blob/master/assets
 
 To Build and test locally:
 
-1. Install NodeJs.
-2. Install Go.
-3. Install [reflex](https://github.com/cespare/reflex) with `get -u github.com/cespare/reflex` outside of dozzle.
+1. Install [NodeJs](https://nodejs.org/en/download/) and [pnpm](https://pnpm.io/installation).
+2. Install [Go](https://go.dev/doc/install).
+3. Install [reflex](https://github.com/cespare/reflex) with `go get -u github.com/cespare/reflex` outside of dozzle.
 4. Install node modules `pnpm install`.
 5. Do `pnpm dev`


### PR DESCRIPTION
Hi there :wave: Thanks for open sourcing this project! I was playing with the code and found a few minor things in the documentation that could have been a little clearer to me as a Go novice:

* Add links to the installation documentation for the various tools the project depends on.
* Make the CLI command to install reflex copy-pastable.
* I also ran into a pnpm user error which dropped a log file to disk which shouldn't be checked in so I added it to the git-ignore list to clean up the git status.

Hope that these minor changes can make it even easier for others to get started to contribute to the repository and thanks again!