### PR TITLE
docs: Add docker-compose.yml option

### DIFF
--- a/docs/guide/log-files-on-disk.md
+++ b/docs/guide/log-files-on-disk.md
@@ -24,7 +24,7 @@ docker run -v /var/log/system.log:/var/log/test.log alpine tail -f /var/log/test
 version: "3"
 services:
   dozzle-from-file:
-    container_name: dozzle-from-file-diskmonitor
+    container_name: dozzle-from-file
     image: alpine
     volumes:
       - /var/log/system.log:/var/log/stream.log

--- a/docs/guide/log-files-on-disk.md
+++ b/docs/guide/log-files-on-disk.md
@@ -12,10 +12,32 @@ However, there are workarounds to be able to still access files using mounts.
 
 ## Mounting Local Log Files with Alpine
 
-Dozzle reads any output stream. This can be used in combination with alpine to `tail` a mounted file. An example of this is:
+Dozzle reads any output stream. This can be used in combination with alpine to `tail` a mounted file. An example of this is as follows:
+
+::: code-group
 
 ```sh
 docker run -v /var/log/system.log:/var/log/test.log alpine tail -f /var/log/test.log
 ```
 
+```yaml [docker-compose.yml]
+version: "3"
+services:
+  dozzle-from-file:
+    container_name: dozzle-from-file-diskmonitor
+    image: alpine
+    volumes:
+      - /var/log/system.log:/var/log/stream.log
+    command:
+      - tail
+      - -f
+      - /var/log/stream.log     
+    network_mode: none
+    restart: unless-stopped
+```
+
+:::
+
 In the above example `/var/log/system.log` is mounted from the host and used with `tail -f` to follow the file. `tail` is smart to follow log rotations. During my testing, using alpine only uses about `300KB` of memory.
+
+The second tab shows a `docker-compose` file which is useful if you want the log stream to survive server reboot.


### PR DESCRIPTION
Have expanded the `docker run` example for streaming log files from disk to include a `docker-compose.yml` option.