### PR TITLE
docs: remove leading tcp://

### DIFF
--- a/docs/guide/supported-env-vars.md
+++ b/docs/guide/supported-env-vars.md
@@ -27,7 +27,7 @@ Configurations can be done with flags or environment variables. The table below 
 | `--namespace`         | `DOZZLE_NAMESPACE`         | `""`           |
 
 > [!TIP]
-> Some flags like `--remote-host` or `--remote-agent` can be used multiple times. For example, `--remote-agent tcp://167.99.1.1:7007 --remote-agent tcp://167.99.1.2:7007` or comma-separated `DOZZLE_REMOTE_AGENT=tcp://167.99.1.1:7007,tcp://167.99.1.2:7007`.
+> Some flags like `--remote-host` or `--remote-agent` can be used multiple times. For example, `--remote-agent 167.99.1.1:7007 --remote-agent 167.99.1.2:7007` or comma-separated `DOZZLE_REMOTE_AGENT=167.99.1.1:7007,167.99.1.2:7007`.
 
 ## Generate users.yml
 


### PR DESCRIPTION
Examples were wrong, see
[#3523](https://github.com/amir20/dozzle/issues/3523) where tcp://1.2.3.4:7007 gets transformed into tcp://1.2.3.4:7007:443

Root cause: the endpoint values are passed to google golang grpc library, NewClient, which does not support "tcp://" prefix like other parts. Instead it supports
none, "dns://", "zookeeper://", "unix://", "unix-abstract://", "vsock:", "ipv4:", "ipv6:". In the future additional syntax might be added

See https://pkg.go.dev/google.golang.org/grpc#NewClient for GRPC documentation
and https://github.com/grpc/grpc/blob/master/doc/naming.md for possible values