### PR TITLE
fix: limit default SQL log entries to 100

### DIFF
--- a/assets/components/LogViewer/LogAnalytics.vue
+++ b/assets/components/LogViewer/LogAnalytics.vue
@@ -31,7 +31,7 @@
 import { Container } from "@/models/Container";
 import { type Table } from "@apache-arrow/esnext-esm";
 const { container } = defineProps<{ container: Container }>();
-const query = ref("SELECT * FROM logs");
+const query = ref("SELECT * FROM logs LIMIT 100");
 const error = ref<string | null>(null);
 const debouncedQuery = debouncedRef(query, 500);
 const evaluating = ref(false);


### PR DESCRIPTION
When opening the SQL Analytics, it fetches all logs by default. On containers with many logs this can take a while. This PR changes the default by limiting it to first 100 log entries