### PR TITLE
fix: panic - waitGroup counter goes negative

### DIFF
--- a/internal/support/docker/docker_service.go
+++ b/internal/support/docker/docker_service.go
@@ -121,6 +121,7 @@ func (d *DockerClientService) Attach(ctx context.Context, container container.Co
 
 	var wg sync.WaitGroup
 
+	wg.Add(1)
 	wg.Go(func() {
 		defer wg.Done()
 		if _, err := io.Copy(containerWriter, stdin); err != nil {
@@ -130,7 +131,9 @@ func (d *DockerClientService) Attach(ctx context.Context, container container.Co
 		containerWriter.Close()
 	})
 
+	wg.Add(1)
 	wg.Go(func() {
+		defer wg.Done()
 		if container.Tty {
 			if _, err := io.Copy(stdout, containerReader); err != nil {
 				log.Error().Err(err).Msg("error while writing to ws")

--- a/internal/support/docker/docker_service.go
+++ b/internal/support/docker/docker_service.go
@@ -121,9 +121,7 @@ func (d *DockerClientService) Attach(ctx context.Context, container container.Co
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
 	wg.Go(func() {
-		defer wg.Done()
 		if _, err := io.Copy(containerWriter, stdin); err != nil {
 			log.Error().Err(err).Msg("error while reading from ws")
 		}
@@ -131,9 +129,7 @@ func (d *DockerClientService) Attach(ctx context.Context, container container.Co
 		containerWriter.Close()
 	})
 
-	wg.Add(1)
 	wg.Go(func() {
-		defer wg.Done()
 		if container.Tty {
 			if _, err := io.Copy(stdout, containerReader); err != nil {
 				log.Error().Err(err).Msg("error while writing to ws")


### PR DESCRIPTION
Fixes #4099 

When the attach event is triggered, the waitGroup counter is not incremented. So it panics and stops the backend when the websocket connection is closed. fixed by incrementing wg counter.