### PR TITLE
fix: allows dots inside URLs (not at end)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.24.5
           check-latest: true
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.4"
+          go-version: "1.24.5"
           check-latest: true
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.4"
+          go-version: "1.24.5"
           check-latest: true
       - name: Generate dependencies
         run: make fake_assets shared_key.pem shared_cert.pem

--- a/internal/support/web/url.go
+++ b/internal/support/web/url.go
@@ -12,7 +12,7 @@ const (
 )
 
 // Standard URL regex pattern to match http/https URLs
-var urlRegex = regexp.MustCompile(`(https?:\/\/[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_\+~#?&//=]*[^.]))`)
+var urlRegex = regexp.MustCompile(`(https?://[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}[-a-zA-Z0-9()@:%_+.~#?&/=]*/?(?:[-a-zA-Z0-9@%_+~#?&/=]|\b))`)
 
 // MarkURLs marks URLs in the logEvent message with special markers
 func MarkURLs(logEvent *container.LogEvent) bool {


### PR DESCRIPTION
Dots are no longer allowed within URLs since https://github.com/amir20/dozzle/pull/4016.

This PR adjusts the regex to re-allow them inside URLs, but not at the end. See this page for examples:
https://regex101.com/r/GyEriu/4

Also took the opportunity to slightly clean up the regex by removing superfluous escapes.

Note: we could also optionally disallow `?` (question marks) at the end of URLs so that they're considered part of the sentence around it rather than the last char of the URL itself (even though it's technically valid).

Before:

<img width="610" height="44" alt="image" src="https://github.com/user-attachments/assets/95213a6a-eb0d-4630-894c-3a16b4b78882" />

After:

<img width="616" height="42" alt="image" src="https://github.com/user-attachments/assets/7c03d535-8a1e-4b00-8a33-4519fac76b8e" />