### PR TITLE
fix: emit orphaned log lines when no real entry follows

### DIFF
--- a/internal/container/event_generator.go
+++ b/internal/container/event_generator.go
@@ -85,11 +85,76 @@ func (g *EventGenerator) flushGroup(pendingGroup []*LogEvent) bool {
 	})
 }
 
+// emitAsSingles emits each event individually as LogTypeSingle.
+func (g *EventGenerator) emitAsSingles(events []*LogEvent) bool {
+	for _, e := range events {
+		e.Type = LogTypeSingle
+		if !g.emit(e) {
+			return false
+		}
+	}
+	return true
+}
+
+// skipOrphanedLines drains leading simple events without a level that look
+// like orphaned continuation lines from a group already emitted in a prior
+// fetch. Returns the first non-orphan event (or nil if the stream ends).
+// If no non-orphan event arrives (stream ends or times out waiting), the
+// buffered events are emitted as singles — they weren't really orphans.
+func (g *EventGenerator) skipOrphanedLines() *LogEvent {
+	var orphanBuffer []*LogEvent
+	var lastTimestamp int64
+
+	// First event must block — we need at least one event to start.
+	current := g.nextEvent()
+	if current == nil {
+		return nil
+	}
+
+	for {
+		isOrphan := current.IsSimple() && !current.HasLevel() && current.Timestamp > 0 &&
+			(lastTimestamp == 0 || math.Abs(float64(lastTimestamp-current.Timestamp)) < maxGroupTimeDelta)
+
+		if !isOrphan {
+			if len(orphanBuffer) > 0 {
+				log.Debug().Int("count", len(orphanBuffer)).Str("container", g.containerID).Msg("skipped orphaned continuation lines")
+			}
+			return current
+		}
+
+		lastTimestamp = current.Timestamp
+		orphanBuffer = append(orphanBuffer, current)
+
+		// Use peek (with timeout) so we don't block forever on a live stream.
+		if next := g.peek(); next == nil {
+			// No more events within the timeout — these aren't orphans.
+			// Emit them as singles, then block for the next event so the
+			// stream continues processing.
+			g.emitAsSingles(orphanBuffer)
+			return g.nextEvent()
+		}
+		if current = g.nextEvent(); current == nil {
+			g.emitAsSingles(orphanBuffer)
+			return nil
+		}
+	}
+}
+
 func (g *EventGenerator) processBuffer() {
+	defer func() {
+		close(g.Events)
+		g.wg.Done()
+	}()
+
 	var pendingGroup []*LogEvent
-	seenFirst := false
-	var lastOrphanTimestamp int64
-	orphanCount := 0
+
+	// Skip leading orphaned continuation lines from a prior fetch.
+	first := g.skipOrphanedLines()
+	if first == nil {
+		return
+	}
+	// Put the first real event back so the main loop picks it up.
+	g.next = first
 
 loop:
 	for {
@@ -99,9 +164,8 @@ loop:
 			break loop
 		}
 
-		// Complex logs are emitted immediately and always mark seenFirst
+		// Complex logs are emitted immediately
 		if !current.IsSimple() {
-			seenFirst = true
 			if !g.flushGroup(pendingGroup) {
 				break loop
 			}
@@ -110,24 +174,6 @@ loop:
 				break loop
 			}
 			continue
-		}
-
-		// Skip leading simple events without a level that look like orphaned
-		// continuation lines from a group already emitted in a prior fetch.
-		// Only skip if they have a timestamp and are close in time, matching
-		// the group continuation criteria.
-		if !seenFirst && !current.HasLevel() && current.Timestamp > 0 {
-			if lastOrphanTimestamp == 0 || math.Abs(float64(lastOrphanTimestamp-current.Timestamp)) < maxGroupTimeDelta {
-				lastOrphanTimestamp = current.Timestamp
-				orphanCount++
-				continue
-			}
-		}
-		if !seenFirst {
-			if orphanCount > 0 {
-				log.Debug().Int("count", orphanCount).Str("container", g.containerID).Msg("skipped orphaned continuation lines")
-			}
-			seenFirst = true
 		}
 
 		// Simple log - peek ahead to decide grouping
