### PR TITLE
style: brighten orange theme color

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -8,7 +8,7 @@
   --color-red: oklch(64% 0.218 28.85);
   --color-purple: oklch(51.49% 0.215 321.03);
   --color-blue: oklch(65% 0.171 249.5);
-  --color-orange: oklch(70% 0.186 48.13);
+  --color-orange: oklch(85% 0.186 48.13);
 }
 
 @utility pt-safe {


### PR DESCRIPTION
Adjust the `--color-orange` definition to improve its prominence vs the red.

Fixes #4456

## Before:
<img width="439" height="310" alt="Screenshot 2026-02-19 at 01 10 44" src="https://github.com/user-attachments/assets/14b75133-1d30-40ab-8f9d-c158aa87150e" />

## After:
<img width="435" height="315" alt="Screenshot 2026-02-19 at 01 10 29" src="https://github.com/user-attachments/assets/4aac49a0-09af-43eb-b000-a9b3c75fad04" />
