### PR TITLE
feat: safe area styling for ios pwa

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -126,3 +126,12 @@
     }
   }
 }
+
+nav {
+  padding-top: env(safe-area-inset-top);
+}
+
+body {
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+}

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <title>Dozzle</title>
     <script type="application/json" id="config__json">
       {{ marshal .Config }}


### PR DESCRIPTION
This PR adds required meta tags and some safe area styling for PWA to render correctly on iOS.

I was able to test this by opening iOS Simulator in XCode and going to `http:/localhost:3100` in safari, and then pressing share button and saving it to home screen.

Before:

<img src="https://github.com/user-attachments/assets/d1aef3ed-1229-4d10-a7b9-1f1c0a320c7f" height="800"></img>

After:

<img src="https://github.com/user-attachments/assets/842bd17b-00df-49f0-b003-d827ab44d739" height="800"></img>

