### PR TITLE
docs: Traefik, Docker Swarm, Dozzle issue

### DIFF
--- a/docs/guide/faq.md
+++ b/docs/guide/faq.md
@@ -123,19 +123,9 @@ In Swarm Mode, Dozzle instances may require their own overlay network. If you se
 ```
 services:
   logs:
-    image: amir20/dozzle:latest
+    ...
     networks: [ traefik, dozzle ]
-    environment:
-      - DOZZLE_MODE=swarm
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    deploy:
-      mode: global
-      endpoint_mode: dnsrr
-      labels:
-        - "traefik.enable=true"
-        - "traefik.http.services.logs.loadbalancer.server.port=8080"
-        - "traefik.http.services.logs.loadbalancer.sticky.cookie.name=dozzle"
+    ...
 
 networks:
   dozzle:
@@ -144,4 +134,4 @@ networks:
     external: true
 ```
 
-Notice the external network `traefik` is the overlay network which is used for the load balancer service discovery, and we've created a new `dozzle` overlay network for the Dozzle nodes to talk to one another.
+The external network `traefik` is the overlay network which is used for the load balancer service discovery, and we've created a new `dozzle` overlay network for the Dozzle nodes to talk to one another.


### PR DESCRIPTION
Hello! So I ran into some weird behavior when I was trying out Dozzle in Swarm Mode. 

### Environment
- Dozzle 8.14.12
- Traefik 3.6
- Docker Swarm (Docker 28.3.3)
- Proxmox 9.1.4
  - 6 LXC nodes
    - 5 Alpine LXCs
    - 1 Debian LXC
 
Non-zero chance that this is a result of nested Alpine virtualization Proxmox -> LXC -> Docker container which has caused me a bunch of headaches already.

### Docker Compose (monitoring/docker-compose.yml)
```yml
services:
  logs:
    image: amir20/dozzle:latest
    networks: [ traefik ]
    environment:
      - DOZZLE_MODE=swarm
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
    deploy:
      mode: global
      endpoint_mode: dnsrr
      labels:
        - "traefik.enable=true"
        - "traefik.http.services.logs.loadbalancer.server.port=8080"
networks:
  traefik:
    external: true
```

The `traefik` network is the network on which Traefik does its service discovery.

### Problem
With the above setup, I would correctly see one Dozzle instance on each Swarm node, but when I would visit logs.mydomain.com, it would do one of three things:
- Time out
- Show 1 Swarm node (presumably only the node that that instance is sitting on)
- Show 5 Swarm nodes (excluding the Debian node)


### Solution
Add a separate overlay network with just the Dozzle nodes. This fixed my issues, and I don't have the knowledge to understand why. I figured that at the very least, I could contribute this to the documentation so that others might try this as a debugging step in their setups in the future.

```yml
services:
  logs:
    ...
    networks: [ traefik, overlay ]
    ...
```

```yml
networks:
  dozzle:
    driver: overlay
```

Naturally, if you feel like this doesn't need to be documented since it's not really frequently asked (couldn't find anyone else asking this) or if it belongs elsewhere, let me know please.