### PR TITLE
Bundle docker-compose binary in scratch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY public ./public
 RUN pnpm build
 
 # Grab docker-compose binary
-FROM docker/compose-bin:v2.36.0 AS compose
+FROM --platform=$TARGETPLATFORM docker/compose-bin:v2.36.0 AS compose
 
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,33 @@
-# Build assets
 FROM --platform=$BUILDPLATFORM node:25.9.0-alpine AS node
 
 RUN npm install -g --force corepack && corepack enable
 
 WORKDIR /build
 
-# Install dependencies from lock file
 COPY pnpm-*.yaml ./
 RUN pnpm fetch --ignore-scripts --no-optional
 
-# Copy package.json and install dependencies
 COPY package.json ./
 RUN pnpm install --offline --ignore-scripts --no-optional
 
-# Copy assets and translations to build
 COPY vite.config.ts tsconfig.json .prettierrc.cjs .npmrc ./
 COPY assets ./assets
 COPY locales ./locales
 COPY public ./public
 
-# Build assets
 RUN pnpm build
+
+FROM docker/compose-bin:v2.36.0 AS compose
 
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
-RUN apk add --no-cache ca-certificates && mkdir /dozzle
+RUN apk add --no-cache ca-certificates upx && mkdir /dozzle
 
 WORKDIR /dozzle
 
-# Copy go mod files
 COPY go.* ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
-# Copy all other files
 COPY internal ./internal
 COPY proto ./proto
 COPY types ./types
@@ -40,16 +35,17 @@ COPY main.go ./
 COPY protos ./protos
 COPY shared_key.pem shared_cert.pem ./
 
-# Copy assets built with node
 COPY --from=node /build/dist ./dist
 
-# Args
 ARG TAG=dev
 ARG TARGETOS TARGETARCH
 
-# Build binary
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/amir20/dozzle/internal/support/cli.Version=$TAG" -o dozzle
+
+# Compress both binaries
+COPY --from=compose /docker-compose ./docker-compose
+RUN upx --best dozzle docker-compose
 
 RUN mkdir /data
 
@@ -59,6 +55,7 @@ COPY --from=builder /data /data
 COPY --from=builder /tmp /tmp
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /dozzle/dozzle /dozzle
+COPY --from=builder /dozzle/docker-compose /usr/local/bin/docker-compose
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,41 @@
+# Build assets
 FROM --platform=$BUILDPLATFORM node:25.9.0-alpine AS node
 
 RUN npm install -g --force corepack && corepack enable
 
 WORKDIR /build
 
+# Install dependencies from lock file
 COPY pnpm-*.yaml ./
 RUN pnpm fetch --ignore-scripts --no-optional
 
+# Copy package.json and install dependencies
 COPY package.json ./
 RUN pnpm install --offline --ignore-scripts --no-optional
 
+# Copy assets and translations to build
 COPY vite.config.ts tsconfig.json .prettierrc.cjs .npmrc ./
 COPY assets ./assets
 COPY locales ./locales
 COPY public ./public
 
+# Build assets
 RUN pnpm build
 
+# Grab docker-compose binary
 FROM docker/compose-bin:v2.36.0 AS compose
 
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
-RUN apk add --no-cache ca-certificates upx && mkdir /dozzle
+RUN apk add --no-cache ca-certificates && mkdir /dozzle
 
 WORKDIR /dozzle
 
+# Copy go mod files
 COPY go.* ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
+# Copy all other files
 COPY internal ./internal
 COPY proto ./proto
 COPY types ./types
@@ -35,17 +43,16 @@ COPY main.go ./
 COPY protos ./protos
 COPY shared_key.pem shared_cert.pem ./
 
+# Copy assets built with node
 COPY --from=node /build/dist ./dist
 
+# Args
 ARG TAG=dev
 ARG TARGETOS TARGETARCH
 
+# Build binary
 RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build \
   GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/amir20/dozzle/internal/support/cli.Version=$TAG" -o dozzle
-
-# Compress both binaries
-COPY --from=compose /docker-compose ./docker-compose
-RUN upx --best dozzle docker-compose
 
 RUN mkdir /data
 
@@ -55,7 +62,7 @@ COPY --from=builder /data /data
 COPY --from=builder /tmp /tmp
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /dozzle/dozzle /dozzle
-COPY --from=builder /dozzle/docker-compose /usr/local/bin/docker-compose
+COPY --from=compose /docker-compose /usr/local/bin/docker-compose
 
 EXPOSE 8080
 


### PR DESCRIPTION
Bundle `docker/compose-bin` v2.36.0 into the final scratch image so that `docker-compose` is available alongside the `dozzle` binary.

- Uses `--platform=$TARGETPLATFORM` on the compose stage to ensure the correct architecture is pulled during multi-arch builds.
- Copies `docker-compose` directly from the compose stage into `/usr/local/bin/docker-compose` in the final scratch image.