### PR TITLE
fix: set correct timestamp on downloaded zip log files

### DIFF
--- a/internal/web/download.go
+++ b/internal/web/download.go
@@ -137,7 +137,11 @@ func (h *handler) downloadLogs(w http.ResponseWriter, r *http.Request) {
 	for _, c := range containers {
 		// Create new file in zip for this container's logs
 		fileName := fmt.Sprintf("%s-%s.log", c.containerService.Container.Name, nowFmt)
-		f, err := zw.Create(fileName)
+		f, err := zw.CreateHeader(&zip.FileHeader{
+			Name:     fileName,
+			Modified: now,
+			Method:   zip.Deflate,
+		})
 		if err != nil {
 			log.Error().Err(err).Msgf("error creating zip entry for container %s", c.id)
 			return


### PR DESCRIPTION
## Summary
- Fixes #4515 — downloaded log zip files had entries dated 1979-11-30 (Go zero time)
- Use `zw.CreateHeader` with `Modified: time.Now()` instead of `zw.Create` so files have the current timestamp

## Test plan
- [x] Download container logs and verify the zip entries have the current date/time

🤖 Generated with [Claude Code](https://claude.com/claude-code)