### PR TITLE
feat: Translate the example log entries

### DIFF
--- a/assets/pages/settings.vue
+++ b/assets/pages/settings.vue
@@ -171,14 +171,14 @@ const hoursAgo = (hours: number) => {
 };
 
 const fakeMessages = [
-  new SimpleLogEntry({{ $t("settings.log.preview") }}, "123", 1, hoursAgo(16), "info", undefined, "stdout"),
-  new SimpleLogEntry({{ $t("settings.log.warning") }}, "123", 2, hoursAgo(12), "warn", undefined, "stdout"),
-  new SimpleLogEntry({{ $t("settings.log.multi-line-error.start-line") }}, "123", 3, hoursAgo(7), "error", "start", "stderr"),
-  new SimpleLogEntry({{ $t("settings.log.multi-line-error.middle-line") }}, "123", 4, hoursAgo(2), "error", "middle", "stderr"),
-  new SimpleLogEntry({{ $t("settings.log.multi-line-error.end-line") }}, "123", 5, new Date(), "error", "end", "stderr"),
+  new SimpleLogEntry(t("settings.log.preview"), "123", 1, hoursAgo(16), "info", undefined, "stdout"),
+  new SimpleLogEntry(t("settings.log.warning"), "123", 2, hoursAgo(12), "warn", undefined, "stdout"),
+  new SimpleLogEntry(t("settings.log.multi-line-error.start-line"), "123", 3, hoursAgo(7), "error", "start", "stderr"),
+  new SimpleLogEntry(t("settings.log.multi-line-error.middle-line"), "123", 4, hoursAgo(2), "error", "middle", "stderr"),
+  new SimpleLogEntry(t("settings.log.multi-line-error.end-line"), "123", 5, new Date(), "error", "end", "stderr"),
   new ComplexLogEntry(
     {
-      message: {{ $t("settings.log.complex") }},
+      message: t("settings.log.complex"),
       context: {
         key: "value",
         key2: "value2",
@@ -192,7 +192,7 @@ const fakeMessages = [
     keys,
   ),
   new SimpleLogEntry(
-    {{ $t("settings.log.simple") }},
+    t("settings.log.simple"),
     "123",
     7,
     new Date(),

--- a/assets/pages/settings.vue
+++ b/assets/pages/settings.vue
@@ -171,14 +171,14 @@ const hoursAgo = (hours: number) => {
 };
 
 const fakeMessages = [
-  new SimpleLogEntry("This is a preview of the logs", "123", 1, hoursAgo(16), "info", undefined, "stdout"),
-  new SimpleLogEntry("A warning log looks like this", "123", 2, hoursAgo(12), "warn", undefined, "stdout"),
-  new SimpleLogEntry("This is a multi line error message", "123", 3, hoursAgo(7), "error", "start", "stderr"),
-  new SimpleLogEntry("with a second line", "123", 4, hoursAgo(2), "error", "middle", "stderr"),
-  new SimpleLogEntry("and finally third line.", "123", 5, new Date(), "error", "end", "stderr"),
+  new SimpleLogEntry({{ $t("settings.log.preview") }}, "123", 1, hoursAgo(16), "info", undefined, "stdout"),
+  new SimpleLogEntry({{ $t("settings.log.warning") }}, "123", 2, hoursAgo(12), "warn", undefined, "stdout"),
+  new SimpleLogEntry({{ $t("settings.log.multi-line-error.start-line") }}, "123", 3, hoursAgo(7), "error", "start", "stderr"),
+  new SimpleLogEntry({{ $t("settings.log.multi-line-error.middle-line") }}, "123", 4, hoursAgo(2), "error", "middle", "stderr"),
+  new SimpleLogEntry({{ $t("settings.log.multi-line-error.end-line") }}, "123", 5, new Date(), "error", "end", "stderr"),
   new ComplexLogEntry(
     {
-      message: "This is a complex log entry as json",
+      message: {{ $t("settings.log.complex") }},
       context: {
         key: "value",
         key2: "value2",
@@ -192,7 +192,7 @@ const fakeMessages = [
     keys,
   ),
   new SimpleLogEntry(
-    "This is a very very long message which would wrap by default. Disabling soft wraps would disable this. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ",
+    {{ $t("settings.log.simple") }},
     "123",
     7,
     new Date(),

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -103,7 +103,7 @@ settings:
     preview: Dies ist eine Vorschau auf die Protokolle
     warning: Ein Warnprotokoll sieht wie folgt aus
     complex: Dies ist ein komplexer Protokolleintrag als json
-    simple: Dies ist eine sehr, sehr lange Nachricht, die standardmäßig umbrochen wird. Die Deaktivierung von Soft Wraps würde dies unterbinden. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+    simple: Dies ist eine sehr, sehr lange Nachricht, die standardmäßig umbrochen wird. Die Deaktivierung von Zeilenumbrüche würde dies unterbinden. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
     multi-line-error: 
       start-line: Dies ist eine mehrzeilige Fehlermeldung
       middle-line: mit einer zweiten Zeile

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -99,6 +99,15 @@ settings:
   12-24-format: >-
     Standardmäßig verwendet Dozzle die Spracheinstellungen des Browsers, um die
     Zeit anzuzeigen. Du kannst die Zeit auf 12 oder 24 Stunden umstellen.
+  log:
+    preview: Dies ist eine Vorschau auf die Protokolle
+    warning: Ein Warnprotokoll sieht wie folgt aus
+    complex: Dies ist ein komplexer Protokolleintrag als json
+    simple: Dies ist eine sehr, sehr lange Nachricht, die standardmäßig umbrochen wird. Die Deaktivierung von Soft Wraps würde dies unterbinden. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+    multi-line-error: 
+      start-line: Dies ist eine mehrzeilige Fehlermeldung
+      middle-line: mit einer zweiten Zeile
+      end-line: und schließlich einer dritten Zeile.
 releases:
   features: Ein neues Feature | {count} Features
   bugFixes: Ein Bug Fix | {count} Fixes

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -91,6 +91,15 @@ settings:
   show-std: Show stdout and stderr labels
   automatic-redirect: Automatically redirect to new containers with the same name
   compact: Enable compact mode for logs
+  log:
+    preview: This is a preview of the logs
+    warning: A warning log looks like this
+    complex: This is a complex log entry as json
+    simple: This is a very very long message which would wrap by default. Disabling soft wraps would disable this. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
+    multi-line-error: 
+      start-line: This is a multi line error message
+      middle-line: with a second line
+      end-line: and finally third line.
 releases:
   features: one new feature | {count} features
   bugFixes: one bug fix | {count} fixes


### PR DESCRIPTION
Please check again whether I have included the variables correctly. I have never worked with `.vue` files before. The log has already been translated into German. I have not touched the other languages.