### PR TITLE
fix: star conflicting with dropdown 

### DIFF
--- a/assets/components/ScrollableView.vue
+++ b/assets/components/ScrollableView.vue
@@ -2,7 +2,7 @@
   <section :class="{ 'h-screen min-h-0': scrollable }" class="flex flex-col">
     <header
       v-if="$slots.header"
-      class="border-base-content/10 bg-base-200 sticky top-[calc(55px+env(safe-area-inset-top))] z-2 border-b py-2 shadow-[1px_1px_2px_0_rgb(0,0,0,0.05)] md:top-0"
+      class="border-base-content/10 bg-base-200 sticky top-[calc(55px+env(safe-area-inset-top))] z-20 border-b py-2 shadow-[1px_1px_2px_0_rgb(0,0,0,0.05)] md:top-0"
     >
       <slot name="header"></slot>
     </header>


### PR DESCRIPTION
Resolved an issue where hovering near the star button would trigger the copy tooltip, obstructing the UI when logs are displayed beneath the header