### PR TITLE
fix: Coerce log level to lowercase when guessing in structured json

### DIFF
--- a/internal/docker/level_guesser.go
+++ b/internal/docker/level_guesser.go
@@ -44,12 +44,12 @@ func guessLogLevel(logEvent *LogEvent) string {
 
 	case map[string]interface{}:
 		if level, ok := value["level"].(string); ok {
-			return level
+			return strings.ToLower(level)
 		}
 
 	case map[string]string:
 		if level, ok := value["level"]; ok {
-			return level
+			return strings.ToLower(level)
 		}
 	}
 

--- a/internal/docker/level_guesser_test.go
+++ b/internal/docker/level_guesser_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestGuessLogLevel(t *testing.T) {
 	tests := []struct {
-		input    string
+		input    any
 		expected string
 	}{
 		{"ERROR: Something went wrong", "error"},
@@ -25,6 +25,10 @@ func TestGuessLogLevel(t *testing.T) {
 		{"[foo] [ ERROR] Something went wrong", "error"},
 		{"123 ERROR Something went wrong", "error"},
 		{"123 Something went wrong", ""},
+		{map[string]interface{}{"level": "info"}, "info"},
+		{map[string]interface{}{"level": "INFO"}, "info"},
+		{map[string]string{"level": "info"}, "info"},
+		{map[string]string{"level": "INFO"}, "info"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
My project generates structured JSON log messages with the `level` attribute having values of DEBUG, INFO, WARN, ERROR, etc <-- all in upper case. When viewed in dozzle, the purple/green/orange/red marker dots don't show for these entries. 

I tracked this down to the **level_guesser.go** file and noticed some missed test coverage. This PR should address that deficiency.