### PR TITLE
fix: preserve notification runtime stats on update

### DIFF
--- a/internal/notification/manager.go
+++ b/internal/notification/manager.go
@@ -152,7 +152,12 @@ func (m *Manager) UpdateSubscription(id int, updates map[string]any) error {
 			SampleWindow:        sub.SampleWindow,
 			MetricCooldowns:     sub.MetricCooldowns,
 			MetricSampleBuffers: sub.MetricSampleBuffers,
+			TriggeredContainerIDs: sub.TriggeredContainerIDs,
 		}
+
+		// Preserve runtime stats (atomics can't be copied in struct literal)
+		updated.TriggerCount.Store(sub.TriggerCount.Load())
+		updated.LastTriggeredAt.Store(sub.LastTriggeredAt.Load())
 
 		// Apply updates to the clone
 		for key, value := range updates {


### PR DESCRIPTION
## Summary
- `UpdateSubscription` clones the subscription into a new struct but was not copying `TriggerCount`, `LastTriggeredAt`, or `TriggeredContainerIDs`
- Any PATCH update (toggle enabled, rename, change expression) silently reset accumulated notification stats to zero
- Atomics (`TriggerCount`, `LastTriggeredAt`) require explicit `.Store()` calls since they can't be set in a struct literal

## Test plan
- [ ] Create a notification rule, trigger it a few times, verify trigger count increments
- [ ] Toggle the rule enabled/disabled via PATCH, verify trigger count and last triggered time are preserved
- [ ] Rename the rule, verify stats are still preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)