### PR TITLE
chore: remove redundant GOEXPERIMENT=jsonv2

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
 args_bin = []
 bin = "./tmp/dozzle"
-cmd = "GOEXPERIMENT=jsonv2 go build -race -o ./tmp/dozzle ."
+cmd = "go build -race -o ./tmp/dozzle ."
 delay = 1000
 exclude_dir = [
   "assets",

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ ARG TARGETOS TARGETARCH
 
 # Build binary
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
-  GOEXPERIMENT=jsonv2 GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/amir20/dozzle/internal/support/cli.Version=$TAG" -o dozzle
+  GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/amir20/dozzle/internal/support/cli.Version=$TAG" -o dozzle
 
 RUN mkdir /data
 


### PR DESCRIPTION
## Summary
- Remove `GOEXPERIMENT=jsonv2` from `Dockerfile` and `.air.toml`
- Go 1.25+ uses the v2 JSON implementation by default, making this flag redundant

## Test plan
- [ ] Verify Docker build completes successfully
- [ ] Verify `make dev` works with updated `.air.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)