### PR TITLE
fix: fix ansi link color + regex

### DIFF
--- a/assets/components/LogViewer/LogItem.vue
+++ b/assets/components/LogViewer/LogItem.vue
@@ -26,8 +26,3 @@ const { hosts } = useHosts();
 const container = currentContainer(toRef(() => logEntry.containerID));
 const host = computed(() => hosts.value[container.value.host]);
 </script>
-<style scoped lang="postcss">
-.log-wrapper :deep(a) {
-  @apply text-primary underline-offset-4 hover:underline;
-}
-</style>

--- a/assets/components/LogViewer/SimpleLogItem.vue
+++ b/assets/components/LogViewer/SimpleLogItem.vue
@@ -28,7 +28,8 @@ defineProps<{
 }>();
 
 const colorize = (value: string) => ansiConvertor.toHtml(value);
-const urlPattern = /(https?:\/\/[^\s]+)/g;
+const urlPattern =
+  /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b[-a-zA-Z0-9()@:%_+.~#?&\/=]*/g;
 const linkify = (text: string) =>
   text.replace(urlPattern, (url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
 </script>

--- a/assets/components/LogViewer/SimpleLogItem.vue
+++ b/assets/components/LogViewer/SimpleLogItem.vue
@@ -32,3 +32,9 @@ const urlPattern = /(https?:\/\/[^\s]+)/g;
 const linkify = (text: string) =>
   text.replace(urlPattern, (url) => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
 </script>
+
+<style scoped lang="postcss">
+.log-wrapper :deep(a) {
+  @apply text-primary underline-offset-4 hover:underline;
+}
+</style>


### PR DESCRIPTION
This fixes a regression of https://github.com/amir20/dozzle/pull/3357 which was due to the relevant style being moved over to another component.

Before:

![image](https://github.com/user-attachments/assets/a52a44e5-dd4b-4de6-9e41-4f43763b0845)

After:

![image](https://github.com/user-attachments/assets/3dd5cdc4-c79c-4b89-b8f0-1bcd59027d00)

This also solidifies the regex for matching URLs, as it could cause issues in some cases such as when an URL is at the very end of a log entry.

Before:

![image](https://github.com/user-attachments/assets/6f2757e7-c39f-4a53-9157-c0446d488b52)

After:

![image](https://github.com/user-attachments/assets/c75d417e-d9f9-4150-a639-8a41403a0694)