### PR TITLE
feat: adds forward-proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY --from=node /build/dist ./dist
 COPY analytics ./analytics
 COPY healthcheck ./healthcheck
 COPY docker ./docker
+COPY auth ./auth
 COPY web ./web
 COPY main.go ./
 

--- a/assets/pages/index.vue
+++ b/assets/pages/index.vue
@@ -1,5 +1,13 @@
 <template>
   <div class="flex flex-col gap-16 px-4 pt-8 md:px-8">
+    <section v-if="config.user">
+      <div class="flex items-center gap-4">
+        <div class="ml-auto">
+          {{ config.user?.email }}
+        </div>
+        <img class="h-10 w-10 rounded-full p-1 ring-2 ring-base-content/50" :src="config.user.avatar" />
+      </div>
+    </section>
     <section>
       <div class="stats grid bg-base-lighter shadow">
         <div class="stat">

--- a/assets/stores/config.ts
+++ b/assets/stores/config.ts
@@ -8,6 +8,12 @@ interface Config {
   maxLogs: number;
   hostname: string;
   hosts: { name: string; id: string }[];
+  user?: {
+    username: string;
+    email: string;
+    name: string;
+    avatar: string;
+  };
 }
 
 const pageConfig = JSON.parse(text);

--- a/auth/proxy.go
+++ b/auth/proxy.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"context"
+	"crypto/md5"
+	"encoding/hex"
+	"net/http"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type contextKey string
+
+const RemoteUser contextKey = "remoteUser"
+
+type User struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Avatar   string `json:"avatar,omitempty"`
+}
+
+func hashEmail(email string) string {
+	email = strings.TrimSpace(email)
+	email = strings.ToLower(email)
+	hash := md5.Sum([]byte(email))
+
+	return hex.EncodeToString(hash[:])
+}
+
+func newUser(username, email, name string) *User {
+	avatar := ""
+	if email != "" {
+		avatar = "https://gravatar.com/avatar/" + hashEmail(email)
+	}
+	return &User{
+		Username: username,
+		Email:    email,
+		Name:     name,
+		Avatar:   avatar,
+	}
+}
+
+func ForwardProxyAuthorizationRequired(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Remote-Email") == "" {
+			log.Error("Unable to find remote email. Please check your proxy configuration. Expecting header 'Remote-Email'")
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		user := newUser(r.Header.Get("Remote-User"), r.Header.Get("Remote-Email"), r.Header.Get("Remote-Name"))
+
+		ctx := context.WithValue(r.Context(), RemoteUser, user)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/web/__snapshots__/web.snapshot
+++ b/web/__snapshots__/web.snapshot
@@ -1,7 +1,7 @@
 /* snapshot: Test_createRoutes_foobar */
 HTTP/1.1 200 OK
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/plain; charset=utf-8
 
 foo page
@@ -9,7 +9,7 @@ foo page
 /* snapshot: Test_createRoutes_index */
 HTTP/1.1 200 OK
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/plain; charset=utf-8
 
 index page
@@ -17,7 +17,7 @@ index page
 /* snapshot: Test_createRoutes_redirect */
 HTTP/1.1 301 Moved Permanently
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/html; charset=utf-8
 Location: /foobar/
 
@@ -26,7 +26,7 @@ Location: /foobar/
 /* snapshot: Test_createRoutes_redirect_with_auth */
 HTTP/1.1 307 Temporary Redirect
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/html; charset=utf-8
 Location: /foobar/login
 
@@ -35,7 +35,7 @@ Location: /foobar/login
 /* snapshot: Test_createRoutes_username_password */
 HTTP/1.1 307 Temporary Redirect
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/html; charset=utf-8
 Location: /login
 
@@ -44,7 +44,7 @@ Location: /login
 /* snapshot: Test_createRoutes_username_password_invalid */
 HTTP/1.1 401 Unauthorized
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/plain; charset=utf-8
 X-Content-Type-Options: nosniff
 
@@ -56,7 +56,7 @@ Connection: close
 Cache-Control: no-transform
 Cache-Control: no-cache
 Connection: keep-alive
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/event-stream
 X-Accel-Buffering: no
 
@@ -66,7 +66,7 @@ data: end of stream
 /* snapshot: Test_createRoutes_version */
 HTTP/1.1 200 OK
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/html
 
 <pre>dev</pre>
@@ -74,7 +74,7 @@ Content-Type: text/html
 /* snapshot: Test_handler_between_dates */
 HTTP/1.1 200 OK
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: application/ld+json; charset=UTF-8
 
 {"m":"INFO Testing stdout logs...","ts":1589396137772,"id":466600245,"l":"info","s":"stdout"}
@@ -101,7 +101,7 @@ Connection: close
 Cache-Control: no-transform
 Cache-Control: no-cache
 Connection: keep-alive
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/event-stream
 X-Accel-Buffering: no
 
@@ -114,7 +114,7 @@ Connection: close
 Cache-Control: no-transform
 Cache-Control: no-cache
 Connection: keep-alive
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/event-stream
 X-Accel-Buffering: no
 
@@ -132,7 +132,7 @@ data: {"actorId":"1234","name":"start","host":"localhost"}
 /* snapshot: Test_handler_streamLogs_error_finding_container */
 HTTP/1.1 404 Not Found
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/plain; charset=utf-8
 X-Content-Type-Options: nosniff
 
@@ -144,7 +144,7 @@ Connection: close
 Cache-Control: no-transform
 Cache-Control: no-cache
 Connection: keep-alive
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/plain; charset=utf-8
 X-Accel-Buffering: no
 X-Content-Type-Options: nosniff
@@ -154,7 +154,7 @@ test error
 /* snapshot: Test_handler_streamLogs_error_std */
 HTTP/1.1 400 Bad Request
 Connection: close
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/plain; charset=utf-8
 X-Content-Type-Options: nosniff
 
@@ -166,7 +166,7 @@ Connection: close
 Cache-Control: no-transform
 Cache-Control: no-cache
 Connection: keep-alive
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/event-stream
 X-Accel-Buffering: no
 
@@ -181,7 +181,7 @@ Connection: close
 Cache-Control: no-transform
 Cache-Control: no-cache
 Connection: keep-alive
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/event-stream
 X-Accel-Buffering: no
 
@@ -194,7 +194,7 @@ Connection: close
 Cache-Control: no-transform
 Cache-Control: no-cache
 Connection: keep-alive
-Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;
+Content-Security-Policy: default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;
 Content-Type: text/event-stream
 X-Accel-Buffering: no
 

--- a/web/csp.go
+++ b/web/csp.go
@@ -6,7 +6,7 @@ import (
 
 func cspHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Security-Policy", "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; manifest-src 'self'; connect-src 'self' api.github.com;")
+		w.Header().Set("Content-Security-Policy", "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' gravatar.com data:; manifest-src 'self'; connect-src 'self' api.github.com;")
 		next.ServeHTTP(w, r)
 	})
 }

