### PR TITLE
feat: deactivates collection of stats after 6 hours of idle

### DIFF
--- a/internal/docker/container_store.go
+++ b/internal/docker/container_store.go
@@ -49,11 +49,13 @@ func (s *ContainerStore) Client() Client {
 }
 
 func (s *ContainerStore) Subscribe(ctx context.Context, events chan ContainerEvent) {
-	if !s.statsCollector.IsRunning() {
-		go s.statsCollector.Start(context.Background())
-	}
-
+	go s.statsCollector.Start(context.Background())
 	s.subscribers.Store(ctx, events)
+}
+
+func (s *ContainerStore) Unsubscribe(ctx context.Context) {
+	s.subscribers.Delete(ctx)
+	s.statsCollector.Stop()
 }
 
 func (s *ContainerStore) SubscribeStats(ctx context.Context, stats chan ContainerStat) {

--- a/internal/docker/container_store.go
+++ b/internal/docker/container_store.go
@@ -28,7 +28,7 @@ func NewContainerStore(ctx context.Context, client Client) *ContainerStore {
 	s.wg.Add(1)
 
 	go s.init(ctx)
-	go s.statsCollector.StartCollecting(ctx)
+	go s.statsCollector.Start(ctx)
 
 	return s
 }
@@ -49,6 +49,10 @@ func (s *ContainerStore) Client() Client {
 }
 
 func (s *ContainerStore) Subscribe(ctx context.Context, events chan ContainerEvent) {
+	if !s.statsCollector.IsRunning() {
+		go s.statsCollector.Start(context.Background())
+	}
+
 	s.subscribers.Store(ctx, events)
 }
 

--- a/internal/docker/container_store.go
+++ b/internal/docker/container_store.go
@@ -28,7 +28,6 @@ func NewContainerStore(ctx context.Context, client Client) *ContainerStore {
 	s.wg.Add(1)
 
 	go s.init(ctx)
-	go s.statsCollector.Start(ctx)
 
 	return s
 }
@@ -49,7 +48,15 @@ func (s *ContainerStore) Client() Client {
 }
 
 func (s *ContainerStore) Subscribe(ctx context.Context, events chan ContainerEvent) {
-	go s.statsCollector.Start(context.Background())
+	go func() {
+		if s.statsCollector.Start(context.Background()) {
+			log.Debug("clearing container stats as stats collector has been stopped")
+			s.containers.Range(func(_ string, c *Container) bool {
+				c.Stats.Clear()
+				return true
+			})
+		}
+	}()
 	s.subscribers.Store(ctx, events)
 }
 

--- a/internal/docker/stats_collector.go
+++ b/internal/docker/stats_collector.go
@@ -49,6 +49,8 @@ func (c *StatsCollector) forceStop() {
 }
 
 func (c *StatsCollector) Stop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	c.timer = time.AfterFunc(timeToStop, func() {
 		c.forceStop()
 	})

--- a/internal/docker/stats_collector.go
+++ b/internal/docker/stats_collector.go
@@ -23,7 +23,7 @@ type StatsCollector struct {
 	mu          sync.Mutex
 }
 
-var minActiveContainers = 50
+var minActiveContainers = 10
 var timeToStop = 12 * time.Hour
 
 func NewStatsCollector(client Client) *StatsCollector {

--- a/internal/utils/ring_buffer.go
+++ b/internal/utils/ring_buffer.go
@@ -31,6 +31,13 @@ func (r *RingBuffer[T]) Push(data T) {
 	}
 }
 
+func (r *RingBuffer[T]) Clear() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.data = r.data[:0]
+	r.start = 0
+}
+
 func (r *RingBuffer[T]) Data() []T {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()

--- a/internal/utils/ring_buffer_test.go
+++ b/internal/utils/ring_buffer_test.go
@@ -25,3 +25,36 @@ func TestRingBuffer(t *testing.T) {
 		t.Errorf("Expected data to be %v, got %v", expectedData, data)
 	}
 }
+
+func TestRingBuffer_MarshalJSON(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	rb.Push(1)
+	rb.Push(2)
+	rb.Push(3)
+
+	data, err := rb.MarshalJSON()
+	if err != nil {
+		t.Errorf("Expected error to be nil, got %v", err)
+	}
+
+	expectedData := []byte("[1,2,3]")
+	if !reflect.DeepEqual(data, expectedData) {
+		t.Errorf("Expected data to be %v, got %v", expectedData, data)
+	}
+}
+
+func TestRingBuffer_Clear(t *testing.T) {
+	rb := NewRingBuffer[int](3)
+
+	rb.Push(1)
+	rb.Push(2)
+	rb.Push(3)
+
+	rb.Clear()
+	data := rb.Data()
+	expectedData := []int{}
+	if !reflect.DeepEqual(data, expectedData) {
+		t.Errorf("Expected data to be %v, got %v", expectedData, data)
+	}
+}

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -49,6 +49,12 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 		store.Subscribe(ctx, events)
 	}
 
+	defer func() {
+		for _, store := range h.stores {
+			store.Unsubscribe(ctx)
+		}
+	}()
+
 	if err := sendContainersJSON(allContainers, w); err != nil {
 		log.Errorf("error writing containers to event stream: %v", err)
 	}


### PR DESCRIPTION
This PR attempts to stop the background stat collector after 6 hours of idle time. The timer starts after the last client has disconnected. 