### PR TITLE
fix: Adjusted `<meter>` thresholds for CPU and Memory usage display

### DIFF
--- a/assets/components/ContainerTable.vue
+++ b/assets/components/ContainerTable.vue
@@ -83,9 +83,9 @@
                   class="flex-1 overflow-hidden rounded-3xl"
                   min="0"
                   max="100"
-                  low="40"
+                  low="60"
                   optimum="0"
-                  high="70"
+                  high="80"
                   :value="Math.min(container.movingAverage.cpu, 100)"
                 ></meter>
                 <span class="w-8 text-right text-sm">{{ container.movingAverage.cpu.toFixed(0) }}%</span>
@@ -97,9 +97,9 @@
                   class="flex-1 overflow-hidden rounded-3xl"
                   min="0"
                   max="100"
-                  low="40"
+                  low="70"
                   optimum="0"
-                  high="70"
+                  high="90"
                   :value="container.movingAverage.memory"
                 ></meter>
                 <span class="w-8 text-right text-sm">{{ container.movingAverage.memory.toFixed(0) }}%</span>


### PR DESCRIPTION
## Description

This PR updates the `low` and `high` attributes of the HTML5 `<meter>` elements in `ContainerTable.vue`.

### What changed?

- Adjusted the visual scaling of CPU and Memory meters to be less aggressive.
- Updated thresholds:

  - **CPU**: `low=60`, `high=80` (was 40/70)
  - **Memory**: `low=70`, `high=90` (was 40/70)

### Why?

- Previous values triggered color shifts too early, even under normal load.
- These changes better reflect actual performance ranges and enhance visual clarity.

### Impact

- Purely UI-level change.
- No functional or data logic altered.

## Related Issues and/or Discussions

### Discussions

- Relates to #3939