### PR TITLE
feat: add support for custom headers for forward-proxy auth

### DIFF
--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -178,6 +178,39 @@ notifier:
 
 Valid SSL keys are required because Authelia only supports SSL.
 
+### Setting up Dozzle with Cloudflare Zero Trust
+
+Cloudflare Zero Trust is a service for authenticated access to selfhosted
+software. This section defines how Dozzle can be setup to use Cloudflare Zero
+Trust for authentication.
+
+::: code-group
+
+```yaml [docker-compose.yml]
+version: "3.3"
+
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    networks:
+      - net
+    environment:
+      DOZZLE_AUTH_PROVIDER: forward-proxy
+	  DOZZLE_AUTH_HEADER_USER: Cf-Access-Authenticated-User-Email
+	  DOZZLE_AUTH_HEADER_EMAIL: Cf-Access-Authenticated-User-Email
+	  DOZZLE_AUTH_HEADER_NAME: Cf-Access-Authenticated-User-Email
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    expose:
+      - 8080
+    restart: unless-stopped
+```
+
+After running the Dozzle container, configure the Application in Cloudflare Zero
+Trust dashboard by following the
+[guide](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/)
+here.
+
 ## File Based User Management
 
 Dozzle supports multi-user authentication by setting `--auth-provider` to `simple`. In this mode, Dozzle will try to read `/data/users.yml`. The content of the file looks like

--- a/internal/web/routes_proxy_test.go
+++ b/internal/web/routes_proxy_test.go
@@ -20,7 +20,7 @@ func Test_createRoutes_proxy_missing_headers(t *testing.T) {
 	handler := createHandler(nil, afero.NewIOFS(fs), Config{Base: "/",
 		Authorization: Authorization{
 			Provider:   FORWARD_PROXY,
-			Authorizer: auth.NewForwardProxyAuth(),
+			Authorizer: auth.NewForwardProxyAuth("Remote-User", "Remote-Email", "Remote-Name"),
 		},
 	})
 	req, err := http.NewRequest("GET", "/", nil)
@@ -39,7 +39,7 @@ func Test_createRoutes_proxy_happy(t *testing.T) {
 	handler := createHandler(nil, afero.NewIOFS(fs), Config{Base: "/",
 		Authorization: Authorization{
 			Provider:   FORWARD_PROXY,
-			Authorizer: auth.NewForwardProxyAuth(),
+			Authorizer: auth.NewForwardProxyAuth("Remote-User", "Remote-Email", "Remote-Name"),
 		},
 	})
 	req, err := http.NewRequest("GET", "/", nil)

--- a/main.go
+++ b/main.go
@@ -44,6 +44,9 @@ type args struct {
 	Level                string              `arg:"env:DOZZLE_LEVEL" default:"info" help:"set Dozzle log level. Use debug for more logging."`
 	Username             string              `arg:"env:DOZZLE_USERNAME" help:"sets the username for auth."`
 	Password             string              `arg:"env:DOZZLE_PASSWORD" help:"sets password for auth"`
+	AuthHeaderUser       string              `arg:"env:DOZZLE_AUTH_HEADER_USER" default:"Remote-User" help:"sets the HTTP Header to use for username in Forward Proxy configuration."`
+	AuthHeaderEmail      string              `arg:"env:DOZZLE_AUTH_HEADER_EMAIL" default:"Remote-Email" help:"sets the HTTP Header to use for email in Forward Proxy configuration."`
+	AuthHeaderName       string              `arg:"env:DOZZLE_AUTH_HEADER_NAME" default:"Remote-Name" help:"sets the HTTP Header to use for name in Forward Proxy configuration."`
 	NoAnalytics          bool                `arg:"--no-analytics,env:DOZZLE_NO_ANALYTICS" help:"disables anonymous analytics"`
 	WaitForDockerSeconds int                 `arg:"--wait-for-docker-seconds,env:DOZZLE_WAIT_FOR_DOCKER_SECONDS" help:"wait for docker to be available for at most this many seconds before starting the server."`
 	FilterStrings        []string            `arg:"env:DOZZLE_FILTER,--filter,separate" help:"filters docker containers using Docker syntax."`
@@ -168,7 +171,7 @@ func createServer(args args, clients map[string]web.DockerClient) *http.Server {
 	var authorizer web.Authorizer
 	if args.AuthProvider == "forward-proxy" {
 		provider = web.FORWARD_PROXY
-		authorizer = auth.NewForwardProxyAuth()
+		authorizer = auth.NewForwardProxyAuth(args.AuthHeaderUser, args.AuthHeaderEmail, args.AuthHeaderName)
 	} else if args.AuthProvider == "simple" {
 		provider = web.SIMPLE
 


### PR DESCRIPTION
This PR adds support for Custom Headers for Forward Proxy-based Authentication. I've kept the defaults the same as the ones used currently.

I tested this PR with the following `docker-compose.yaml` and `Caddyfile`.

```
services:
  dozzle:
    image: amir20/dozzle:latest
    restart: always
    environment:
      dozzle_auth_provider: forward-proxy
      dozzle_auth_header_user: cf-access-authenticated-user-email
      dozzle_auth_header_email: cf-access-authenticated-user-email
      dozzle_auth_header_name: cf-access-authenticated-user-email
      dozzle_no_analytics: true
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
    ports:
      - "8080:8080"
```

```
:3000 {
    reverse_proxy http://localhost:8080 {
	    header_up Cf-Access-Authenticated-User-Email "ankit@test.com"
	}
}
```