### PR TITLE
fix: Updates to sidebar on mobile to align closer to desktop

### DIFF
--- a/assets/components/common/MobileMenu.vue
+++ b/assets/components/common/MobileMenu.vue
@@ -20,7 +20,7 @@
     </div>
 
     <transition name="fade">
-      <div v-show="show">
+      <div v-show="show" id="side-container">
         <div class="mt-4 flex items-center justify-center gap-2">
           <dropdown-menu
             v-model="sessionHost"
@@ -39,7 +39,7 @@
 
         <ul class="menu">
           <li class="menu-title">{{ $t("label.containers") }}</li>
-          <li v-for="item in sortedContainers" :key="item.id">
+          <li v-for="item in sortedContainers" :key="item.id" :class="item.state">
             <router-link
               :to="{ name: 'container-id', params: { id: item.id } }"
               active-class="active-primary"
@@ -85,6 +85,15 @@ const sortedContainers = computed(() =>
 const hosts = computed(() => config.hosts.map(({ id, name }) => ({ value: id, label: name })));
 </script>
 <style scoped lang="postcss">
+#side-container {
+  height: calc(100vh - 60px);
+  overflow: auto;
+}
+
+li.exited {
+  @apply opacity-50;
+}
+
 .fade-enter-active,
 .fade-leave-active {
   @apply transition-opacity;

--- a/assets/components/common/MobileMenu.vue
+++ b/assets/components/common/MobileMenu.vue
@@ -20,7 +20,7 @@
     </div>
 
     <transition name="fade">
-      <div v-show="show" id="side-container">
+      <div v-show="show" class="h-[calc(100vh-60px)] overflow-auto">
         <div class="mt-4 flex items-center justify-center gap-2">
           <dropdown-menu
             v-model="sessionHost"
@@ -85,11 +85,6 @@ const sortedContainers = computed(() =>
 const hosts = computed(() => config.hosts.map(({ id, name }) => ({ value: id, label: name })));
 </script>
 <style scoped lang="postcss">
-#side-container {
-  height: calc(100vh - 60px);
-  overflow: auto;
-}
-
 li.exited {
   @apply opacity-50;
 }


### PR DESCRIPTION
Updated the sidebar on the mobile to bring it closer to parity as the desktop. And fix some scrolling issues.

1. Updated the sidebar on mobile to show stopped containers
2. Sidebar either did not take the full height OR it overflowed and did not scroll on mobile. Both issues have been fixed by setting the height and overflow properties.

( FYI I hate CSS 😅 )