### PR TITLE
Use ui-monospace as the default font for log viewer

### DIFF
--- a/assets/components/LogViewer/LogViewer.vue
+++ b/assets/components/LogViewer/LogViewer.vue
@@ -66,7 +66,7 @@ watch(
 <style scoped lang="scss">
 .events {
   padding: 1em 0;
-  font-family: SFMono-Regular, Consolas, Liberation Mono, monaco, Menlo, monospace;
+  font-family: ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monaco, Menlo, monospace;
 
   & > li {
     display: flex;

--- a/assets/components/LogViewer/LogViewer.vue
+++ b/assets/components/LogViewer/LogViewer.vue
@@ -66,7 +66,7 @@ watch(
 <style scoped lang="scss">
 .events {
   padding: 1em 0;
-  font-family: ui-monospace, SFMono-Regular, Consolas, Liberation Mono, monaco, Menlo, monospace;
+  font-family: ui-monospace, SFMono-Regular, SF Mono, Consolas, Liberation Mono, monaco, Menlo, monospace;
 
   & > li {
     display: flex;


### PR DESCRIPTION
For the most part, this makes Safari use SF Mono instead of falling back to Consolas.