### PR TITLE
chore: Add .DS_Store to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.out
 *.pem
 *.csr
 tmp
+.DS_Store


### PR DESCRIPTION
Description:

This Pull Request adds .DS_Store to the .gitignore file.

What was changed?
	
- Added `.DS_Store` to .gitignore.

Why was this change necessary?

The `.DS_Store` files are automatically generated by Finder on macOS. They do not contain any project-relevant data. Ignoring them prevents unnecessary clutter in the repository.