### PR TITLE
fix: use light mode bg color as theme color

### DIFF
--- a/assets/App.vue
+++ b/assets/App.vue
@@ -15,7 +15,7 @@ watchEffect(() => {
   if (theme === "auto") {
     theme = mode.value;
   }
-  document.querySelector('meta[name="theme-color"]')?.setAttribute("content", theme == "dark" ? "#121212" : "#3FA68F");
+  document.querySelector('meta[name="theme-color"]')?.setAttribute("content", theme == "dark" ? "#121212" : "#F5F5F5");
   document.documentElement.setAttribute("data-theme", theme);
 });
 </script>


### PR DESCRIPTION
This sets the color of the tab bar to white to match the background color:

<img width="1232" alt="image" src="https://github.com/user-attachments/assets/480d1b37-0c8d-4638-be83-0673aad9badf" />


---

Updates #3703 