### PR TITLE
feat: Supports log levels with common separators

### DIFF
--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -22,6 +22,7 @@ var logLevels = [][]string{
 
 var plainLevels = map[string][]*regexp.Regexp{}
 var bracketLevels = map[string][]*regexp.Regexp{}
+var separatorLevels = map[string][]*regexp.Regexp{}
 var timestampRegex = regexp.MustCompile(`^(?:\d{4}[-/]\d{2}[-/]\d{2}(?:[T ](?:\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?|\d{2}:\d{2}(?:AM|PM)))?\s+)`)
 
 func init() {
@@ -36,6 +37,7 @@ func init() {
 		first := levelGroup[0]
 		for _, level := range levelGroup {
 			bracketLevels[first] = append(bracketLevels[first], regexp.MustCompile("(?i)\\[ ?"+level+" ?\\]"))
+			separatorLevels[first] = append(separatorLevels[first], regexp.MustCompile("(?i)"+level+"[=/-]"))
 		}
 	}
 
@@ -62,6 +64,13 @@ func guessLogLevel(logEvent *LogEvent) string {
 
 			// Look for the level in brackets
 			for _, regex := range bracketLevels[first] {
+				if regex.MatchString(value) {
+					return first
+				}
+			}
+
+			// Look for the level with a separator after
+			for _, regex := range separatorLevels[first] {
 				if regex.MatchString(value) {
 					return first
 				}

--- a/internal/container/level_guesser_test.go
+++ b/internal/container/level_guesser_test.go
@@ -14,6 +14,8 @@ func TestGuessLogLevel(t *testing.T) {
 		expected string
 	}{
 		{"2024/12/30 12:21AM INF this is a test", "info"},
+		{"2025-01-07 22:00:08,059: DEBUG/MainProcess TaskPool: ", "debug"},
+		{"Some test with error=test", "error"},
 		{"2024-12-30T17:43:16Z DBG loggging debug from here", "debug"},
 		{"2025-01-07 15:40:15,784 LL=\"ERROR\" some message", "error"},
 		{"2025-01-07 15:40:15,784 LL=\"WARN\" some message", "warn"},


### PR DESCRIPTION
Revival of [this PR](https://github.com/amir20/dozzle/pull/3368) that added support for log levels followed by an equal sign, but also added support for `/` and `-`. Original PR was removed in https://github.com/amir20/dozzle/pull/3491

`/` is especially a common format for celery:

```
[2025-02-20 14:55:36,789: INFO/MainProcess] Task example.tasks.add[1234abcd] succeeded in 0.015s: 42
[2025-02-20 14:56:10,123: ERROR/MainProcess] Task example.tasks.divide[5678efgh] raised exception: ZeroDivisionError('division by zero')
```

