### PR TITLE
fix: fixes a potential rare edge case that log entry has no payload. see #2451.

### DIFF
--- a/assets/models/LogEntry.ts
+++ b/assets/models/LogEntry.ts
@@ -144,21 +144,21 @@ export class SkippedLogsEntry extends LogEntry<string> {
 }
 
 export function asLogEntry(event: LogEvent): LogEntry<string | JSONObject> {
-  if (typeof event.m === "string") {
+  if (isObject(event.m)) {
+    return new ComplexLogEntry(
+      event.m,
+      event.id,
+      new Date(event.ts),
+      event.l,
+      event.s === "unknown" ? "stderr" : event.s ?? "stderr",
+    );
+  } else {
     return new SimpleLogEntry(
       event.m,
       event.id,
       new Date(event.ts),
       event.l,
       event.p,
-      event.s === "unknown" ? "stderr" : event.s ?? "stderr",
-    );
-  } else {
-    return new ComplexLogEntry(
-      event.m,
-      event.id,
-      new Date(event.ts),
-      event.l,
       event.s === "unknown" ? "stderr" : event.s ?? "stderr",
     );
   }


### PR DESCRIPTION
This should fix #2451 where a json object has no payload. 