### PR TITLE
fix: guess log level will also check severity

### DIFF
--- a/internal/docker/level_guesser.go
+++ b/internal/docker/level_guesser.go
@@ -53,6 +53,10 @@ func guessLogLevel(logEvent *LogEvent) string {
 			if level, ok := level.(string); ok {
 				return strings.ToLower(level)
 			}
+		} else if severity, ok := value.Get("severity"); ok {
+			if severity, ok := severity.(string); ok {
+				return strings.ToLower(severity)
+			}
 		}
 
 	case *orderedmap.OrderedMap[string, string]:
@@ -61,6 +65,8 @@ func guessLogLevel(logEvent *LogEvent) string {
 		}
 		if level, ok := value.Get("level"); ok {
 			return strings.ToLower(level)
+		} else if severity, ok := value.Get("severity"); ok {
+			return strings.ToLower(severity)
 		}
 
 	case map[string]interface{}:

--- a/internal/docker/level_guesser_test.go
+++ b/internal/docker/level_guesser_test.go
@@ -41,6 +41,18 @@ func TestGuessLogLevel(t *testing.T) {
 				orderedmap.Pair[string, any]{Key: "level", Value: "info"},
 			),
 		), "info"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, string]{Key: "key", Value: "value"},
+				orderedmap.Pair[string, string]{Key: "severity", Value: "info"},
+			),
+		), "info"},
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, any]{Key: "key", Value: "value"},
+				orderedmap.Pair[string, any]{Key: "severity", Value: "info"},
+			),
+		), "info"},
 		{nilOrderedMap, ""},
 		{nil, ""},
 	}


### PR DESCRIPTION
It's fairly common to have severity as the key for the log level. For example google cloud uses it. So this PR adds a check to check for the severity key if the level key is not found.