### PR TITLE
fix: use coolify.serviceName for unique container names in multi-container apps

### DIFF
--- a/docs/guide/container-names.md
+++ b/docs/guide/container-names.md
@@ -32,7 +32,7 @@ services:
 
 If you're using [Coolify](https://coolify.io/), Dozzle automatically recognizes Coolify's labels as fallbacks:
 
-- `coolify.resourceName` → Used as container name if `dev.dozzle.name` is not set
+- `coolify.serviceName` → Used as container name if `dev.dozzle.name` is not set
 - `coolify.projectName` → Used for grouping if `dev.dozzle.group` is not set
 
 No additional configuration is needed for Coolify deployments.

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -386,8 +386,8 @@ func newContainer(c docker.Summary, host string) container.Container {
 	name := "no name"
 	if c.Labels["dev.dozzle.name"] != "" {
 		name = c.Labels["dev.dozzle.name"]
-	} else if c.Labels["coolify.resourceName"] != "" {
-		name = c.Labels["coolify.resourceName"]
+	} else if c.Labels["coolify.serviceName"] != "" {
+		name = c.Labels["coolify.serviceName"]
 	} else if len(c.Names) > 0 {
 		name = strings.TrimPrefix(c.Names[0], "/")
 	}
@@ -416,8 +416,8 @@ func newContainerFromJSON(c docker.InspectResponse, host string) container.Conta
 	name := "no name"
 	if c.Config.Labels["dev.dozzle.name"] != "" {
 		name = c.Config.Labels["dev.dozzle.name"]
-	} else if c.Config.Labels["coolify.resourceName"] != "" {
-		name = c.Config.Labels["coolify.resourceName"]
+	} else if c.Config.Labels["coolify.serviceName"] != "" {
+		name = c.Config.Labels["coolify.serviceName"]
 	} else if len(c.Name) > 0 {
 		name = strings.TrimPrefix(c.Name, "/")
 	}

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -271,14 +271,14 @@ func Test_newContainer_labelPriority(t *testing.T) {
 	}{
 		{
 			name:          "dozzle labels take priority",
-			labels:        map[string]string{"dev.dozzle.name": "dozzle-name", "coolify.resourceName": "coolify-name", "dev.dozzle.group": "dozzle-group", "coolify.projectName": "coolify-project"},
+			labels:        map[string]string{"dev.dozzle.name": "dozzle-name", "coolify.serviceName": "coolify-name", "dev.dozzle.group": "dozzle-group", "coolify.projectName": "coolify-project"},
 			containerName: "/docker-name",
 			expectedName:  "dozzle-name",
 			expectedGroup: "dozzle-group",
 		},
 		{
 			name:          "coolify labels as fallback",
-			labels:        map[string]string{"coolify.resourceName": "coolify-name", "coolify.projectName": "coolify-project"},
+			labels:        map[string]string{"coolify.serviceName": "coolify-name", "coolify.projectName": "coolify-project"},
 			containerName: "/docker-name",
 			expectedName:  "coolify-name",
 			expectedGroup: "coolify-project",
@@ -292,7 +292,7 @@ func Test_newContainer_labelPriority(t *testing.T) {
 		},
 		{
 			name:          "coolify name with dozzle group",
-			labels:        map[string]string{"coolify.resourceName": "coolify-name", "dev.dozzle.group": "dozzle-group"},
+			labels:        map[string]string{"coolify.serviceName": "coolify-name", "dev.dozzle.group": "dozzle-group"},
 			containerName: "/docker-name",
 			expectedName:  "coolify-name",
 			expectedGroup: "dozzle-group",
@@ -323,14 +323,14 @@ func Test_newContainerFromJSON_labelPriority(t *testing.T) {
 	}{
 		{
 			name:          "dozzle labels take priority",
-			labels:        map[string]string{"dev.dozzle.name": "dozzle-name", "coolify.resourceName": "coolify-name", "dev.dozzle.group": "dozzle-group", "coolify.projectName": "coolify-project"},
+			labels:        map[string]string{"dev.dozzle.name": "dozzle-name", "coolify.serviceName": "coolify-name", "dev.dozzle.group": "dozzle-group", "coolify.projectName": "coolify-project"},
 			containerName: "/docker-name",
 			expectedName:  "dozzle-name",
 			expectedGroup: "dozzle-group",
 		},
 		{
 			name:          "coolify labels as fallback",
-			labels:        map[string]string{"coolify.resourceName": "coolify-name", "coolify.projectName": "coolify-project"},
+			labels:        map[string]string{"coolify.serviceName": "coolify-name", "coolify.projectName": "coolify-project"},
 			containerName: "/docker-name",
 			expectedName:  "coolify-name",
 			expectedGroup: "coolify-project",


### PR DESCRIPTION
## Summary

- Use `coolify.serviceName` instead of `coolify.resourceName` as fallback for container display name
- `resourceName` is identical for all containers in a multi-container Coolify app, making them indistinguishable
- `serviceName` is unique per sub-service, falling back to `resourceName` for single-container apps

Fixes #4432

## Test plan

- [x] Existing label priority tests updated and passing
- [x] Verify with multi-container Coolify app that containers show distinct names
