### PR TITLE
docs: multiple namespaces use DOZZLE_NAMESPACE (comma-separated), not DOZZLE_NAMESPACES

### DIFF
--- a/docs/guide/k8s.md
+++ b/docs/guide/k8s.md
@@ -104,7 +104,7 @@ To verify that the API is running, you can run the following command:
 kubectl top pod
 ```
 
-For now this is required to use Dozzle in Kubernetes.
+For now, this is required to use Dozzle in Kubernetes.
 
 ## Namespaces and Filters
 
@@ -140,11 +140,11 @@ spec:
 ```
 
 > [!NOTE]
-> Dozzle supports multiple namespaces, you can set the `DOZZLE_NAMESPACES` environment variable to a comma separated list of namespaces. When multiple namespaces are specified, Dozzle will monitor each namespace separately and combine the results.
+> Dozzle supports multiple namespaces, you can set the `DOZZLE_NAMESPACE` environment variable to a comma-separated list of namespaces. When multiple namespaces are specified, Dozzle will monitor each namespace separately and combine the results.
 
 ### Labels and Filters
 
-`DOZZLE_FILTER` behave similarlty to Docker filters. You can limit the scope of Dozzle using the `DOZZLE_FILTER` environment variable. For example, to scope only to `env=prod`:
+`DOZZLE_FILTER` behave similarly to Docker filters. You can limit the scope of Dozzle using the `DOZZLE_FILTER` environment variable. For example, to scope only to `env=prod`:
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
The documentation currently states that Dozzle supports multiple namespaces via DOZZLE_NAMESPACES. In practice, multiple namespaces work when passed to DOZZLE_NAMESPACE as a comma-separated list. This PR updates the docs and examples to match the real behaviour.

## What changed
Replaced references to DOZZLE_NAMESPACES with DOZZLE_NAMESPACE.

## Why
Users following the current docs will set DOZZLE_NAMESPACES and see no effect. Aligning the docs with actual behaviour prevents misconfiguration.

## Impact
No breaking changes to running setups using DOZZLE_NAMESPACE.

## Discussion
Refs: https://github.com/amir20/dozzle/discussions/3614#discussioncomment-14102788