### PR TITLE
fix: re-establish cloud connection after pro plan upgrade

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -137,8 +137,14 @@ func (c *Client) Run(ctx context.Context) {
 
 		if err != nil {
 			if isPermissionDenied(err) {
-				log.Debug().Msg("cloud account does not have pro plan, stopping cloud client")
-				return
+				log.Debug().Msg("cloud account does not have pro plan, waiting for upgrade")
+				select {
+				case <-ctx.Done():
+					return
+				case <-c.startCh:
+				}
+				backoff = initialBackoff
+				continue
 			}
 			if isUnauthenticated(err) {
 				log.Warn().Err(err).Dur("pause", unauthenticatedPause).Msg("invalid API key, pausing before retry")

--- a/internal/web/cloud.go
+++ b/internal/web/cloud.go
@@ -150,13 +150,27 @@ func (h *handler) cloudStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.config.OnCloudSetup != nil {
-		h.config.OnCloudSetup()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to read cloud status response")
+		writeError(w, http.StatusBadGateway, "failed to read cloud status")
+		return
+	}
+
+	var statusResp struct {
+		Plan struct {
+			Name string `json:"name"`
+		} `json:"plan"`
+	}
+	if json.Unmarshal(body, &statusResp) == nil && statusResp.Plan.Name == "pro" {
+		if h.config.OnCloudSetup != nil {
+			h.config.OnCloudSetup()
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	io.Copy(w, resp.Body)
+	w.Write(body)
 }
 
 type cloudConfigResponse struct {


### PR DESCRIPTION
When a non-pro user gets PermissionDenied from cloud, the client now
waits for a Notify signal instead of stopping permanently. The status
endpoint only triggers reconnection when the plan is actually "pro".

https://claude.ai/code/session_018UccGgYo7v6CSsUB16GkWa