### PR TITLE
Add option to wait for docker before starting

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,6 +10,7 @@ jobs:
   buildx:
     name: Push branches and PRs
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'amir20/dozzle' }}
     steps:
       - name: Docker meta
         id: meta

--- a/main.go
+++ b/main.go
@@ -25,17 +25,17 @@ var (
 )
 
 type args struct {
-	Addr          string              `arg:"env:DOZZLE_ADDR" default:":8080" help:"sets host:port to bind for server. This is rarely needed inside a docker container."`
-	Base          string              `arg:"env:DOZZLE_BASE" default:"/" help:"sets the base for http router."`
-	Level         string              `arg:"env:DOZZLE_LEVEL" default:"info" help:"set Dozzle log level. Use debug for more logging."`
-	TailSize      int                 `arg:"env:DOZZLE_TAILSIZE" default:"300" help:"update the initial tail size when fetching logs."`
-	Key           string              `arg:"env:DOZZLE_KEY" help:"set a random key for username and password. This is required for auth."`
-	Username      string              `arg:"env:DOZZLE_USERNAME" help:"sets the username for auth."`
-	Password      string              `arg:"env:DOZZLE_PASSWORD" help:"sets password for auth"`
-	NoAnalytics   bool                `arg:"--no-analytics,env:DOZZLE_NO_ANALYTICS" help:"disables anonymous analytics"`
-	WaitForDocker bool                `arg:"--wait-for-docker,env:DOZZLE_WAIT_FOR_DOCKER" help:"wait for docker to be available before starting the server."`
-	FilterStrings []string            `arg:"env:DOZZLE_FILTER,--filter,separate" help:"filters docker containers using Docker syntax."`
-	Filter        map[string][]string `arg:"-"`
+	Addr                 string              `arg:"env:DOZZLE_ADDR" default:":8080" help:"sets host:port to bind for server. This is rarely needed inside a docker container."`
+	Base                 string              `arg:"env:DOZZLE_BASE" default:"/" help:"sets the base for http router."`
+	Level                string              `arg:"env:DOZZLE_LEVEL" default:"info" help:"set Dozzle log level. Use debug for more logging."`
+	TailSize             int                 `arg:"env:DOZZLE_TAILSIZE" default:"300" help:"update the initial tail size when fetching logs."`
+	Key                  string              `arg:"env:DOZZLE_KEY" help:"set a random key for username and password. This is required for auth."`
+	Username             string              `arg:"env:DOZZLE_USERNAME" help:"sets the username for auth."`
+	Password             string              `arg:"env:DOZZLE_PASSWORD" help:"sets password for auth"`
+	NoAnalytics          bool                `arg:"--no-analytics,env:DOZZLE_NO_ANALYTICS" help:"disables anonymous analytics"`
+	WaitForDockerSeconds int                 `arg:"--wait-for-docker-seconds,env:DOZZLE_WAIT_FOR_DOCKER_SECONDS" help:"wait for docker to be available for at most this many seconds before starting the server."`
+	FilterStrings        []string            `arg:"env:DOZZLE_FILTER,--filter,separate" help:"filters docker containers using Docker syntax."`
+	Filter               map[string][]string `arg:"-"`
 }
 
 func (args) Version() string {
@@ -75,11 +75,12 @@ func main() {
 		_, err := dockerClient.ListContainers()
 		if err == nil {
 			break
-		} else if !args.WaitForDocker {
+		} else if args.WaitForDockerSeconds <= 0 {
 			log.Fatalf("Could not connect to Docker Engine: %v", err)
 		} else {
 			log.Infof("Waiting for Docker Engine (attempt %d): %s", i, err)
 			time.Sleep(5 * time.Second)
+			args.WaitForDockerSeconds -= 5
 		}
 	}
 


### PR DESCRIPTION
## What does this pull request do?

This pull request adds a new configuration option `DOZZLE_WAIT_FOR_DOCKER` which if set will defer the server start until the connection to docker is healthy.

## Why is this useful?

In some environments, the docker connection isn't via a socket file but instead via tcp, for example if we're connecting to a remote docker host or if we're using a proxy to only allow selective access to docker APIs for security reasons. In these scenarios, the docker host may or may not be ready to serve requests at the time that dozzle starts. To simplify deployments in such an environment, it's very useful if dozzle can "self heal" and only start talking to the docker host once the docker host is ready for connections.

Of course it would also be possible to perform an external health check before starting the dozzle container, but this adds non-trivial complexity to the orchestration especially as the the dozzle container doesn't contain a shell so we couldn't for example override the entrypoint to a loop like `sh -c "while ! exec /dozzle; do sleep 5; done"`. Other tools that talk to the docker host (e.g. [Traefik](https://doc.traefik.io/traefik/)) implement this sort of "self heal" mechanism so I believe it would be neat if dozzle could also do this, especially as the added code complexity is quite minor.

## How can I test these changes?

Create a docker-compose file that defines dozzle and the docker socket proxy:

```yaml
version: "2.3"

services:

  dozzle:
    build: .
    environment:
      DOZZLE_NO_ANALYTICS: "1"
      DOZZLE_WAIT_FOR_DOCKER_SECONDS: "120"
      DOCKER_HOST: "tcp://docker-proxy:2375"
    ports:
      - "8080:8080"

  docker-proxy:
    image: tecnativa/docker-socket-proxy
    environment:
      CONTAINERS: "1"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock:ro
```

Now start dozzle via `docker-compose up --build dozzle` and you will notice that the server waits to start up since the docker connection can't be established. Now start the docker socket proxy via `docker-compose up -d docker-proxy` and you will notice that dozzle now starts the server.