### PR TITLE
fix: fixes log parser

### DIFF
--- a/internal/docker/logfmt.go
+++ b/internal/docker/logfmt.go
@@ -17,7 +17,7 @@ func ParseLogFmt(log string) (*orderedmap.OrderedMap[string, string], error) {
 		char := log[i]
 		if isKey {
 			if char == '=' {
-				if i == start {
+				if start >= i {
 					return nil, errors.New("invalid format: key is empty")
 				}
 				key = log[start:i]

--- a/internal/docker/logfmt_test.go
+++ b/internal/docker/logfmt_test.go
@@ -68,6 +68,12 @@ func TestParseLog(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "Broken format with unexpected quotes",
+			log:     `key1=value"1"= key2="value2"`,
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name:    "Invalid log with unclosed quotes",
 			log:     "key1=\"value1 key2=value2",
 			want:    nil,


### PR DESCRIPTION
Hello, @amir20 and thank you for creating Dozzle! It’s a fantastic tool, and I really appreciate the effort you’ve put into developing it.

I recently encountered a crash with the following panic:

```
panic: runtime error: slice bounds out of range [222:221]

goroutine 260 [running]:
github.com/amir20/dozzle/internal/docker.ParseLogFmt({0x400060751f, 0x18c})
    /dozzle/internal/docker/logfmt.go:23 +0x3f8
github.com/amir20/dozzle/internal/docker.createEvent({0x4000607500?, 0x1ac}, 0x113a7d0?)
    /dozzle/internal/docker/event_generator.go:198 +0x50c
github.com/amir20/dozzle/internal/docker.(*EventGenerator).consumeReader(0x4000319ce0)
    /dozzle/internal/docker/event_generator.go:95 +0x50
created by github.com/amir20/dozzle/internal/docker.NewEventGenerator in goroutine 215
    /dozzle/internal/docker/event_generator.go:54 +0x260
```

The issue seems to originate in `ParseLogFmt`, where a slice bounds error causes the application to crash.

In this PR, I’m proposing a simple fix to avoid this panic. Additionally, I’ve added a test to cover the corner case that leads to the panic to help prevent similar issues in the future. If you have any feedback or need adjustments, please let me know, and I’d be happy to make changes.
