### PR TITLE
feat: Adding debug log when host-specific certificate path not found

### DIFF
--- a/internal/docker/host.go
+++ b/internal/docker/host.go
@@ -49,8 +49,7 @@ func ParseConnection(connection string) (Host, error) {
 	host := remoteUrl.Hostname()
 	if _, err := os.Stat(filepath.Join(basePath, host)); !os.IsNotExist(err) {
 		basePath = filepath.Join(basePath, host)
-	}
-	else {
+	} else {
 		log.Debugf("Remote host certificate path does not exist %s, falling back to default: %s", filepath.Join(basePath, host), basePath)
 	}
 

--- a/internal/docker/host.go
+++ b/internal/docker/host.go
@@ -2,11 +2,12 @@ package docker
 
 import (
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	
+	log "github.com/sirupsen/logrus"
 )
 
 type Host struct {

--- a/internal/docker/host.go
+++ b/internal/docker/host.go
@@ -50,6 +50,9 @@ func ParseConnection(connection string) (Host, error) {
 	if _, err := os.Stat(filepath.Join(basePath, host)); !os.IsNotExist(err) {
 		basePath = filepath.Join(basePath, host)
 	}
+	else {
+		log.Debugf("Remote host certificate path does not exist %s, falling back to default: %s", filepath.Join(basePath, host), basePath)
+	}
 
 	cacertPath := filepath.Join(basePath, "ca.pem")
 	certPath := filepath.Join(basePath, "cert.pem")


### PR DESCRIPTION
Ran into this while figuring out why my remote host config wasn't working. Debug logging didn't tell me where it was expecting (and failing) to find the client certificate files, only that it didn't find them at the default `/certs` location. 

Existing debug log shows the final default path it looks for, but not the host-specific one it tries first. 

Added a debug log action to specify when this fails, where it expects the files to be. 