### PR TITLE
fix: do not hide ContainerActionsToolbar component on mobile

### DIFF
--- a/assets/components/ContainerViewer/ContainerLog.vue
+++ b/assets/components/ContainerViewer/ContainerLog.vue
@@ -9,7 +9,7 @@
           v-if="container.state === 'running'"
         />
 
-        <ContainerActionsToolbar @clear="viewer?.clear()" class="max-md:hidden" :container="container" />
+        <ContainerActionsToolbar @clear="viewer?.clear()" :container="container" />
         <a class="btn btn-circle btn-xs" @click="close()" v-if="closable">
           <mdi:close />
         </a>

--- a/assets/components/ContainerViewer/HistoricalContainerLog.vue
+++ b/assets/components/ContainerViewer/HistoricalContainerLog.vue
@@ -12,7 +12,7 @@
           Live Logs
         </router-link>
 
-        <ContainerActionsToolbar class="max-md:hidden" :container="container" historical />
+        <ContainerActionsToolbar :container="container" historical />
         <a class="btn btn-circle btn-xs" @click="close()" v-if="closable">
           <mdi:close />
         </a>


### PR DESCRIPTION
This PR makes the ContainerActionsToolbar component visible on mobile devices by removing the `max-md:hidden` class.