@@ -157,9 +203,6 @@ loop:
 			next.Level = pendingGroup[0].Level
 		}
 	}
-
-	close(g.Events)
-	g.wg.Done()
 }
 
 func (g *EventGenerator) nextEvent() *LogEvent {

--- a/internal/container/event_generator_test.go
+++ b/internal/container/event_generator_test.go
@@ -240,16 +240,14 @@ func TestEventGenerator_MixedLogs(t *testing.T) {
 	assert.Equal(t, LogTypeSingle, event2.Type)
 }
 
-func TestEventGenerator_SkipsLeadingOrphanedContinuationLines(t *testing.T) {
-	// Simulate a pagination boundary where orphaned continuation lines
-	// (no level, with timestamp) appear before the first real log entry.
-	// These should be skipped as they belong to a group from a prior fetch.
+// Tests for orphan skipping: leading levelless lines ARE skipped when real logs follow.
+func TestEventGenerator_OrphanSkipped_FollowedByLeveledLog(t *testing.T) {
 	baseTime := "2020-05-13T18:55:37.772853839Z"
 	messages := []string{
-		baseTime + " at line 42",          // orphan continuation (no level)
-		baseTime + " in function foo",     // orphan continuation (no level)
-		baseTime + " ERROR: Next error",   // real entry with level
-		baseTime + " at line 99",          // continuation of the real entry
+		baseTime + " at line 42",        // orphan (no level)
+		baseTime + " in function foo",   // orphan (no level)
+		baseTime + " ERROR: Next error", // real entry with level
+		baseTime + " at line 99",        // continuation of real entry
 	}
 
 	reader := &mockLogReader{
@@ -260,62 +258,16 @@ func TestEventGenerator_SkipsLeadingOrphanedContinuationLines(t *testing.T) {
 	g := NewEventGenerator(context.Background(), reader, Container{Tty: false})
 	event := <-g.Events
 
-	require.NotNil(t, event, "Expected event to not be nil")
+	require.NotNil(t, event)
 	assert.Equal(t, LogTypeGroup, event.Type)
-
 	fragments, ok := event.Message.([]LogFragment)
-	require.True(t, ok, "Expected Message to be []LogFragment")
+	require.True(t, ok)
 	assert.Len(t, fragments, 2)
 	assert.Equal(t, "ERROR: Next error", fragments[0].Message)
 	assert.Equal(t, "at line 99", fragments[1].Message)
 }
 
-func TestEventGenerator_DoesNotSkipLeadingLevellessLogsWithTimestampGap(t *testing.T) {
-	// Leading lines without levels but far apart in time should NOT be skipped.
-	// They are standalone logs, not orphaned group continuations.
-	messages := []string{
-		"2020-05-13T18:55:37.000Z some log without level",
-		"2020-05-13T18:55:38.000Z another log without level",
-	}
-
-	reader := &mockLogReader{
-		messages: messages,
-		types:    []StdType{STDOUT, STDOUT},
-	}
-
-	g := NewEventGenerator(context.Background(), reader, Container{Tty: false})
-
-	// First line is skipped (potential orphan), but the second is too far in time
-	// so it should be emitted.
-	event1 := <-g.Events
-	require.NotNil(t, event1, "Expected event to not be nil")
-	assert.Equal(t, LogTypeSingle, event1.Type)
-	assert.Equal(t, "another log without level", event1.Message)
-}
-
-func TestEventGenerator_AllOrphanedLinesProducesNoEvents(t *testing.T) {
-	// If all lines are orphaned continuations, no events should be emitted.
-	baseTime := "2020-05-13T18:55:37.772853839Z"
-	messages := []string{
-		baseTime + " at line 42",
-		baseTime + " in function foo",
-		baseTime + " in function bar",
-	}
-
-	reader := &mockLogReader{
-		messages: messages,
-		types:    []StdType{STDERR, STDERR, STDERR},
-	}
-
-	g := NewEventGenerator(context.Background(), reader, Container{Tty: false})
-	event, ok := <-g.Events
-
-	assert.False(t, ok, "Expected channel to be closed with no events")
-	assert.Nil(t, event)
-}
-
-func TestEventGenerator_OrphanedLinesFollowedByComplexLog(t *testing.T) {
-	// Orphaned continuation lines should be skipped even when followed by a complex log.
+func TestEventGenerator_OrphanSkipped_FollowedByComplexLog(t *testing.T) {
 	baseTime := "2020-05-13T18:55:37.772853839Z"
 	messages := []string{
 		baseTime + " at line 42",
@@ -331,19 +283,67 @@ func TestEventGenerator_OrphanedLinesFollowedByComplexLog(t *testing.T) {
 	g := NewEventGenerator(context.Background(), reader, Container{Tty: false})
 	event := <-g.Events
 
-	require.NotNil(t, event, "Expected event to not be nil")
+	require.NotNil(t, event)
 	assert.Equal(t, LogTypeComplex, event.Type)
 }
 
-func TestEventGenerator_DoesNotSkipLeadingLinesWithoutTimestamp(t *testing.T) {
-	// Lines without timestamps (e.g., tty/raw input) should not be skipped
-	// even if they lack a level.
+// Tests for orphan NOT skipped: leading levelless lines are emitted when no real logs follow.
+func TestEventGenerator_OrphanNotSkipped_AllLevellessLines(t *testing.T) {
+	baseTime := "2020-05-13T18:55:37.772853839Z"
+	messages := []string{
+		baseTime + " at line 42",
+		baseTime + " in function foo",
+		baseTime + " in function bar",
+	}
+
+	reader := &mockLogReader{
+		messages: messages,
+		types:    []StdType{STDERR, STDERR, STDERR},
+	}
+
+	g := NewEventGenerator(context.Background(), reader, Container{Tty: false})
+
+	var events []*LogEvent
+	for event := range g.Events {
+		events = append(events, event)
+	}
+
+	assert.Len(t, events, 3)
+	for _, event := range events {
+		assert.Equal(t, LogTypeSingle, event.Type)
+	}
+}
+
+func TestEventGenerator_OrphanNotSkipped_TimestampGapBreaksOrphanDetection(t *testing.T) {
+	// Lines far apart in time are not orphans — the gap breaks the detection.
+	messages := []string{
+		"2020-05-13T18:55:37.000Z some log without level",
+		"2020-05-13T18:55:38.000Z another log without level",
+	}
+
+	reader := &mockLogReader{
+		messages: messages,
+		types:    []StdType{STDOUT, STDOUT},
+	}
+
+	g := NewEventGenerator(context.Background(), reader, Container{Tty: false})
+
+	// First line is buffered as orphan candidate, but the second has a timestamp
+	// gap so it's not an orphan — first is skipped, second is emitted.
+	event1 := <-g.Events
+	require.NotNil(t, event1)
+	assert.Equal(t, LogTypeSingle, event1.Type)
+	assert.Equal(t, "another log without level", event1.Message)
+}
+
+func TestEventGenerator_OrphanNotSkipped_NoTimestamp(t *testing.T) {
+	// Lines without timestamps (e.g., tty/raw input) are never treated as orphans.
 	input := "some raw output"
 
 	g := NewEventGenerator(context.Background(), makeFakeReader(input, STDOUT), Container{Tty: true})
 	event := <-g.Events
 
-	require.NotNil(t, event, "Expected event to not be nil")
+	require.NotNil(t, event)
 	assert.Equal(t, input, event.Message)
 	assert.Equal(t, LogTypeSingle, event.Type)
 }


### PR DESCRIPTION
## Summary
- Fixes a bug from #4518 where containers outputting only levelless logs (e.g., startup status lines) would show nothing
- Refactors orphan detection into a separate `skipOrphanedLines` phase that buffers candidates and decides based on what follows
- Fixes a live stream termination bug where peek timeout caused `processBuffer` to exit, losing all subsequent logs

Fixes https://github.com/amir20/dozzle/issues/4526

## Test plan
- [x] Existing orphan skip tests pass (orphans before leveled/complex logs are still skipped)
- [x] New test: all-levelless lines are emitted as singles when nothing follows
- [x] Timestamp gap and no-timestamp edge cases covered
- [x] Manual test: container with only levelless startup logs shows all lines
- [x] Manual test: pagination boundary still skips dangling group continuations

🤖 Generated with [Claude Code](https://claude.com/claude-code)