### PR TITLE
Fix json log line still says "expand json" when expanded

### DIFF
--- a/assets/components/LogViewer/ComplexLogItem.vue
+++ b/assets/components/LogViewer/ComplexLogItem.vue
@@ -4,7 +4,7 @@
       <log-date :date="logEntry.date"></log-date>
     </div>
     <div class="column">
-      <ul class="fields" @click="expanded = !expanded">
+      <ul class="fields" :class="{ expanded }" @click="expanded = !expanded">
         <li v-for="(value, name) in validValues(logEntry.message)">
           <span class="has-text-grey">{{ name }}=</span>
           <span class="has-text-weight-bold" v-html="markSearch(value)"></span>
@@ -44,6 +44,12 @@ function validValues(obj: Record<string, any>) {
       display: inline-block;
       margin-left: 0.5em;
       font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+    }
+  }
+
+  &.expanded:hover {
+    &::after {
+      content: "collapse json";
     }
   }
 


### PR DESCRIPTION
Noticed this issue when using the new json log lines feature. This should fix it. Now when you expand the json, it will say "collapse json" if it's still expanded.

![Screen Shot 2022-10-01 at 5 19 12 PM](https://user-images.githubusercontent.com/3276350/193428852-db4ad594-5d16-4a69-a446-498883d2837d.png)

![Screen Shot 2022-10-01 at 5 19 29 PM](https://user-images.githubusercontent.com/3276350/193428855-60fd6814-ca3b-4f17-8992-9a0e01dcd5fc.png)
