### PR TITLE
fix: fix link color when using colorized logs

### DIFF
--- a/assets/components/LogViewer/SimpleLogItem.vue
+++ b/assets/components/LogViewer/SimpleLogItem.vue
@@ -38,7 +38,7 @@ const linkify = (text: string) =>
   text.replace(urlPattern, (url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
 </script>
 <style scoped lang="postcss">
-.log-wrapper > :deep(a) {
+.log-wrapper :deep(a) {
   @apply text-primary underline-offset-4 hover:underline;
 }
 </style>


### PR DESCRIPTION
Following up on https://github.com/amir20/dozzle/pull/3353, this PR fixes a minor bug where HTML links are not shown with their normal color when using ANSI color escape sequences due to https://github.com/rburns/ansi-to-html inserting HTML tags inside `.log-wrapper`.

With:

```js
console.log(`${chalk.red('hi')} https://www.google.com ${chalk.green('world')}`);
```

Before:

![image](https://github.com/user-attachments/assets/a60ebbf3-3366-4ab1-8876-bc484256d03e)

After:

![image](https://github.com/user-attachments/assets/e75353ca-32cd-43d4-b364-48365e9bbeed)