### PR TITLE
fix: detect agent stream errors and reconnect

### DIFF
--- a/internal/agent/client_test.go
+++ b/internal/agent/client_test.go
@@ -89,6 +89,10 @@ func (m *MockedClientService) Exec(ctx context.Context, c container.Container, c
 	return args.Error(0)
 }
 
+func (m *MockedClientService) Healthy() bool {
+	return true
+}
+
 var wantedContainer = container.Container{}
 
 func init() {

--- a/internal/support/container/client_service.go
+++ b/internal/support/container/client_service.go
@@ -29,4 +29,7 @@ type ClientService interface {
 	// Terminal
 	Attach(context.Context, container.Container, container.ExecEventReader, io.Writer) error
 	Exec(context.Context, container.Container, []string, container.ExecEventReader, io.Writer) error
+
+	// Health
+	Healthy() bool
 }

--- a/internal/support/docker/docker_service.go
+++ b/internal/support/docker/docker_service.go
@@ -218,3 +218,7 @@ func (d *DockerClientService) Exec(ctx context.Context, c container.Container, c
 
 	return nil
 }
+
+func (d *DockerClientService) Healthy() bool {
+	return true
+}

--- a/internal/support/k8s/k8s_service.go
+++ b/internal/support/k8s/k8s_service.go
@@ -189,3 +189,7 @@ func (k *K8sClientService) Exec(ctx context.Context, c container.Container, cmd 
 	wg.Wait()
 	return nil
 }
+
+func (k *K8sClientService) Healthy() bool {
+	return true
+}


### PR DESCRIPTION
Agents did not reconnect after restart, regardless of method used (podman restart, or podman stop/start). Streams broke but the connection appeared healthy, so no reconnection was triggered.

Adds Healthy() to ClientService interface. Agent sets healthy=false when any stream (stats, events, containers) fails. RetryAndList() checks health and reconnects unhealthy agents.