### PR TITLE
feat: Expand trace level aliases in level_guesser.go

### DIFF
--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -16,7 +16,7 @@ var logLevels = [][]string{
 	{"warn", "warning", "wrn"},
 	{"info", "inf"},
 	{"debug", "dbg"},
-	{"trace"},
+	{"trace", "verbose", "ver", "vbs"},
 	{"fatal", "sev", "severe", "crit", "critical"},
 }
 


### PR DESCRIPTION
Added verbose level aliases under the "trace" level so they get grouped as one.

PR based on my [feature request](https://github.com/amir20/dozzle/issues/4412)