### PR TITLE
Fix bad version update URL

### DIFF
--- a/locales/de.yml
+++ b/locales/de.yml
@@ -52,6 +52,6 @@ settings:
   search: Aktiviere die Suche mit Dozzle mit
   using-version: Du verwendest Dozzle {version}.
   update-available: >-
-    Eine neue Version ist verfügbar! Aktualisiere auf <a :href="{href}" class="next-release"
+    Eine neue Version ist verfügbar! Aktualisiere auf <a href="{href}" class="next-release"
     target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Zeige stdout und stderr Labels

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -53,6 +53,6 @@ settings:
   search: Enable searching with Dozzle using
   using-version: You are using Dozzle {version}.
   update-available: >-
-    New version is available! Update to <a :href="{href}" class="next-release"
+    New version is available! Update to <a href="{href}" class="next-release"
     target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Show stdout and stderr labels

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -53,5 +53,5 @@ settings:
   using-version: Estás usando Dozzle {version}.
   update-available: >-
     ¡La nueva versión está disponible! Actualizar a la
-    <a :href="{href}" class="next-release" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
+    <a href="{href}" class="next-release" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Mostrar etiquetas de salida estándar y salida de error estándar

--- a/locales/pr.yml
+++ b/locales/pr.yml
@@ -53,5 +53,5 @@ settings:
   using-version: Está a usar o Dozzle {version}.
   update-available: >-
     Está disponível uma nova versão! Actualização para
-    <a :href="{href}" class="next-release" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
+    <a href="{href}" class="next-release" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Mostrar etiquetas de saída padrão e saída de erro padrão

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -51,6 +51,6 @@ settings:
   search: Включить поиск с помощью Dozzle, используя
   using-version: Вы используете версию Dozzle {version}.
   update-available: >-
-    Доступна новая версия! Обновить до <a :href="{href}" class="next-release"
+    Доступна новая версия! Обновить до <a href="{href}" class="next-release"
     target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Показывать метки stdout и stderr

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -51,6 +51,6 @@ settings:
   search: 使用Dozzle启用搜索
   using-version: 您正在使用Dozzle {version}。
   update-available: >-
-    新版本可用！更新到 <a :href="{href}" class="next-release"
+    新版本可用！更新到 <a href="{href}" class="next-release"
     target="_blank" rel="noreferrer noopener">{nextVersion}</a>。
   show-std: 显示stdout和stderr标签


### PR DESCRIPTION
Removed the colon from the `<a>` tags in the "New version available" link, which prevented the URL from opening.