### PR TITLE
feat: Improve page title and add localization

### DIFF
--- a/assets/composables/title.ts
+++ b/assets/composables/title.ts
@@ -1,6 +1,6 @@
 const { hostname } = config;
 let subtitle = $ref("");
-const title = $computed(() => `${subtitle} - Dozzle` + (hostname ? ` @ ${hostname}` : ""));
+const title = $computed(() => (subtitle ? `${subtitle} - ` : "") + "Dozzle" + (hostname ? ` @ ${hostname}` : ""));
 
 useTitle($$(title));
 

--- a/assets/layouts/default.vue
+++ b/assets/layouts/default.vue
@@ -51,11 +51,7 @@ const { oruga } = useProgrammatic();
 const { authorizationNeeded } = config;
 
 const containerStore = useContainerStore();
-const { activeContainers, visibleContainers } = storeToRefs(containerStore);
-
-watchEffect(() => {
-  setTitle(`${visibleContainers.value.length} containers`);
-});
+const { activeContainers } = storeToRefs(containerStore);
 
 onKeyStroke("k", (e) => {
   if ((e.ctrlKey || e.metaKey) && !e.shiftKey) {

--- a/assets/pages/container/[id].vue
+++ b/assets/pages/container/[id].vue
@@ -16,11 +16,8 @@ const { id } = defineProps<{ id: string }>();
 const currentContainer = store.currentContainer($$(id));
 const { activeContainers, ready } = storeToRefs(store);
 
-setTitle("loading");
-
-onMounted(() => {
-  setTitle(currentContainer.value?.name);
+watchEffect(() => {
+  if (ready.value === true)
+    currentContainer.value !== undefined ? setTitle(currentContainer.value.name) : setTitle("Not Found");
 });
-
-watchEffect(() => setTitle(currentContainer.value?.name));
 </script>

--- a/assets/pages/index.vue
+++ b/assets/pages/index.vue
@@ -52,9 +52,13 @@
 <script lang="ts" setup>
 import { Container } from "@/models/Container";
 
+const { t } = useI18n();
 const { version } = config;
 const containerStore = useContainerStore();
-const { containers } = storeToRefs(containerStore) as { containers: unknown } as { containers: Ref<Container[]> };
+const { containers, ready } = storeToRefs(containerStore) as unknown as {
+  containers: Ref<Container[]>;
+  ready: Ref<boolean>;
+};
 
 const mostRecentContainers = $computed(() => [...containers.value].sort((a, b) => +b.created - +a.created));
 const runningContainers = $computed(() => mostRecentContainers.filter((c) => c.state === "running"));
@@ -76,6 +80,10 @@ useIntervalFn(
   1000,
   { immediate: true },
 );
+
+watchEffect(() => {
+  if (ready.value === true) setTitle(t("title.dashboard", { count: runningContainers.length }));
+});
 </script>
 <style lang="scss" scoped>
 .panel {

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -30,6 +30,7 @@ error:
 title:
   page-not-found: Seite nicht gefunden
   login: Authentifizierung erforderlich
+  dashboard: 1 Container | {count} Container
   settings: Einstellungen
 button:
   logout: Ausloggen

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -31,6 +31,7 @@ error:
 title:
   page-not-found: Page not found
   login: Authentication Required
+  dashboard: 1 container | {count} containers
   settings: Settings
 button:
   logout: Logout

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -30,6 +30,7 @@ error:
 title:
   page-not-found: Página no encontrada
   login: Autenticación requerida
+  dashboard: 1 contenedor | {count} contenedores
   settings: Configuración
 button:
   logout: Cerrar la sesión

--- a/locales/pr.yml
+++ b/locales/pr.yml
@@ -30,6 +30,7 @@ error:
 title:
   page-not-found: Página não encontrada
   login: Autenticação Requerida
+  dashboard: 1 contentor | {count} contentores
   settings: Configurações
 button:
   logout: Terminar sessão

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -30,6 +30,7 @@ error:
 title:
   page-not-found: Страница не найдена
   login: Требуется авторизация
+  dashboard: 1 контейнер | {count} контейнеров
   settings: Настройки
 button:
   logout: Выйти

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -30,6 +30,7 @@ error:
 title:
   page-not-found: 页面未找到
   login: 需要身份验证
+  dashboard: 1 容器 | {count} 容器
   settings: 设置
 button:
   logout: 退出


### PR DESCRIPTION
This PR improves the page title handling.
It fixes the following things:
* Add translations
* Add pluralization for the amount of running containers
* Prevent unnecessary updates by only setting the title when the data is fully loaded
* Set the correct title for the settings page when reloading
* A bug where the title would not change when switching from a container logs page to the dashboard

_Note_
I tried my best with the translations, but I do not know if they are all correct.
Google Translate gives me the right English translation back for each language.