### PR TITLE
docs: Updated documentation for Remote Host Setup

### DIFF
--- a/docs/guide/remote-hosts.md
+++ b/docs/guide/remote-hosts.md
@@ -10,6 +10,8 @@ Dozzle supports connecting to multiple remote hosts via `tcp://` using TLS and n
 
 Remote hosts can be configured with `--remote-host` or `DOZZLE_REMOTE_HOST`. All certs must be mounted to `/certs` directory. The `/certs` directory expects to have `/certs/{ca,cert,key}.pem` or `/certs/{host}/{ca,cert,key}.pem` in case of multiple hosts.
 
+Note the `{host}` value referred to here is the IP or FQDN configured and not the [optional label](#adding-labels-to-hosts). 
+
 Multiple `--remote-host` flags can be used to specify multiple hosts. However, using `DOZZLE_REMOTE_HOST` the value should be comma separated.
 
 ::: code-group

--- a/docs/guide/remote-hosts.md
+++ b/docs/guide/remote-hosts.md
@@ -8,7 +8,7 @@ Dozzle supports connecting to multiple remote hosts via `tcp://` using TLS and n
 
 ## Connecting to remote hosts
 
-Remote hosts can be configured with `--remote-host` or `DOZZLE_REMOTE_HOST`. All certs must be mounted to `/certs` directory. The `/cert` directory expects to have `/certs/{ca,cert,key}.pem` or `/certs/{host}/{ca,cert,key}.pem` in case of multiple hosts.
+Remote hosts can be configured with `--remote-host` or `DOZZLE_REMOTE_HOST`. All certs must be mounted to `/certs` directory. The `/certs` directory expects to have `/certs/{ca,cert,key}.pem` or `/certs/{host}/{ca,cert,key}.pem` in case of multiple hosts.
 
 Multiple `--remote-host` flags can be used to specify multiple hosts. However, using `DOZZLE_REMOTE_HOST` the value should be comma separated.
 


### PR DESCRIPTION
Fixed a minor path typo to avoid confusion (`/cert` to `/certs`)

Added a clarification to specify the host subfolder name expected. I spent some time wondering why my config wasn't working as my subfolder was named after the host label. 
It might be worth also adding to DEBUG logs when searching for certs in this subfolder. When debugging I saw that it couldn't find certs at the /certs location but there was no mention of the path it was looking for in /certs/hostIP so I didn't realise the path it expected didn't exist. 