### PR TITLE
chore: set User-Agent header on outgoing HTTP requests

### DIFF
--- a/internal/notification/dispatcher/cloud.go
+++ b/internal/notification/dispatcher/cloud.go
@@ -75,6 +75,7 @@ func (c *CloudDispatcher) Send(ctx context.Context, notification types.Notificat
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", UserAgent)
 	req.Header.Set("X-API-Key", c.APIKey)
 
 	resp, err := c.client.Do(req)

--- a/internal/notification/dispatcher/webhook.go
+++ b/internal/notification/dispatcher/webhook.go
@@ -15,6 +15,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// UserAgent is set by the application at startup
+var UserAgent = "Dozzle/head"
+
 // WebhookDispatcher sends notifications to a webhook URL
 type WebhookDispatcher struct {
 	Name         string
@@ -86,6 +89,7 @@ func (w *WebhookDispatcher) SendTest(ctx context.Context, notification types.Not
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", UserAgent)
 
 	resp, err := w.client.Do(req)
 	if err != nil {

--- a/internal/web/cloud.go
+++ b/internal/web/cloud.go
@@ -39,6 +39,7 @@ func (h *handler) cloudCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to create request", http.StatusInternalServerError)
 		return
 	}
+	req.Header.Set("User-Agent", dispatcher.UserAgent)
 	q := req.URL.Query()
 	q.Set("token", token)
 	req.URL.RawQuery = q.Encode()
@@ -129,6 +130,7 @@ func (h *handler) cloudStatus(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to create request")
 		return
 	}
+	req.Header.Set("User-Agent", dispatcher.UserAgent)
 	req.Header.Set("X-API-Key", apiKey)
 
 	resp, err := client.Do(req)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"embed"
+	"fmt"
 	"io/fs"
 
 	"net"
@@ -17,6 +18,7 @@ import (
 	"github.com/amir20/dozzle/internal/auth"
 	"github.com/amir20/dozzle/internal/docker"
 	"github.com/amir20/dozzle/internal/k8s"
+	"github.com/amir20/dozzle/internal/notification/dispatcher"
 	"github.com/amir20/dozzle/internal/support/cli"
 	docker_support "github.com/amir20/dozzle/internal/support/docker"
 	k8s_support "github.com/amir20/dozzle/internal/support/k8s"
@@ -52,6 +54,7 @@ func main() {
 	}
 
 	log.Info().Msgf("Dozzle version %s", args.Version())
+	dispatcher.UserAgent = fmt.Sprintf("Dozzle/%s", args.Version())
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()


### PR DESCRIPTION
## Summary
- Sets `User-Agent: Dozzle/<version>` on all outgoing HTTP requests in webhook dispatcher, cloud dispatcher, and cloud API handlers
- Adds `dispatcher.Version` package variable set from `cli.Version` at startup

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race` passes for affected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)