### PR TITLE
fix: healthcheck should not fail when a remote host is unavailable

### DIFF
--- a/internal/web/healthcheck.go
+++ b/internal/web/healthcheck.go
@@ -16,25 +16,25 @@ func (h *handler) healthcheck(w http.ResponseWriter, r *http.Request) {
 	clients := h.hostService.LocalClients()
 
 	var (
-		healthy atomic.Bool
-		wg      sync.WaitGroup
+		anyHealthy atomic.Bool
+		wg         sync.WaitGroup
 	)
-	healthy.Store(true)
 
 	for _, client := range clients {
 		wg.Go(func() {
 			ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
 			defer cancel()
 			if err := client.Ping(ctx); err != nil {
-				log.Error().Err(err).Str("host", client.Host().Name).Msg("error pinging host")
-				healthy.Store(false)
+				log.Warn().Err(err).Str("host", client.Host().Name).Msg("error pinging host")
+			} else {
+				anyHealthy.Store(true)
 			}
 		})
 	}
 
 	wg.Wait()
 
-	if !healthy.Load() {
+	if !anyHealthy.Load() {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/internal/web/healthcheck.go
+++ b/internal/web/healthcheck.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -15,10 +16,10 @@ func (h *handler) healthcheck(w http.ResponseWriter, r *http.Request) {
 	clients := h.hostService.LocalClients()
 
 	var (
-		mu      sync.Mutex
-		healthy = true
+		healthy atomic.Bool
 		wg      sync.WaitGroup
 	)
+	healthy.Store(true)
 
 	for _, client := range clients {
 		wg.Go(func() {
@@ -26,16 +27,14 @@ func (h *handler) healthcheck(w http.ResponseWriter, r *http.Request) {
 			defer cancel()
 			if err := client.Ping(ctx); err != nil {
 				log.Error().Err(err).Str("host", client.Host().Name).Msg("error pinging host")
-				mu.Lock()
-				healthy = false
-				mu.Unlock()
+				healthy.Store(false)
 			}
 		})
 	}
 
 	wg.Wait()
 
-	if !healthy {
+	if !healthy.Load() {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/internal/web/healthcheck.go
+++ b/internal/web/healthcheck.go
@@ -1,7 +1,10 @@
 package web
 
 import (
+	"context"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -10,11 +13,31 @@ func (h *handler) healthcheck(w http.ResponseWriter, r *http.Request) {
 	log.Debug().Msg("Executing healthcheck")
 
 	clients := h.hostService.LocalClients()
+
+	var (
+		mu      sync.Mutex
+		healthy = true
+		wg      sync.WaitGroup
+	)
+
 	for _, client := range clients {
-		if err := client.Ping(r.Context()); err != nil {
-			log.Error().Err(err).Str("host", client.Host().Name).Msg("error pinging host")
-			w.WriteHeader(http.StatusInternalServerError)
-		}
+		wg.Go(func() {
+			ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+			defer cancel()
+			if err := client.Ping(ctx); err != nil {
+				log.Error().Err(err).Str("host", client.Host().Name).Msg("error pinging host")
+				mu.Lock()
+				healthy = false
+				mu.Unlock()
+			}
+		})
+	}
+
+	wg.Wait()
+
+	if !healthy {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
 	}
 
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary
- Healthcheck now pings all hosts concurrently with a 3-second per-host timeout instead of sequentially with a shared context
- Passes if at least one Docker connection is healthy, so one unavailable remote host doesn't mark Dozzle as unhealthy
- Fixed missing `return` after error status that caused `superfluous response.WriteHeader` warnings
- Downgraded per-host ping failures to warn level

Fixes #4622

## Test plan
- [ ] Deploy with a remote host that is down, verify healthcheck still passes
- [ ] Verify healthcheck fails when all connections (including local socket) are down
- [ ] Verify no more `superfluous response.WriteHeader` warnings in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)