### PR TITLE
feat: Display actions dropdown on mobile

### DIFF
--- a/assets/components/GroupedViewer/GroupedLog.vue
+++ b/assets/components/GroupedViewer/GroupedLog.vue
@@ -1,14 +1,14 @@
 <template>
   <ScrollableView :scrollable="scrollable" v-if="group.containers.length && ready">
     <template #header>
-      <div class="mx-2 flex items-center gap-2 md:ml-4">
+      <div class="mx-2 flex flex-wrap items-center gap-2 md:ml-4">
         <div class="@container flex flex-1 gap-1.5 truncate md:gap-2">
           <div class="inline-flex font-mono text-sm">
             <div class="font-semibold">{{ $t("label.container", group.containers.length) }}</div>
           </div>
         </div>
-        <MultiContainerStat class="ml-auto" :containers="group.containers" />
-        <MultiContainerActionToolbar class="max-md:hidden" @clear="viewer?.clear()" />
+        <MultiContainerStat class="ml-auto justify-center max-md:basis-full max-md:order-last" :containers="group.containers" />
+        <MultiContainerActionToolbar @clear="viewer?.clear()" />
       </div>
     </template>
     <template #default>

--- a/assets/components/HostViewer/HostLog.vue
+++ b/assets/components/HostViewer/HostLog.vue
@@ -1,7 +1,7 @@
 <template>
   <ScrollableView :scrollable="scrollable" v-if="host">
     <template #header>
-      <div class="mx-2 flex items-center gap-2 md:ml-4">
+      <div class="mx-2 flex flex-wrap items-center gap-2 md:ml-4">
         <div class="flex flex-1 gap-1.5 truncate md:gap-2">
           <ph:computer-tower />
           <div class="inline-flex font-mono text-sm">
@@ -11,8 +11,8 @@
             {{ $t("label.container", containers.length) }}
           </Tag>
         </div>
-        <MultiContainerStat class="ml-auto" :containers="containers" />
-        <MultiContainerActionToolbar class="max-md:hidden" @clear="viewer?.clear()" />
+        <MultiContainerStat class="ml-auto justify-center max-md:basis-full max-md:order-last" :containers="containers" />
+        <MultiContainerActionToolbar @clear="viewer?.clear()" />
       </div>
     </template>
     <template #default>

--- a/assets/components/MultiContainerViewer/MultiContainerLog.vue
+++ b/assets/components/MultiContainerViewer/MultiContainerLog.vue
@@ -1,15 +1,15 @@
 <template>
   <ScrollableView :scrollable="scrollable" v-if="containers.length && ready">
     <template #header>
-      <div class="mx-2 flex items-center gap-2 md:ml-4">
+      <div class="mx-2 flex flex-wrap items-center gap-2 md:ml-4">
         <div class="@container flex flex-1 gap-1.5 truncate md:gap-2">
           <octicon:container-24 />
           <div class="inline-flex font-mono text-sm">
             <div class="font-semibold">{{ containers.length }} containers</div>
           </div>
         </div>
-        <MultiContainerStat class="ml-auto" :containers="containers" />
-        <MultiContainerActionToolbar class="max-md:hidden" @clear="viewer?.clear()" />
+        <MultiContainerStat class="ml-auto justify-center max-md:basis-full max-md:order-last" :containers="containers" />
+        <MultiContainerActionToolbar @clear="viewer?.clear()" />
       </div>
     </template>
     <template #default>

--- a/assets/components/ServiceViewer/ServiceLog.vue
+++ b/assets/components/ServiceViewer/ServiceLog.vue
@@ -1,7 +1,7 @@
 <template>
   <ScrollableView :scrollable="scrollable" v-if="service.name">
     <template #header>
-      <div class="mx-2 flex items-center gap-2 md:ml-4">
+      <div class="mx-2 flex flex-wrap items-center gap-2 md:ml-4">
         <div class="@container flex flex-1 gap-1.5 truncate md:gap-2">
           <ph:stack-simple />
           <div class="inline-flex font-mono text-sm">
@@ -11,8 +11,8 @@
             {{ $t("label.container", service.containers.length) }}
           </Tag>
         </div>
-        <MultiContainerStat class="ml-auto" :containers="service.containers" />
-        <MultiContainerActionToolbar class="max-md:hidden" @clear="viewer?.clear()" />
+        <MultiContainerStat class="ml-auto justify-center max-md:basis-full max-md:order-last" :containers="service.containers" />
+        <MultiContainerActionToolbar @clear="viewer?.clear()" />
       </div>
     </template>
     <template #default>

--- a/assets/components/StackViewer/StackLog.vue
+++ b/assets/components/StackViewer/StackLog.vue
@@ -1,7 +1,7 @@
 <template>
   <ScrollableView :scrollable="scrollable" v-if="stack.name">
     <template #header>
-      <div class="mx-2 flex items-center gap-2 md:ml-4">
+      <div class="mx-2 flex flex-wrap items-center gap-2 md:ml-4">
         <div class="@container flex flex-1 gap-1.5 truncate md:gap-2">
           <ph:stack />
           <div class="inline-flex font-mono text-sm">
@@ -14,8 +14,8 @@
             {{ $t("label.service", stack.services.length) }}
           </Tag>
         </div>
-        <MultiContainerStat class="ml-auto" :containers="stack.containers" />
-        <MultiContainerActionToolbar class="max-md:hidden" @clear="viewer?.clear()" />
+        <MultiContainerStat class="ml-auto justify-center max-md:basis-full max-md:order-last" :containers="stack.containers" />
+        <MultiContainerActionToolbar @clear="viewer?.clear()" />
       </div>
     </template>
     <template #default>


### PR DESCRIPTION
Displays the actions dropdown in the mobile menu, and rearranges the toolbar items in order to fit.

According what proposed here: https://github.com/amir20/dozzle/commit/1637b37cc15e24e23036e78b7e8991a61dc8b998#commitcomment-152751497