### PR TITLE
fix: fixes ansi-to-html fallback colors

### DIFF
--- a/assets/components/LogViewer/SimpleLogItem.vue
+++ b/assets/components/LogViewer/SimpleLogItem.vue
@@ -19,8 +19,8 @@ import stripAnsi from "strip-ansi";
 
 const ansiConvertor = new AnsiConvertor({
   escapeXML: false,
-  fg: "oklch(var(--base-content-color))",
-  bg: "oklch(var(--base-color))",
+  fg: "var(--color-base-content)",
+  bg: "var(--color-base-100)",
 });
 
 defineProps<{


### PR DESCRIPTION
This fixes wrong CSS variables being used for fallback colors, as daisyUI 5 changed them.

Note: no need for `oklch` anymore since they're now already in that format in main.css.

With the following code (using [chalk](https://github.com/chalk/chalk)):

```ts
console.log(chalk.bgRed('Hello') + ' World');
console.log(chalk.red('Hello') + ' World');
```

Before:

![image](https://github.com/user-attachments/assets/7dbbd1e1-f6f6-4cc5-bb4f-d5c6e41b9f89)
![image](https://github.com/user-attachments/assets/e1875461-64d5-40b4-bcc0-a54e59b28a71)

After:

![image](https://github.com/user-attachments/assets/f709d2bc-90bd-499a-9699-2497a1cff845)
![image](https://github.com/user-attachments/assets/40a09d29-eaca-4f21-b3e8-a11bbca4ca8b)

