### PR TITLE
feat: add DOZZLE_AUTH_LOGOUT_URL support for ForwarderProxy

### DIFF
--- a/assets/components/Links.vue
+++ b/assets/components/Links.vue
@@ -33,7 +33,7 @@
             {{ config.user.email }}
           </div>
         </div>
-        <ul v-if="config.authProvider === 'simple'" class="menu mt-4 p-0">
+        <ul v-if="config.authProvider === 'simple' || config.logoutUrl" class="menu mt-4 p-0">
           <li>
             <button @click.prevent="logout()" class="text-primary p-2">
               <material-symbols:logout />
@@ -46,11 +46,17 @@
   </div>
 </template>
 <script lang="ts" setup>
-async function logout() {
-  await fetch(withBase("/api/token"), {
-    method: "DELETE",
-  });
+const { logoutUrl } = config;
 
-  location.reload();
+async function logout() {
+  if (logoutUrl) {
+    location.href = logoutUrl;
+  } else {
+    await fetch(withBase("/api/token"), {
+      method: "DELETE",
+    });
+
+    location.reload();
+  }
 }
 </script>

--- a/assets/stores/config.ts
+++ b/assets/stores/config.ts
@@ -10,6 +10,7 @@ export interface Config {
   hostname: string;
   hosts: Host[];
   authProvider: "simple" | "none" | "forward-proxy";
+  logoutUrl?: string;
   enableActions: boolean;
   enableShell: boolean;
   enableDownload: boolean;

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -211,6 +211,12 @@ In this mode, Dozzle expects the following headers:
 - `Remote-Filter` to be a comma-separated list of filters allowed for user.
 - `Remote-Roles` to be a comma-separated list of roles allowed for user.
 
+Additionally, you can configure a logout URL with:
+
+```yaml
+DOZZLE_AUTH_LOGOUT_URL: http://oauth2.example.ru/oauth2/sign_out
+```
+
 ### Setting up Dozzle with Authelia
 
 [Authelia](https://www.authelia.com/) is an open-source authentication and authorization server and portal fulfilling the identity and access management. While setting up Authelia is out of scope for this section, the configuration can be shared as an example for setting up Dozzle with Authelia.

--- a/docs/guide/supported-env-vars.md
+++ b/docs/guide/supported-env-vars.md
@@ -18,6 +18,7 @@ Configurations can be done with flags or environment variables. The table below 
 | `--auth-header-name`   | `DOZZLE_AUTH_HEADER_NAME`   | `Remote-Name`   |
 | `--auth-header-filter` | `DOZZLE_AUTH_HEADER_FILTER` | `Remote-Filter` |
 | `--auth-header-roles`  | `DOZZLE_AUTH_HEADER_ROLES`  | `Remote-Roles`  |
+| `--auth-logout-url`    | `DOZZLE_AUTH_LOGOUT_URL`    | `""`            |
 | `--enable-actions`     | `DOZZLE_ENABLE_ACTIONS`     | `false`         |
 | `--enable-shell`       | `DOZZLE_ENABLE_SHELL`       | `false`         |
 | `--disable-avatars`    | `DOZZLE_DISABLE_AVATARS`    | `false`         |

--- a/internal/support/cli/args.go
+++ b/internal/support/cli/args.go
@@ -22,6 +22,7 @@ type Args struct {
 	AuthHeaderName   string              `arg:"--auth-header-name,env:DOZZLE_AUTH_HEADER_NAME" default:"Remote-Name" help:"sets the HTTP Header to use for name in Forward Proxy configuration."`
 	AuthHeaderFilter string              `arg:"--auth-header-filter,env:DOZZLE_AUTH_HEADER_FILTER" default:"Remote-Filter" help:"sets the HTTP Header to use for filtering in Forward Proxy configuration."`
 	AuthHeaderRoles  string              `arg:"--auth-header-roles,env:DOZZLE_AUTH_HEADER_ROLES" default:"Remote-Roles" help:"sets the HTTP Header to use for roles in Forward Proxy configuration."`
+	AuthLogoutUrl    string              `arg:"--auth-logout-url,env:DOZZLE_AUTH_LOGOUT_URL" help:"sets the Logout URL used with Forward Proxy."`
 	EnableActions    bool                `arg:"--enable-actions,env:DOZZLE_ENABLE_ACTIONS" default:"false" help:"enables essential actions on containers from the web interface."`
 	EnableShell      bool                `arg:"--enable-shell,env:DOZZLE_ENABLE_SHELL" default:"false" help:"enables shell access to containers from the web interface."`
 	DisableAvatars   bool                `arg:"--disable-avatars,env:DOZZLE_DISABLE_AVATARS" default:"false" help:"disables avatars for authenticated users."`

--- a/internal/web/index.go
+++ b/internal/web/index.go
@@ -4,6 +4,7 @@ import (
 	"html/template"
 	"io"
 	"sort"
+	"strings"
 
 	"encoding/json"
 
@@ -52,6 +53,10 @@ func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
 			config["enableShell"] = h.config.EnableShell
 			config["enableActions"] = h.config.EnableActions
 			config["enableDownload"] = true
+		}
+
+		if h.config.Authorization.Provider == FORWARD_PROXY && strings.TrimSpace(h.config.Authorization.LogoutUrl) != "" {
+			config["logoutUrl"] = strings.TrimSpace(h.config.Authorization.LogoutUrl)
 		}
 
 		config["authProvider"] = h.config.Authorization.Provider

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -52,6 +52,7 @@ type Authorization struct {
 	Provider   AuthProvider
 	Authorizer Authorizer
 	TTL        time.Duration
+	LogoutUrl  string
 }
 
 type Authorizer interface {

--- a/main.go
+++ b/main.go
@@ -208,6 +208,7 @@ func createServer(args cli.Args, hostService web.HostService) *http.Server {
 			Provider:   provider,
 			Authorizer: authorizer,
 			TTL:        authTTL,
+			LogoutUrl:  args.AuthLogoutUrl,
 		},
 		EnableActions:    args.EnableActions,
 		EnableShell:      args.EnableShell,


### PR DESCRIPTION
Adds support for a logout URL when using ForwarderProxy authentication in Dozzle. Users can now configure DOZZLE_AUTH_LOGOUT_URL to provide a custom logout endpoint.

Fixes https://github.com/amir20/dozzle/issues/4149#issuecomment-3339701720