### PR TITLE
fix: Icon placement when hovering over containers with health checks.

### DIFF
--- a/assets/components/SideMenu.vue
+++ b/assets/components/SideMenu.vue
@@ -36,6 +36,7 @@
               <div class="truncate">
                 {{ item.name }}<span class="font-light opacity-70" v-if="item.isSwarm">{{ item.swarmId }}</span>
               </div>
+              <container-health :health="item.health"></container-health>
               <span
                 class="pin"
                 @click.stop.prevent="store.appendActiveContainer(item)"
@@ -44,8 +45,6 @@
               >
                 <cil:columns />
               </span>
-
-              <container-health :health="item.health"></container-health>
             </router-link>
             <template #content>
               <container-popup :container="item"></container-popup>
@@ -145,7 +144,7 @@ const activeContainersById = computed(() =>
   @apply text-[0.95rem];
 }
 .containers a {
-  @apply auto-cols-[auto_max-content];
+  @apply auto-cols-[auto_max-content_max-content];
   .pin {
     display: none;
 


### PR DESCRIPTION
I noticed that when hovering over a container in the side list with a health check the spacing would be thrown off when the pin container button appears.

**Before**
![Screenshot from 2023-12-01 17-18-48](https://github.com/amir20/dozzle/assets/3438974/e41176c1-7940-4220-8c9c-21e16d889bb9)

I resolved this by fixing the spacing of the grid so that it stays aligned. Additionally I swapped the pin button to be after the heath icon. This is so that the button stays in a consistent position, allow the user to move down an continue to pin if they need to. 

**After**
![Screenshot from 2023-12-01 17-33-56](https://github.com/amir20/dozzle/assets/3438974/b57b66ea-f49c-4974-80e5-cafac051e2c5)
