### PR TITLE
fix: use fixed path for agent healthcheck address file

### DIFF
--- a/internal/support/cli/agent_command.go
+++ b/internal/support/cli/agent_command.go
@@ -114,14 +114,9 @@ func (a *AgentCmd) Run(args Args, embeddedCerts embed.FS) error {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 	const agentAddrFile = "/tmp/dozzle-agent.addr"
-	agentAddr := listener.Addr().String()
-	if host, port, err := net.SplitHostPort(agentAddr); err == nil && (host == "" || host == "::" || host == "0.0.0.0") {
-		agentAddr = "localhost:" + port
-	}
-	if err := os.WriteFile(agentAddrFile, []byte(agentAddr), 0644); err != nil {
+	if err := os.WriteFile(agentAddrFile, []byte(args.Agent.Addr), 0644); err != nil {
 		return fmt.Errorf("failed to write agent address file: %w", err)
 	}
-	log.Debug().Str("file", agentAddrFile).Msg("Created agent address file")
 	go StartEvent(args, "", client, "agent")
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/internal/support/cli/agent_command.go
+++ b/internal/support/cli/agent_command.go
@@ -114,7 +114,11 @@ func (a *AgentCmd) Run(args Args, embeddedCerts embed.FS) error {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 	const agentAddrFile = "/tmp/dozzle-agent.addr"
-	if err := os.WriteFile(agentAddrFile, []byte(listener.Addr().String()), 0644); err != nil {
+	agentAddr := listener.Addr().String()
+	if host, port, err := net.SplitHostPort(agentAddr); err == nil && (host == "" || host == "::" || host == "0.0.0.0") {
+		agentAddr = "localhost:" + port
+	}
+	if err := os.WriteFile(agentAddrFile, []byte(agentAddr), 0644); err != nil {
 		return fmt.Errorf("failed to write agent address file: %w", err)
 	}
 	log.Debug().Str("file", agentAddrFile).Msg("Created agent address file")

--- a/internal/support/cli/agent_command.go
+++ b/internal/support/cli/agent_command.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"os/signal"
@@ -114,12 +113,11 @@ func (a *AgentCmd) Run(args Args, embeddedCerts embed.FS) error {
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
-	tempFile, err := os.CreateTemp("", "agent-*.addr")
-	if err != nil {
-		return fmt.Errorf("failed to create temp file: %w", err)
+	const agentAddrFile = "/tmp/dozzle-agent.addr"
+	if err := os.WriteFile(agentAddrFile, []byte(listener.Addr().String()), 0644); err != nil {
+		return fmt.Errorf("failed to write agent address file: %w", err)
 	}
-	io.WriteString(tempFile, listener.Addr().String())
-	log.Debug().Str("file", tempFile.Name()).Msg("Created temp file")
+	log.Debug().Str("file", agentAddrFile).Msg("Created agent address file")
 	go StartEvent(args, "", client, "agent")
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -192,7 +190,7 @@ func (a *AgentCmd) Run(args Args, embeddedCerts embed.FS) error {
 	stop()
 	log.Info().Msg("Shutting down agent")
 	server.Stop()
-	log.Debug().Str("file", tempFile.Name()).Msg("Removing temp file")
-	os.Remove(tempFile.Name())
+	log.Debug().Str("file", agentAddrFile).Msg("Removing agent address file")
+	os.Remove(agentAddrFile)
 	return nil
 }

--- a/internal/support/cli/health_command.go
+++ b/internal/support/cli/health_command.go
@@ -5,7 +5,6 @@ import (
 	"embed"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/amir20/dozzle/internal/healthcheck"
 	"github.com/rs/zerolog/log"
@@ -14,11 +13,8 @@ import (
 type HealthcheckCmd struct{}
 
 func (h *HealthcheckCmd) Run(args Args, embeddedCerts embed.FS) error {
-	if matches, err := filepath.Glob("/tmp/agent-*.addr"); err == nil && len(matches) == 1 {
-		data, err := os.ReadFile(matches[0])
-		if err != nil {
-			return fmt.Errorf("failed to read file: %w", err)
-		}
+	const agentAddrFile = "/tmp/dozzle-agent.addr"
+	if data, err := os.ReadFile(agentAddrFile); err == nil {
 		agentAddress := string(data)
 		certs, err := ReadCertificates(embeddedCerts, args.CertPath, args.KeyPath)
 		if err != nil {

--- a/internal/support/cli/health_command.go
+++ b/internal/support/cli/health_command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"net"
 	"os"
 
 	"github.com/amir20/dozzle/internal/healthcheck"
@@ -16,6 +17,9 @@ func (h *HealthcheckCmd) Run(args Args, embeddedCerts embed.FS) error {
 	const agentAddrFile = "/tmp/dozzle-agent.addr"
 	if data, err := os.ReadFile(agentAddrFile); err == nil {
 		agentAddress := string(data)
+		if host, port, err := net.SplitHostPort(agentAddress); err == nil && (host == "" || host == "::" || host == "0.0.0.0") {
+			agentAddress = "localhost:" + port
+		}
 		certs, err := ReadCertificates(embeddedCerts, args.CertPath, args.KeyPath)
 		if err != nil {
 			return fmt.Errorf("failed to read certificates: %w", err)


### PR DESCRIPTION
## Summary
- Replaced `os.CreateTemp` + glob pattern with a fixed well-known path (`/tmp/dozzle-agent.addr`) for the agent healthcheck address file
- The glob-based lookup was fragile — if the temp file was cleaned up by the OS (e.g., systemd-tmpfiles on Proxmox/Debian hosts), the healthcheck would fall back to HTTP on `:8080` instead of RPC on `:7007`

See #4614

## Test plan
- [ ] Run agent with `docker compose`, verify healthcheck passes consistently
- [ ] Verify healthcheck uses RPC path (logs show "Making RPC request to agent")
- [ ] Confirm address file is created at `/tmp/dozzle-agent.addr` and cleaned up on shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)