### PR TITLE
fix: grouped log alerts failing with type mismatch

### DIFF
--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -58,11 +58,14 @@ func extractMessage(l container.LogEvent) any {
 	case string:
 		return container.StripANSI(v)
 	case []container.LogFragment:
-		cleaned := make([]container.LogFragment, len(v))
+		var sb strings.Builder
 		for i, fragment := range v {
-			cleaned[i] = container.LogFragment{Message: container.StripANSI(fragment.Message)}
+			if i > 0 {
+				sb.WriteString("\n")
+			}
+			sb.WriteString(container.StripANSI(fragment.Message))
 		}
-		return cleaned
+		return sb.String()
 	case *orderedmap.OrderedMap[string, any]:
 		// Convert OrderedMap to regular map for expr compatibility
 		result := make(map[string]any)

--- a/internal/notification/types_test.go
+++ b/internal/notification/types_test.go
@@ -285,6 +285,71 @@ func TestSubscription_EventCooldown(t *testing.T) {
 	})
 }
 
+func TestFromLogEvent_GroupedLogFragments(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		logEvent   container.LogEvent
+		want       bool
+	}{
+		{
+			name:       "grouped log fragments - matches contains",
+			expression: `message contains "error"`,
+			logEvent: container.LogEvent{
+				Type: container.LogTypeGroup,
+				Message: []container.LogFragment{
+					{Message: "first line"},
+					{Message: "error occurred here"},
+					{Message: "third line"},
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "grouped log fragments - does not match",
+			expression: `message contains "fatal"`,
+			logEvent: container.LogEvent{
+				Type: container.LogTypeGroup,
+				Message: []container.LogFragment{
+					{Message: "first line"},
+					{Message: "second line"},
+				},
+			},
+			want: false,
+		},
+		{
+			name:       "grouped log fragments - single fragment matches",
+			expression: `message contains "info"`,
+			logEvent: container.LogEvent{
+				Type: container.LogTypeGroup,
+				Message: []container.LogFragment{
+					{Message: "info: something happened"},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notificationLog := FromLogEvent(tt.logEvent)
+
+			_, isString := notificationLog.Message.(string)
+			assert.True(t, isString, "grouped log message should be converted to string")
+
+			program, err := expr.Compile(tt.expression, expr.Env(types.NotificationLog{}), expr.AsBool())
+			require.NoError(t, err, "failed to compile expression")
+
+			sub := &Subscription{
+				LogProgram: program,
+			}
+
+			got := sub.MatchesLog(notificationLog)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestFromLogEvent_OrderedMapConversion(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary
- Grouped log entries (multiple lines within the same second) were passed as `[]LogFragment` to the expr evaluator, causing `interface conversion: interface {} is []container.LogFragment, not string` errors for expressions like `message contains "info"`
- Now joins fragments into a newline-separated string so alert expressions work consistently across all log types

## Test plan
- [x] Added tests for grouped log fragment expression evaluation
- [x] All existing notification tests pass

Fixes #4611

🤖 Generated with [Claude Code](https://claude.com/claude-code)