### PR TITLE
fix: correct Makefile dependencies and missing .PHONY declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build: dist generate
 	CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/amir20/dozzle/internal/support/cli.Version=local"
 
 .PHONY: docker
-docker: shared_key.pem shared_cert.pem
+docker: generate
 	@docker build --build-arg TAG=local -t amir20/dozzle:local .
 
 .PHONY: generate
@@ -51,12 +51,14 @@ shared_cert.pem: shared_key.pem
 
 .PHONY: push
 push: docker
-	@docker tag amir20/dozzle:latest amir20/dozzle:local-test
+	@docker tag amir20/dozzle:local amir20/dozzle:local-test
 	@docker push amir20/dozzle:local-test
 
+.PHONY: run
 run: docker
 	docker run -it --rm -p 8080:8080 -v /var/run/docker.sock:/var/run/docker.sock amir20/dozzle:local
 
+.PHONY: preview
 preview: build
 	pnpm preview
 


### PR DESCRIPTION
## Summary
- Fix `docker` target to depend on `generate` instead of just certs, so `make run` works from a clean state (protobuf files are generated before `docker build`)
- Fix `push` target tagging non-existent `:latest` instead of `:local`
- Add missing `.PHONY` for `run` and `preview` targets

## Test plan
- [ ] `make run` from a clean state (after `make clean`)
- [ ] `make push` tags the correct image

🤖 Generated with [Claude Code](https://claude.com/claude-code)