### PR TITLE
feat: implement ability to disable avatars

### DIFF
--- a/assets/components/Links.vue
+++ b/assets/components/Links.vue
@@ -14,7 +14,7 @@
 
     <dropdown class="dropdown-end" v-if="config.user">
       <template #trigger>
-        <template v-if="disableAvatars">
+        <template v-if="config.disableAvatars || !config.user.email">
           <material-symbols:person class="size-6" />
         </template>
         <template v-else>
@@ -29,12 +29,12 @@
           <div class="font-bold">
             {{ config.user.name }}
           </div>
-          <div class="text-sm font-light">
+          <div v-if="config.user.email" class="text-sm font-light">
             {{ config.user.email }}
           </div>
         </div>
-        <ul class="menu mt-4 p-0">
-          <li v-if="config.authProvider === 'simple'">
+        <ul v-if="config.authProvider === 'simple'" class="menu mt-4 p-0">
+          <li>
             <button @click.prevent="logout()" class="text-primary p-2">
               <material-symbols:logout />
               {{ $t("button.logout") }}
@@ -46,8 +46,6 @@
   </div>
 </template>
 <script lang="ts" setup>
-const { disableAvatars } = config;
-
 async function logout() {
   await fetch(withBase("/api/token"), {
     method: "DELETE",

--- a/assets/components/Links.vue
+++ b/assets/components/Links.vue
@@ -14,10 +14,15 @@
 
     <dropdown class="dropdown-end" v-if="config.user">
       <template #trigger>
-        <img
-          class="ring-base-content/60 size-6 max-w-none rounded-full p-px ring-1"
-          :src="withBase('/api/profile/avatar')"
-        />
+        <template v-if="disableAvatars">
+          <material-symbols:person class="size-6" />
+        </template>
+        <template v-else>
+          <img
+            class="ring-base-content/60 size-6 max-w-none rounded-full p-px ring-1"
+            :src="withBase('/api/profile/avatar')"
+          />
+        </template>
       </template>
       <template #content>
         <div class="p-2">
@@ -41,6 +46,8 @@
   </div>
 </template>
 <script lang="ts" setup>
+const { disableAvatars } = config;
+
 async function logout() {
   await fetch(withBase("/api/token"), {
     method: "DELETE",

--- a/assets/stores/config.ts
+++ b/assets/stores/config.ts
@@ -12,6 +12,7 @@ export interface Config {
   authProvider: "simple" | "none" | "forward-proxy";
   enableActions: boolean;
   enableShell: boolean;
+  disableAvatars: boolean;
   user?: {
     username: string;
     email: string;

--- a/docs/guide/supported-env-vars.md
+++ b/docs/guide/supported-env-vars.md
@@ -18,6 +18,7 @@ Configurations can be done with flags or environment variables. The table below 
 | `--auth-header-name`  | `DOZZLE_AUTH_HEADER_NAME`  | `Remote-Name`  |
 | `--enable-actions`    | `DOZZLE_ENABLE_ACTIONS`    | `false`        |
 | `--enable-shell`      | `DOZZLE_ENABLE_SHELL`      | `false`        |
+| `--disable-avatars`   | `DOZZLE_DISABLE_AVATARS`   | `false`        |
 | `--filter`            | `DOZZLE_FILTER`            | `""`           |
 | `--no-analytics`      | `DOZZLE_NO_ANALYTICS`      | `false`        |
 | `--mode`              | `DOZZLE_MODE`              | `server`       |

--- a/internal/support/cli/args.go
+++ b/internal/support/cli/args.go
@@ -23,6 +23,7 @@ type Args struct {
 	AuthHeaderFilter string              `arg:"--auth-header-filter,env:DOZZLE_AUTH_HEADER_FILTER" default:"Remote-Filter" help:"sets the HTTP Header to use for filtering in Forward Proxy configuration."`
 	EnableActions    bool                `arg:"--enable-actions,env:DOZZLE_ENABLE_ACTIONS" default:"false" help:"enables essential actions on containers from the web interface."`
 	EnableShell      bool                `arg:"--enable-shell,env:DOZZLE_ENABLE_SHELL" default:"false" help:"enables shell access to containers from the web interface."`
+	DisableAvatars   bool                `arg:"--disable-avatars,env:DOZZLE_DISABLE_AVATARS" default:"false" help:"disables avatars for authenticated users."`
 	FilterStrings    []string            `arg:"env:DOZZLE_FILTER,--filter,separate" help:"filters docker containers using Docker syntax."`
 	Filter           map[string][]string `arg:"-"`
 	RemoteHost       []string            `arg:"env:DOZZLE_REMOTE_HOST,--remote-host,separate" help:"list of hosts to connect remotely"`

--- a/internal/web/index.go
+++ b/internal/web/index.go
@@ -51,6 +51,7 @@ func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
 		config["hosts"] = hosts
 		config["enableActions"] = h.config.EnableActions
 		config["enableShell"] = h.config.EnableShell
+		config["disableAvatars"] = h.config.DisableAvatars
 	}
 
 	if user != nil {

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -27,16 +27,17 @@ const (
 
 // Config is a struct for configuring the web service
 type Config struct {
-	Base          string
-	Addr          string
-	Version       string
-	Hostname      string
-	NoAnalytics   bool
-	Dev           bool
-	Authorization Authorization
-	EnableActions bool
-	EnableShell   bool
-	Labels        container.ContainerLabels
+	Base           string
+	Addr           string
+	Version        string
+	Hostname       string
+	NoAnalytics    bool
+	Dev            bool
+	Authorization  Authorization
+	EnableActions  bool
+	EnableShell    bool
+	DisableAvatars bool
+	Labels         container.ContainerLabels
 }
 
 type Authorization struct {
@@ -122,7 +123,9 @@ func createRouter(h *handler) *chi.Mux {
 					r.Get("/hosts/{host}/containers/{id}/exec", h.exec)
 				}
 				r.Get("/releases", h.releases)
-				r.Get("/profile/avatar", h.avatar)
+				if !h.config.DisableAvatars {
+					r.Get("/profile/avatar", h.avatar)
+				}
 				r.Patch("/profile", h.updateProfile)
 				r.Get("/version", h.version)
 				if log.Debug().Enabled() {

--- a/main.go
+++ b/main.go
@@ -198,9 +198,10 @@ func createServer(args cli.Args, hostService web.HostService) *http.Server {
 			Authorizer: authorizer,
 			TTL:        authTTL,
 		},
-		EnableActions: args.EnableActions,
-		EnableShell:   args.EnableShell,
-		Labels:        args.Filter,
+		EnableActions:  args.EnableActions,
+		EnableShell:    args.EnableShell,
+		DisableAvatars: args.DisableAvatars,
+		Labels:         args.Filter,
 	}
 
 	assets, err := fs.Sub(content, "dist")


### PR DESCRIPTION
Resolves #4090.

This PR adds an option (argument or env var) to disable avatars entirely.
If the option is set to true, a user icon will be displayed in the place of the avatar instead and the avatar route will be disabled.