### PR TITLE
fix: Fix memory stats not showing on cgroup v2

### DIFF
--- a/internal/docker/calculation.go
+++ b/internal/docker/calculation.go
@@ -15,6 +15,12 @@ func calculateMemUsageUnixNoCache(mem container.MemoryStats) float64 {
 	if v := mem.Stats["inactive_file"]; v < mem.Usage {
 		return float64(mem.Usage - v)
 	}
+	// cgroup v2 fallback: Usage may be 0 on some kernels; use anon memory
+	if mem.Usage == 0 {
+		if anon, ok := mem.Stats["anon"]; ok {
+			return float64(anon)
+		}
+	}
 	return float64(mem.Usage)
 }
 

--- a/internal/docker/calculation_test.go
+++ b/internal/docker/calculation_test.go
@@ -49,6 +49,31 @@ func Test_calculateMemUsageUnixNoCache(t *testing.T) {
 			},
 			want: 100,
 		},
+		{
+			name: "cgroup v2 with zero Usage falls back to anon",
+			args: args{
+				mem: container.MemoryStats{
+					Usage: 0,
+					Stats: map[string]uint64{
+						"inactive_file": 0,
+						"anon":          50,
+					},
+				},
+			},
+			want: 50,
+		},
+		{
+			name: "cgroup v2 with zero Usage and no anon returns 0",
+			args: args{
+				mem: container.MemoryStats{
+					Usage: 0,
+					Stats: map[string]uint64{
+						"inactive_file": 0,
+					},
+				},
+			},
+			want: 0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -290,19 +290,17 @@ func (d *DockerClient) ContainerStats(ctx context.Context, id string, stats chan
 			networkTx += netStats.TxBytes
 		}
 
-		if cpuPercent > 0 || mem > 0 {
-			select {
-			case <-ctx.Done():
-				return nil
-			case stats <- container.ContainerStat{
-				ID:             id,
-				CPUPercent:     cpuPercent,
-				MemoryPercent:  memPercent,
-				MemoryUsage:    mem,
-				NetworkRxTotal: networkRx,
-				NetworkTxTotal: networkTx,
-			}:
-			}
+		select {
+		case <-ctx.Done():
+			return nil
+		case stats <- container.ContainerStat{
+			ID:             id,
+			CPUPercent:     cpuPercent,
+			MemoryPercent:  memPercent,
+			MemoryUsage:    mem,
+			NetworkRxTotal: networkRx,
+			NetworkTxTotal: networkTx,
+		}:
 		}
 	}
 }


### PR DESCRIPTION
Memory stats weren't showing on cgroup v2 because the Usage field could be 0. Added a fallback to use the anon stat when that happens, and removed the guard that was preventing stats from being sent.