### PR TITLE
Implement support for custom container names

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -65,6 +65,7 @@ export default defineConfig({
           { text: "Actions", link: "/guide/actions" },
           { text: "Agent Mode", link: "/guide/agent" },
           { text: "Changing Base", link: "/guide/changing-base" },
+          { text: "Container Names", link: "/guide/container-names" },
           { text: "Container Groups", link: "/guide/container-groups" },
           { text: "Data Analytics", link: "/guide/analytics" },
           { text: "Display Name", link: "/guide/hostname" },

--- a/docs/guide/container-names.md
+++ b/docs/guide/container-names.md
@@ -1,0 +1,30 @@
+---
+title: Container Names
+---
+
+# Container Names
+
+By default, Dozzle retrieves container names directly from Docker. This is usually sufficient, as these names can be customized using the `--name` flag in `docker run` commands or through the `container_name` field in Docker Compose services.
+
+## Custom Names
+
+In cases where modifying the container name itself isn't possible, you can override it by adding a `dev.dozzle.name` label to your container.
+
+Here is an example using Docker Compose or Docker CLI:
+
+::: code-group
+
+```sh
+docker run --label dev.dozzle.name=hello hello-world
+```
+
+```yaml [docker-compose.yml]
+version: "3"
+services:
+  dozzle:
+    image: hello-world
+    labels:
+      - dev.dozzle.name=hello
+```
+
+:::

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -356,7 +356,9 @@ func (d *httpClient) SystemInfo() system.Info {
 
 func newContainer(c types.Container, host string) Container {
 	name := "no name"
-	if len(c.Names) > 0 {
+	if c.Labels["dev.dozzle.name"] != "" {
+		name = c.Labels["dev.dozzle.name"]
+	} else if len(c.Names) > 0 {
 		name = strings.TrimPrefix(c.Names[0], "/")
 	}
 
@@ -380,7 +382,9 @@ func newContainer(c types.Container, host string) Container {
 
 func newContainerFromJSON(c types.ContainerJSON, host string) Container {
 	name := "no name"
-	if len(c.Name) > 0 {
+	if c.Config.Labels["dev.dozzle.name"] != "" {
+		name = c.Config.Labels["dev.dozzle.name"]
+	} else if len(c.Name) > 0 {
 		name = strings.TrimPrefix(c.Name, "/")
 	}
 


### PR DESCRIPTION
This introduces the ability to customize a container's name by adding a `dev.dozzle.name` label to it.

Related issue:
https://github.com/amir20/dozzle/issues/3189