### PR TITLE
feat: add more tags to same release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,6 +111,11 @@ jobs:
           images: |
             amir20/dozzle
             ghcr.io/amir20/dozzle
+          tags: |
+            type=raw,pattern=v{{version}}
+            type=raw,pattern=v{{major}}.{{minor}}
+            type=raw,pattern=v{{major}}
+            type=raw,value=latest
       - name: Writing certs to file
         run: |
           echo "${{ secrets.TTL_KEY }}" > shared_key.pem


### PR DESCRIPTION
I don't know if https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input fail with 'v' prefix, I think not, but I used the 'raw' type because the result is the same after all and can be used w/o risk to changes on semver in future.

Closes #3549 