### PR TITLE
docs: update commented users.yaml generation command 

### DIFF
--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -25,7 +25,7 @@ users:
   admin:
     email: me@email.net
     name: Admin
-    # Generate with docker run -it --rm amir20/dozzle generate --name Admin --email me@email.net --password secret admin
+    # Generate with docker run -it --rm amir20/dozzle generate admin --password password --email me@email.net --name "Admin" 
     password: $2a$11$9ho4vY2LdJ/WBopFcsAS0uORC0x2vuFHQgT/yBqZyzclhHsoaIkzK
     filter:
     roles:


### PR DESCRIPTION
This updates an inconsistency in the Dozzle documentation where it contains a comment with an incorrect command format for generating the users.yaml file 

### Why This Matters
This inconsistency can confuse new users trying to set up basic authentication for the first time, as they might copy the incorrect command and wonder why it doesn't work (I actually spent a considerable amount of time trying to figure out why it wasn't working) only for me to scroll a down to find the solution as the incorrect command appears first in the authentication documentation before the correct command under "generating users.yaml " section 

