### PR TITLE
fix: use io.Copy for exec TTY output instead of stdcopy

### DIFF
--- a/internal/support/docker/docker_service.go
+++ b/internal/support/docker/docker_service.go
@@ -208,7 +208,8 @@ func (d *DockerClientService) Exec(ctx context.Context, c container.Container, c
 	})
 
 	wg.Go(func() {
-		if _, err := stdcopy.StdCopy(stdout, stdout, session.Reader); err != nil {
+		// TTY mode outputs raw bytes without Docker's multiplexing headers.
+		if _, err := io.Copy(stdout, session.Reader); err != nil {
 			log.Error().Err(err).Msg("error while writing to ws")
 		}
 		cancel()


### PR DESCRIPTION
Without TTY, Docker multiplexes stdout/stderr by prefixing each chunk with an 8-byte header (stream type + length). stdcopy.StdCopy parses these headers.

With TTY enabled, output is raw terminal data with no headers. stdcopy.StdCopy misinterprets the first bytes as a header, reads a bogus length, and blocks forever waiting for bytes that never arrive.

Exec always uses TTY mode, so io.Copy is correct (as Attach already does when c.Tty is true).