### PR TITLE
Support building in a container with a custom Dockerfile image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,4 +169,4 @@ To Build and test locally:
 2. Install [Go](https://go.dev/doc/install).
 3. Install [reflex](https://github.com/cespare/reflex) with `go get -u github.com/cespare/reflex` outside of dozzle.
 4. Install node modules `pnpm install`.
-5. Do `pnpm dev`
+5. Do `pnpm dev` (or `pnpm dev:docker` to build in a container).

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   "author": "Amir Raminfar <findamir@gmail.com>",
   "scripts": {
     "watch:assets": "vite --open",
+    "watch:assets:docker": "vite --host",
     "watch:server": "LIVE_FS=true DOZZLE_ADDR=:3100 reflex -c .reflex",
     "dev": "make fake_assets && npm-run-all -p watch:assets watch:server",
+    "dev:docker": "make fake_assets && npm-run-all -p watch:assets:docker watch:server",
     "build": "vite build",
     "release": "release-it",
     "test": "TZ=UTC vitest",


### PR DESCRIPTION
"pnpm dev" generates a nodejs error in a container because of the "--open" option of vite which opens the app in the default browser. "pnpm dev:docker" solves this issue and support building dozzle in a container from a custom Dockerfile image.
The "--host" option publishes the default port where the app is running (3000), but it can be changed to another one by adding the preferred port in the script, like: "vite --host 8080". 