--- a/web/healthcheck.go
+++ b/web/healthcheck.go
@@ -1,0 +1,24 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (h *handler) healthcheck(w http.ResponseWriter, r *http.Request) {
+	log.Trace("Executing healthcheck request")
+	var client DockerClient
+	for _, v := range h.clients {
+		client = v
+		break
+	}
+
+	if ping, err := client.Ping(r.Context()); err != nil {
+		log.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	} else {
+		fmt.Fprintf(w, "OK API Version %v", ping.APIVersion)
+	}
+}

--- a/web/index.go
+++ b/web/index.go
@@ -1,0 +1,141 @@
+package web
+
+import (
+	"encoding/json"
+	"html/template"
+	"io"
+	"sort"
+
+	"net/http"
+	"os"
+	"path"
+
+	"github.com/amir20/dozzle/analytics"
+	"github.com/amir20/dozzle/docker"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func (h *handler) index(w http.ResponseWriter, req *http.Request) {
+	_, err := h.content.Open(req.URL.Path)
+	if err == nil && req.URL.Path != "" && req.URL.Path != "/" {
+		fileServer.ServeHTTP(w, req)
+		if !h.config.NoAnalytics {
+			go func() {
+				host, _ := os.Hostname()
+
+				var client DockerClient
+				for _, v := range h.clients {
+					client = v
+					break
+				}
+
+				if containers, err := client.ListContainers(); err == nil {
+					totalContainers := len(containers)
+					runningContainers := 0
+					for _, container := range containers {
+						if container.State == "running" {
+							runningContainers++
+						}
+					}
+
+					re := analytics.RequestEvent{
+						ClientId:          host,
+						TotalContainers:   totalContainers,
+						RunningContainers: runningContainers,
+					}
+					analytics.SendRequestEvent(re)
+				}
+			}()
+		}
+	} else {
+		if !isAuthorized(req) && req.URL.Path != "login" {
+			http.Redirect(w, req, path.Clean(h.config.Base+"/login"), http.StatusTemporaryRedirect)
+			return
+		}
+		h.executeTemplate(w, req)
+	}
+}
+
+func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
+	file, err := h.content.Open("index.html")
+	if err != nil {
+		log.Panic(err)
+	}
+	bytes, err := io.ReadAll(file)
+	if err != nil {
+		log.Panic(err)
+	}
+	tmpl, err := template.New("index.html").Funcs(template.FuncMap{
+		"marshal": func(v interface{}) template.JS {
+			a, _ := json.Marshal(v)
+			return template.JS(a)
+		},
+	}).Parse(string(bytes))
+	if err != nil {
+		log.Panic(err)
+	}
+
+	path := ""
+	if h.config.Base != "/" {
+		path = h.config.Base
+	}
+
+	hosts := make([]*docker.Host, 0, len(h.clients))
+	for _, v := range h.clients {
+		hosts = append(hosts, v.Host())
+	}
+	sort.Slice(hosts, func(i, j int) bool {
+		return hosts[i].Name < hosts[j].Name
+	})
+
+	config := map[string]interface{}{
+		"base":                path,
+		"version":             h.config.Version,
+		"authorizationNeeded": h.isAuthorizationNeeded(req),
+		"secured":             secured,
+		"hostname":            h.config.Hostname,
+		"hosts":               hosts,
+	}
+
+	if h.config.AuthProvider == "forward-proxy" {
+		user := req.Context().Value(remoteUser).(*User)
+		config["user"] = user
+	}
+
+	data := map[string]interface{}{
+		"Config":   config,
+		"Dev":      h.config.Dev,
+		"Manifest": h.readManifest(),
+		"Base":     path,
+	}
+
+	err = tmpl.Execute(w, data)
+	if err != nil {
+		log.Panic(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+func (h *handler) readManifest() map[string]interface{} {
+	if h.config.Dev {
+		return map[string]interface{}{}
+	} else {
+		file, err := h.content.Open("manifest.json")
+		if err != nil {
+			// this should only happen during test. In production, the file is embedded in the binary and checked in main.go
+			return map[string]interface{}{}
+		}
+		bytes, err := io.ReadAll(file)
+		if err != nil {
+			log.Fatalf("Could not read manifest.json: %v", err)
+		}
+		var manifest map[string]interface{}
+		err = json.Unmarshal(bytes, &manifest)
+		if err != nil {
+			log.Fatalf("Could not parse manifest.json: %v", err)
+		}
+		return manifest
+	}
+
+}

--- a/web/index.go
+++ b/web/index.go
@@ -11,6 +11,7 @@ import (
 	"path"
 
 	"github.com/amir20/dozzle/analytics"
+	"github.com/amir20/dozzle/auth"
 	"github.com/amir20/dozzle/docker"
 
 	log "github.com/sirupsen/logrus"
@@ -99,7 +100,7 @@ func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if h.config.AuthProvider == "forward-proxy" {
-		user := req.Context().Value(remoteUser).(*User)
+		user := req.Context().Value(auth.RemoteUser).(*auth.User)
 		config["user"] = user
 	}
 

--- a/web/routes.go
+++ b/web/routes.go
@@ -94,6 +94,7 @@ func NewUser(username, email, name string) *User {
 func forwardProxyAuthorizationRequired(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Remote-Email") == "" {
+			log.Error("Unable to find remote email. Please check your proxy configuration. Expecting header 'Remote-Email'")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/web/routes.go
+++ b/web/routes.go
@@ -122,9 +122,7 @@ func createRouter(h *handler) *chi.Mux {
 				r.Use(forwardProxyAuthorizationRequired)
 			}
 			r.Group(func(r chi.Router) {
-				if h.config.AuthProvider == "simple" {
-					r.Use(authorizationRequired)
-				}
+				r.Use(authorizationRequired)
 				r.Get("/api/logs/stream/{host}/{id}", h.streamLogs)
 				r.Get("/api/logs/download/{host}/{id}", h.downloadLogs)
 				r.Get("/api/logs/{host}/{id}", h.fetchLogsBetweenDates)

--- a/web/routes.go
+++ b/web/routes.go
@@ -81,7 +81,7 @@ func hashEmail(email string) string {
 func NewUser(username, email, name string) *User {
 	avatar := ""
 	if email != "" {
-		avatar = "https://www.gravatar.com/avatar/" + hashEmail(email)
+		avatar = "https://gravatar.com/avatar/" + hashEmail(email)
 	}
 	return &User{
 		Username: username,

--- a/web/routes.go
+++ b/web/routes.go
@@ -2,37 +2,32 @@ package web
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"html/template"
+	"crypto/md5"
+	"encoding/hex"
 	"io"
 	"io/fs"
-	"sort"
 	"time"
 
 	"net/http"
-	"os"
-	"path"
 	"strings"
 
-	"github.com/amir20/dozzle/analytics"
 	"github.com/amir20/dozzle/docker"
 	"github.com/docker/docker/api/types"
 	"github.com/go-chi/chi/v5"
-
 	log "github.com/sirupsen/logrus"
 )
 
 // Config is a struct for configuring the web service
 type Config struct {
-	Base        string
-	Addr        string
-	Version     string
-	Username    string
-	Password    string
-	Hostname    string
-	NoAnalytics bool
-	Dev         bool
+	Base         string
+	Addr         string
+	Version      string
+	Username     string
+	Password     string
+	Hostname     string
+	NoAnalytics  bool
+	Dev          bool
+	AuthProvider string
 }
 
 type handler struct {
@@ -64,6 +59,52 @@ func CreateServer(clients map[string]DockerClient, content fs.FS, config Config)
 
 var fileServer http.Handler
 
+type contextKey string
+
+const remoteUser contextKey = "remoteUser"
+
+type User struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Avatar   string `json:"avatar,omitempty"`
+}
+
+func hashEmail(email string) string {
+	email = strings.TrimSpace(email)
+	email = strings.ToLower(email)
+	hash := md5.Sum([]byte(email))
+
+	return hex.EncodeToString(hash[:])
+}
+
+func NewUser(username, email, name string) *User {
+	avatar := ""
+	if email != "" {
+		avatar = "https://www.gravatar.com/avatar/" + hashEmail(email)
+	}
+	return &User{
+		Username: username,
+		Email:    email,
+		Name:     name,
+		Avatar:   avatar,
+	}
+}
+
+func forwardProxyAuthorizationRequired(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Remote-Email") == "" {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		user := NewUser(r.Header.Get("Remote-User"), r.Header.Get("Remote-Email"), r.Header.Get("Remote-Name"))
+
+		ctx := context.WithValue(r.Context(), remoteUser, user)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
 func createRouter(h *handler) *chi.Mux {
 	initializeAuth(h)
 
@@ -76,21 +117,29 @@ func createRouter(h *handler) *chi.Mux {
 
 	r.Route(base, func(r chi.Router) {
 		r.Group(func(r chi.Router) {
-			r.Use(authorizationRequired)
-			r.Get("/api/logs/stream/{host}/{id}", h.streamLogs)
-			r.Get("/api/logs/download/{host}/{id}", h.downloadLogs)
-			r.Get("/api/logs/{host}/{id}", h.fetchLogsBetweenDates)
-			r.Get("/api/events/stream", h.streamEvents)
-			r.Get("/logout", h.clearSession)
-			r.Get("/version", h.version)
+			if h.config.AuthProvider == "forward-proxy" {
+				r.Use(forwardProxyAuthorizationRequired)
+			}
+			r.Group(func(r chi.Router) {
+				if h.config.AuthProvider == "simple" {
+					r.Use(authorizationRequired)
+				}
+				r.Get("/api/logs/stream/{host}/{id}", h.streamLogs)
+				r.Get("/api/logs/download/{host}/{id}", h.downloadLogs)
+				r.Get("/api/logs/{host}/{id}", h.fetchLogsBetweenDates)
+				r.Get("/api/events/stream", h.streamEvents)
+				r.Get("/logout", h.clearSession)
+				r.Get("/version", h.version)
+			})
+
+			defaultHandler := http.StripPrefix(strings.Replace(base+"/", "//", "/", 1), http.HandlerFunc(h.index))
+			r.Get("/*", func(w http.ResponseWriter, req *http.Request) {
+				defaultHandler.ServeHTTP(w, req)
+			})
 		})
 
 		r.Post("/api/validateCredentials", h.validateCredentials)
 		r.Get("/healthcheck", h.healthcheck)
-		defaultHandler := http.StripPrefix(strings.Replace(base+"/", "//", "/", 1), http.HandlerFunc(h.index))
-		r.Get("/*", func(w http.ResponseWriter, req *http.Request) {
-			defaultHandler.ServeHTTP(w, req)
-		})
 	})
 
 	if base != "/" {
@@ -102,146 +151,6 @@ func createRouter(h *handler) *chi.Mux {
 	fileServer = http.FileServer(http.FS(h.content))
 
 	return r
-}
-
-func (h *handler) index(w http.ResponseWriter, req *http.Request) {
-	_, err := h.content.Open(req.URL.Path)
-	if err == nil && req.URL.Path != "" && req.URL.Path != "/" {
-		fileServer.ServeHTTP(w, req)
-		if !h.config.NoAnalytics {
-			go func() {
-				host, _ := os.Hostname()
-
-				var client DockerClient
-				for _, v := range h.clients {
-					client = v
-					break
-				}
-
-				if containers, err := client.ListContainers(); err == nil {
-					totalContainers := len(containers)
-					runningContainers := 0
-					for _, container := range containers {
-						if container.State == "running" {
-							runningContainers++
-						}
-					}
-
-					re := analytics.RequestEvent{
-						ClientId:          host,
-						TotalContainers:   totalContainers,
-						RunningContainers: runningContainers,
-					}
-					analytics.SendRequestEvent(re)
-				}
-			}()
-		}
-	} else {
-		if !isAuthorized(req) && req.URL.Path != "login" {
-			http.Redirect(w, req, path.Clean(h.config.Base+"/login"), http.StatusTemporaryRedirect)
-			return
-		}
-		h.executeTemplate(w, req)
-	}
-}
-
-func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
-	file, err := h.content.Open("index.html")
-	if err != nil {
-		log.Panic(err)
-	}
-	bytes, err := io.ReadAll(file)
-	if err != nil {
-		log.Panic(err)
-	}
-	tmpl, err := template.New("index.html").Funcs(template.FuncMap{
-		"marshal": func(v interface{}) template.JS {
-			a, _ := json.Marshal(v)
-			return template.JS(a)
-		},
-	}).Parse(string(bytes))
-	if err != nil {
-		log.Panic(err)
-	}
-
-	path := ""
-	if h.config.Base != "/" {
-		path = h.config.Base
-	}
-
-	hosts := make([]*docker.Host, 0, len(h.clients))
-	for _, v := range h.clients {
-		hosts = append(hosts, v.Host())
-	}
-	sort.Slice(hosts, func(i, j int) bool {
-		return hosts[i].Name < hosts[j].Name
-	})
-
-	config := map[string]interface{}{
-		"base":                path,
-		"version":             h.config.Version,
-		"authorizationNeeded": h.isAuthorizationNeeded(req),
-		"secured":             secured,
-		"hostname":            h.config.Hostname,
-		"hosts":               hosts,
-	}
-
-	data := map[string]interface{}{
-		"Config":   config,
-		"Dev":      h.config.Dev,
-		"Manifest": h.readManifest(),
-		"Base":     path,
-	}
-
-	err = tmpl.Execute(w, data)
-	if err != nil {
-		log.Panic(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-}
-
-func (h *handler) readManifest() map[string]interface{} {
-	if h.config.Dev {
-		return map[string]interface{}{}
-	} else {
-		file, err := h.content.Open("manifest.json")
-		if err != nil {
-			// this should only happen during test. In production, the file is embedded in the binary and checked in main.go
-			return map[string]interface{}{}
-		}
-		bytes, err := io.ReadAll(file)
-		if err != nil {
-			log.Fatalf("Could not read manifest.json: %v", err)
-		}
-		var manifest map[string]interface{}
-		err = json.Unmarshal(bytes, &manifest)
-		if err != nil {
-			log.Fatalf("Could not parse manifest.json: %v", err)
-		}
-		return manifest
-	}
-
-}
-
-func (h *handler) version(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Content-Type", "text/html")
-	fmt.Fprintf(w, "<pre>%v</pre>", h.config.Version)
-}
-
-func (h *handler) healthcheck(w http.ResponseWriter, r *http.Request) {
-	log.Trace("Executing healthcheck request")
-	var client DockerClient
-	for _, v := range h.clients {
-		client = v
-		break
-	}
-
-	if ping, err := client.Ping(r.Context()); err != nil {
-		log.Error(err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	} else {
-		fmt.Fprintf(w, "OK API Version %v", ping.APIVersion)
-	}
 }
 
 func (h *handler) clientFromRequest(r *http.Request) DockerClient {

--- a/web/version.go
+++ b/web/version.go
@@ -1,0 +1,11 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (h *handler) version(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add("Content-Type", "text/html")
+	fmt.Fprintf(w, "<pre>%v</pre>", h.config.Version)
+}


### PR DESCRIPTION
See #2437 on discussion to create multi-user options for Dozzle. 

This is a start for saving all configuration on disk. 

<img width="1719" alt="Screenshot 2023-10-23 at 12 56 10 PM" src="https://github.com/amir20/dozzle/assets/260667/76d242a7-78da-4e70-932f-024452bda2d1">


This PR introduces `Remote-*` headers to associate each session with a user. 

```
Remote-Email: admin@example.com
Remote-Groups: admins,dev
Remote-Name: Admin
Remote-User: admin
```


To use this, set `DOZZLE_AUTH_PROVIDER` to `forward-proxy`. Here is an example from compose file I used for testing....

```

  dozzle:
    image: amir20/dozzle:latest    
    networks:
      - net
    environment:
      DOZZLE_AUTH_PROVIDER: forward-proxy
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock  
    labels:
      - 'traefik.enable=true'
      - 'traefik.http.routers.dozzle.rule=Host(`dozzle.example.com`)'
      - 'traefik.http.routers.dozzle.entrypoints=https'
      - 'traefik.http.routers.dozzle.tls=true'
      - 'traefik.http.routers.dozzle.tls.options=default'
      - 'traefik.http.routers.dozzle.middlewares=authelia@docker'
    expose:
      - 8080
      
```

