### PR TITLE
test: add notification config to agent integration test

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       start_interval: 5s
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./e2e/data/notifications.yml:/data/notifications.yml:ro
     build:
       context: .
   proxy:

--- a/e2e/data/notifications.yml
+++ b/e2e/data/notifications.yml
@@ -1,0 +1,12 @@
+subscriptions:
+  - id: 1
+    name: test-alert
+    enabled: true
+    dispatcherId: 1
+    logExpression: 'message contains "error"'
+    containerExpression: 'name contains "dozzle"'
+dispatchers:
+  - id: 1
+    name: test-webhook
+    type: webhook
+    url: http://localhost:9999/webhook


### PR DESCRIPTION
## Summary
- Mounts `e2e/data/notifications.yml` into the agent container during integration tests
- Exercises the `LoadConfig`-on-startup code path that was fixed in 78114eb2
- Without that fix, the agent would panic with a nil pointer when loading a notification config before `Start()` sets the matcher

## Test plan
- [ ] `make int` passes with agent loading the notification config
- [ ] Agent logs show `"Loaded notification config from disk"` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)