### PR TITLE
fix: fixes the date cutting in continued log events, see #4123

### DIFF
--- a/internal/docker/log_reader.go
+++ b/internal/docker/log_reader.go
@@ -59,7 +59,8 @@ func (d *LogReader) Read() (string, container.StdType, error) {
 			return "", std, err
 		}
 
-		message += tail[32:]
+		_, after, _ := strings.Cut(tail, " ")
+		message += after
 	}
 
 	return message, std, nil


### PR DESCRIPTION
Fixes #4123.

In continued log events do not truncate the date prefix to a fixed length of 32 characters, but up to the first space (inclusive).

This solves the problem of date format in log events from Docker and Podman being different.