### PR TITLE
fix: distinguish cloud unavailable from auth errors

### DIFF
--- a/assets/components/CloudPopover.vue
+++ b/assets/components/CloudPopover.vue
@@ -5,13 +5,27 @@
         <mdi:cloud
           class="size-6"
           :class="
-            !cloudConfig ? 'text-base-content/40' : cloudConfig.linked && !cloudStatusError ? 'text-info' : 'text-error'
+            !cloudConfig
+              ? 'text-base-content/40'
+              : cloudConfig.linked && !cloudStatusError
+                ? 'text-info'
+                : cloudStatusError === 'unavailable'
+                  ? 'text-warning'
+                  : 'text-error'
           "
         />
         <span
           v-if="cloudConfig?.linked"
           class="absolute -top-0.5 -right-0.5 size-2 rounded-full"
-          :class="cloudStatusError ? 'bg-error' : 'bg-success'"
+          :class="
+            cloudStatusError === 'auth'
+              ? 'bg-error'
+              : cloudStatusError === 'unavailable'
+                ? 'bg-warning'
+                : cloudStatusError
+                  ? 'bg-error'
+                  : 'bg-success'
+          "
         ></span>
       </div>
     </template>
@@ -39,14 +53,21 @@
         <template v-else-if="cloudConfig.linked">
           <!-- Error state -->
           <div v-if="cloudStatusError" class="space-y-3">
-            <div class="alert alert-error">
-              <mdi:alert-circle class="text-lg" />
-              <span class="text-sm">{{ $t("cloud.error") }}</span>
+            <div class="alert" :class="cloudStatusError === 'auth' ? 'alert-error' : 'alert-warning'">
+              <mdi:alert-circle v-if="cloudStatusError === 'auth'" class="text-lg" />
+              <mdi:cloud-off-outline v-else class="text-lg" />
+              <span class="text-sm">{{
+                cloudStatusError === "auth" ? $t("cloud.error") : $t("cloud.error-unavailable")
+              }}</span>
             </div>
-            <a :href="cloudLinkUrl" class="btn btn-primary btn-sm w-full">
+            <a v-if="cloudStatusError === 'auth'" :href="cloudLinkUrl" class="btn btn-primary btn-sm w-full">
               <mdi:link-variant class="text-base" />
               {{ $t("cloud.relink-instance") }}
             </a>
+            <button v-else class="btn btn-sm w-full" @click="fetchCloudStatus">
+              <mdi:refresh class="text-base" />
+              {{ $t("button.retry") }}
+            </button>
           </div>
 
           <!-- Loading -->

--- a/assets/components/CloudSettingsCard.vue
+++ b/assets/components/CloudSettingsCard.vue
@@ -23,15 +23,22 @@
     <template v-else-if="cloudConfig.linked">
       <!-- Error state -->
       <div v-if="cloudStatusError" class="space-y-3">
-        <div class="alert alert-error">
-          <mdi:alert-circle class="text-lg" />
-          <span class="text-sm">{{ $t("cloud.error") }}</span>
+        <div class="alert" :class="cloudStatusError === 'auth' ? 'alert-error' : 'alert-warning'">
+          <mdi:alert-circle v-if="cloudStatusError === 'auth'" class="text-lg" />
+          <mdi:cloud-off-outline v-else class="text-lg" />
+          <span class="text-sm">{{
+            cloudStatusError === "auth" ? $t("cloud.error") : $t("cloud.error-unavailable")
+          }}</span>
         </div>
         <div class="flex gap-2">
-          <a :href="cloudLinkUrl" class="btn btn-primary btn-sm">
+          <a v-if="cloudStatusError === 'auth'" :href="cloudLinkUrl" class="btn btn-primary btn-sm">
             <mdi:link-variant class="text-base" />
             {{ $t("cloud.relink-instance") }}
           </a>
+          <button v-else class="btn btn-sm" @click="fetchCloudStatus">
+            <mdi:refresh class="text-base" />
+            {{ $t("button.retry") }}
+          </button>
           <button class="btn btn-outline btn-sm btn-error" @click="confirmUnlink">
             <mdi:link-variant-off class="text-base" />
             {{ $t("cloud.unlink") }}
@@ -132,7 +139,7 @@ async function doUnlink() {
   try {
     const res = await fetch(withBase("/api/cloud/config"), { method: "DELETE" });
     if (!res.ok) {
-      cloudStatusError.value = true;
+      cloudStatusError.value = "unavailable";
       return;
     }
     clearCloudState();

--- a/assets/components/Notification/CloudDestinationForm.vue
+++ b/assets/components/Notification/CloudDestinationForm.vue
@@ -10,10 +10,26 @@
           readonly
           disabled
           class="input join-item w-full font-mono"
-          :class="cloudStatusError ? 'input-error' : 'input-success'"
+          :class="
+            cloudStatusError === 'auth'
+              ? 'input-error'
+              : cloudStatusError === 'unavailable'
+                ? 'input-warning'
+                : 'input-success'
+          "
         />
-        <span class="join-item btn pointer-events-none" :class="cloudStatusError ? 'btn-error' : 'btn-success'">
-          <mdi:alert-circle v-if="cloudStatusError" class="text-lg" />
+        <span
+          class="join-item btn pointer-events-none"
+          :class="
+            cloudStatusError === 'auth'
+              ? 'btn-error'
+              : cloudStatusError === 'unavailable'
+                ? 'btn-warning'
+                : 'btn-success'
+          "
+        >
+          <mdi:alert-circle v-if="cloudStatusError === 'auth'" class="text-lg" />
+          <mdi:cloud-off-outline v-else-if="cloudStatusError === 'unavailable'" class="text-lg" />
           <mdi:check v-else class="text-lg" />
         </span>
       </div>
@@ -24,9 +40,14 @@
         <span class="text-base-content/60 text-sm">{{ $t("notifications.destination-form.cloud-checking") }}</span>
       </div>
       <div v-else-if="cloudStatusError" class="mt-3">
-        <div class="alert alert-error">
-          <mdi:alert-circle class="text-lg" />
-          <span>{{ $t("notifications.destination-form.cloud-relink") }}</span>
+        <div class="alert" :class="cloudStatusError === 'auth' ? 'alert-error' : 'alert-warning'">
+          <mdi:alert-circle v-if="cloudStatusError === 'auth'" class="text-lg" />
+          <mdi:cloud-off-outline v-else class="text-lg" />
+          <span>{{
+            cloudStatusError === "auth"
+              ? $t("notifications.destination-form.cloud-relink")
+              : $t("notifications.destination-form.cloud-unavailable")
+          }}</span>
         </div>
       </div>
       <div v-else-if="cloudStatus" class="mt-3 space-y-3">

--- a/assets/composable/cloudConfig.ts
+++ b/assets/composable/cloudConfig.ts
@@ -3,7 +3,7 @@ import type { CloudConfig, CloudStatus } from "@/types/notifications";
 // Shared state across all component instances
 const cloudConfig = ref<CloudConfig | null>(null);
 const cloudStatus = ref<CloudStatus | null>(null);
-const cloudStatusError = ref(false);
+const cloudStatusError = ref<"auth" | "unavailable" | false>(false);
 const isLoadingCloudStatus = ref(false);
 
 async function fetchCloudConfig() {
@@ -26,12 +26,12 @@ async function fetchCloudStatus() {
   try {
     const res = await fetch(withBase("/api/cloud/status"));
     if (!res.ok) {
-      cloudStatusError.value = true;
+      cloudStatusError.value = res.status === 401 || res.status === 403 ? "auth" : "unavailable";
       return;
     }
     cloudStatus.value = await res.json();
   } catch {
-    cloudStatusError.value = true;
+    cloudStatusError.value = "unavailable";
   } finally {
     isLoadingCloudStatus.value = false;
   }

--- a/internal/web/cloud.go
+++ b/internal/web/cloud.go
@@ -146,7 +146,11 @@ func (h *handler) cloudStatus(w http.ResponseWriter, r *http.Request) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
 		log.Warn().Int("status", resp.StatusCode).Str("body", string(body)).Msg("Cloud status check failed")
-		writeError(w, resp.StatusCode, "cloud API key is invalid or expired")
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			writeError(w, resp.StatusCode, "cloud API key is invalid or expired")
+		} else {
+			writeError(w, http.StatusBadGateway, "cloud service is temporarily unavailable")
+		}
 		return
 	}
 

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -99,6 +99,7 @@ button:
   settings: Indstillinger
   cancel: Annuller
   redirect: Omdiriger
+  retry: Retry
 placeholder:
   search-containers: Søg containere (⌘ + k, ⌃k)
   search: Søg
@@ -277,6 +278,7 @@ notifications:
     cloud-settings-link: Dozzle Cloud Indstillinger
     cloud-checking: Kontrollerer cloud-status...
     cloud-relink: Din API-nøgle er ugyldig eller udløbet. Slet venligst og link din konto igen.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plan
     cloud-usage: Begivenheder i denne periode
   empty-state:
@@ -297,5 +299,6 @@ cloud:
   dashboard: Dashboard
   settings: Indstillinger
   error: Forbindelsesfejl. Gentilknyt venligst din instans.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Fjern tilknytning
   unlink-confirm: Er du sikker på, at du vil fjerne tilknytningen til Dozzle Cloud? Dette fjerner alle cloud-notifikationsdestinationer.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -99,6 +99,7 @@ button:
   settings: Einstellungen
   cancel: Abbruch
   redirect: Umleiten
+  retry: Retry
 placeholder:
   search-containers: Suche Container (⌘ + k, ⌃k)
   search: Suche
@@ -277,6 +278,7 @@ notifications:
     cloud-settings-link: Dozzle Cloud Einstellungen
     cloud-checking: Cloud-Status wird überprüft...
     cloud-relink: Ihr API-Schlüssel ist ungültig oder abgelaufen. Bitte löschen und verknüpfen Sie Ihr Konto erneut.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plan
     cloud-usage: Ereignisse in diesem Zeitraum
   empty-state:
@@ -297,5 +299,6 @@ cloud:
   dashboard: Dashboard
   settings: Einstellungen
   error: Verbindungsfehler. Bitte verknüpfen Sie Ihre Instanz erneut.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Verknüpfung aufheben
   unlink-confirm: Sind Sie sicher, dass Sie die Verknüpfung mit Dozzle Cloud aufheben möchten? Dies entfernt alle Cloud-Benachrichtigungsziele.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -106,6 +106,7 @@ button:
   settings: Settings
   cancel: Cancel
   redirect: Redirect
+  retry: Retry
 placeholder:
   search-containers: Search containers (⌘ + k, ⌃k)
   search: Search
@@ -286,6 +287,7 @@ notifications:
     cloud-settings-link: Dozzle Cloud Settings
     cloud-checking: Checking cloud status...
     cloud-relink: Your API key is invalid or expired. Please delete and link your account again.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plan
     cloud-usage: Events this period
   empty-state:
@@ -308,5 +310,6 @@ cloud:
   dashboard: Dashboard
   settings: Settings
   error: Connection error. Please re-link your instance.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Unlink
   unlink-confirm: Are you sure you want to unlink from Dozzle Cloud? This will remove all cloud notification destinations.

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -99,6 +99,7 @@ button:
   settings: Configuración
   cancel: Cancelar
   redirect: Redirigir
+  retry: Retry
 placeholder:
   search-containers: Buscar contenedores (⌘ + K, CTRL + K)
   search: Buscar
@@ -277,6 +278,7 @@ notifications:
     cloud-settings-link: Configuración de Dozzle Cloud
     cloud-checking: Verificando estado de la nube...
     cloud-relink: Su clave API es inválida o ha expirado. Por favor, elimine y vincule su cuenta de nuevo.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plan
     cloud-usage: Eventos en este período
   empty-state:
@@ -297,5 +299,6 @@ cloud:
   dashboard: Panel
   settings: Configuración
   error: Error de conexión. Por favor, revincule su instancia.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Desvincular
   unlink-confirm: ¿Está seguro de que desea desvincular de Dozzle Cloud? Esto eliminará todos los destinos de notificación en la nube.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -99,6 +99,7 @@ button:
   settings: Paramètres
   cancel: Annuler
   redirect: Rediriger
+  retry: Retry
 placeholder:
   search-containers: Recherche de conteneurs (⌘ + k, ⌃k)
   search: Recherche
@@ -277,6 +278,7 @@ notifications:
     cloud-settings-link: Paramètres Dozzle Cloud
     cloud-checking: Vérification du statut cloud...
     cloud-relink: Votre clé API est invalide ou expirée. Veuillez supprimer et relier votre compte.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plan
     cloud-usage: Événements pour cette période
   empty-state:
@@ -297,5 +299,6 @@ cloud:
   dashboard: Tableau de bord
   settings: Paramètres
   error: Erreur de connexion. Veuillez relier votre instance.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Délier
   unlink-confirm: Êtes-vous sûr de vouloir délier de Dozzle Cloud ? Cela supprimera toutes les destinations de notification cloud.

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -105,6 +105,7 @@ button:
   settings: Pengaturan
   cancel: Batal
   redirect: Alihkan
+  retry: Retry
 
 placeholder:
   search-containers: Cari kontainer (⌘ + k, ⌃k)
@@ -289,6 +290,7 @@ notifications:
     cloud-settings-link: Pengaturan Dozzle Cloud
     cloud-checking: Memeriksa status cloud...
     cloud-relink: Kunci API Anda tidak valid atau kedaluwarsa. Silakan hapus dan hubungkan akun Anda lagi.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Paket
     cloud-usage: Event periode ini
   empty-state:
@@ -309,5 +311,6 @@ cloud:
   dashboard: Dasbor
   settings: Pengaturan
   error: Kesalahan koneksi. Silakan tautkan ulang instans Anda.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Lepaskan tautan
   unlink-confirm: Apakah Anda yakin ingin melepaskan tautan dari Dozzle Cloud? Ini akan menghapus semua tujuan notifikasi cloud.

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -99,6 +99,7 @@ button:
   settings: Impostazioni
   cancel: Annulla
   redirect: Reindirizza
+  retry: Retry
 placeholder:
   search-containers: Ricerca container (⌘ + k, ⌃k)
   search: Cerca
@@ -277,6 +278,7 @@ notifications:
     cloud-settings-link: Impostazioni Dozzle Cloud
     cloud-checking: Verifica dello stato cloud...
     cloud-relink: La tua chiave API non è valida o è scaduta. Elimina e collega nuovamente il tuo account.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Piano
     cloud-usage: Eventi in questo periodo
   empty-state:
@@ -297,5 +299,6 @@ cloud:
   dashboard: Dashboard
   settings: Impostazioni
   error: Errore di connessione. Ricollega la tua istanza.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Scollega
   unlink-confirm: Sei sicuro di voler scollegare da Dozzle Cloud? Questo rimuoverà tutte le destinazioni di notifica cloud.

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -100,6 +100,7 @@ button:
   settings: 설정
   cancel: 취소
   redirect: 이동
+  retry: Retry
 placeholder:
   search-containers: 컨테이너 검색 (⌘ + k, ⌃k)
   search: 검색
@@ -280,6 +281,7 @@ notifications:
     cloud-settings-link: Dozzle Cloud 설정
     cloud-checking: 클라우드 상태 확인 중...
     cloud-relink: API 키가 유효하지 않거나 만료되었습니다. 삭제 후 계정을 다시 연결해 주세요.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: 플랜
     cloud-usage: 이번 기간 이벤트
   empty-state:
@@ -300,5 +302,6 @@ cloud:
   dashboard: 대시보드
   settings: 설정
   error: 연결 오류. 인스턴스를 다시 연결해 주세요.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: 연결 해제
   unlink-confirm: Dozzle Cloud 연결을 해제하시겠습니까? 모든 클라우드 알림 목적지가 삭제됩니다.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -100,6 +100,7 @@ button:
   settings: Instellingen
   cancel: Annuleren
   redirect: Doorsturen
+  retry: Retry
 placeholder:
   search-containers: Zoek containers (⌘ + k, ⌃k)
   search: Zoeken
@@ -278,6 +279,7 @@ notifications:
     cloud-settings-link: Dozzle Cloud-instellingen
     cloud-checking: Cloudstatus controleren...
     cloud-relink: Uw API-sleutel is ongeldig of verlopen. Verwijder en koppel uw account opnieuw.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plan
     cloud-usage: Gebeurtenissen deze periode
   empty-state:
@@ -298,5 +300,6 @@ cloud:
   dashboard: Dashboard
   settings: Instellingen
   error: Verbindingsfout. Koppel je instantie opnieuw.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Ontkoppelen
   unlink-confirm: Weet je zeker dat je de koppeling met Dozzle Cloud wilt opheffen? Dit verwijdert alle cloudmeldingsbestemmingen.

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -105,6 +105,7 @@ button:
   settings: Ustawienia
   cancel: Anuluj
   redirect: Przekieruj
+  retry: Retry
 placeholder:
   search-containers: Przeszukaj kontery (⌘ + k, ⌃k)
   search: Szukaj
@@ -284,6 +285,7 @@ notifications:
     cloud-settings-link: Ustawienia Dozzle Cloud
     cloud-checking: Sprawdzanie statusu chmury...
     cloud-relink: Twój klucz API jest nieprawidłowy lub wygasł. Usuń i połącz swoje konto ponownie.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plan
     cloud-usage: Zdarzenia w tym okresie
   empty-state:
@@ -304,5 +306,6 @@ cloud:
   dashboard: Panel
   settings: Ustawienia
   error: Błąd połączenia. Połącz ponownie swoją instancję.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Rozłącz
   unlink-confirm: Czy na pewno chcesz rozłączyć się z Dozzle Cloud? Spowoduje to usunięcie wszystkich miejsc docelowych powiadomień w chmurze.

--- a/locales/pr.yml
+++ b/locales/pr.yml
@@ -103,6 +103,7 @@ button:
   settings: Configurações
   cancel: Cancelar
   redirect: Redirecionar
+  retry: Retry
 placeholder:
   search-containers: Pesquisar contentores (⌘ + K, CTRL + K)
   search: Pesquisa
@@ -286,6 +287,7 @@ notifications:
     cloud-settings-link: Definições do Dozzle Cloud
     cloud-checking: A verificar o estado da cloud...
     cloud-relink: A sua chave API é inválida ou expirou. Por favor, elimine e ligue a sua conta novamente.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plano
     cloud-usage: Eventos neste período
   empty-state:
@@ -306,5 +308,6 @@ cloud:
   dashboard: Painel
   settings: Definições
   error: Erro de ligação. Por favor, religue a sua instância.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Desligar
   unlink-confirm: Tem a certeza de que pretende desligar do Dozzle Cloud? Isto irá remover todos os destinos de notificação na nuvem.

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -98,6 +98,7 @@ button:
   settings: Configurações
   cancel: Cancelar
   redirect: Redirecionar
+  retry: Retry
 placeholder:
   search-containers: Pesquisar containers (⌘ + k, ⌃k)
   search: Pesquisar
@@ -276,6 +277,7 @@ notifications:
     cloud-settings-link: Configurações do Dozzle Cloud
     cloud-checking: Verificando status da nuvem...
     cloud-relink: Sua chave API é inválida ou expirou. Por favor, exclua e vincule sua conta novamente.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plano
     cloud-usage: Eventos neste período
   empty-state:
@@ -296,5 +298,6 @@ cloud:
   dashboard: Painel
   settings: Configurações
   error: Erro de conexão. Por favor, revincule sua instância.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Desvincular
   unlink-confirm: Tem certeza de que deseja desvincular do Dozzle Cloud? Isso removerá todos os destinos de notificação na nuvem.

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -99,6 +99,7 @@ button:
   settings: Настройки
   cancel: Отмена
   redirect: Перенаправить
+  retry: Retry
 placeholder:
   search-containers: Поиск контейнеров (⌘ + k, ⌃k)
   search: Поиск
@@ -277,6 +278,7 @@ notifications:
     cloud-settings-link: Настройки Dozzle Cloud
     cloud-checking: Проверка статуса облака...
     cloud-relink: Ваш API-ключ недействителен или истёк. Пожалуйста, удалите и привяжите аккаунт заново.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: План
     cloud-usage: События за этот период
   empty-state:
@@ -297,5 +299,6 @@ cloud:
   dashboard: Панель управления
   settings: Настройки
   error: Ошибка подключения. Пожалуйста, привяжите экземпляр повторно.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Отвязать
   unlink-confirm: Вы уверены, что хотите отвязать от Dozzle Cloud? Это удалит все облачные назначения уведомлений.

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -98,6 +98,7 @@ button:
   logout: Odjava
   cancel: Prekliči
   redirect: Preusmeritev
+  retry: Retry
   login: Prijava
   settings: Nastavitve
 placeholder:
@@ -282,6 +283,7 @@ notifications:
     cloud-settings-link: Nastavitve Dozzle Cloud
     cloud-checking: Preverjanje stanja oblaka...
     cloud-relink: Vaš API ključ je neveljaven ali potekel. Prosimo, izbrišite in ponovno povežite svoj račun.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Načrt
     cloud-usage: Dogodki v tem obdobju
   empty-state:
@@ -302,5 +304,6 @@ cloud:
   dashboard: Nadzorna plošča
   settings: Nastavitve
   error: Napaka povezave. Prosimo, ponovno povežite svojo instanco.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Prekini povezavo
   unlink-confirm: Ali ste prepričani, da želite prekiniti povezavo z Dozzle Cloud? To bo odstranilo vse cilje obvestil v oblaku.

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -107,6 +107,7 @@ button:
   settings: Ayarlar
   cancel: İptal
   redirect: Yönlendir
+  retry: Retry
 placeholder:
   search-containers: Konteynerlerde ara (⌘ + k, ⌃k)
   search: Ara
@@ -277,6 +278,7 @@ notifications:
     cloud-settings-link: Dozzle Cloud Ayarları
     cloud-checking: Bulut durumu kontrol ediliyor...
     cloud-relink: API anahtarınız geçersiz veya süresi dolmuş. Lütfen silin ve hesabınızı tekrar bağlayın.
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: Plan
     cloud-usage: Bu dönemdeki olaylar
   empty-state:
@@ -297,5 +299,6 @@ cloud:
   dashboard: Pano
   settings: Ayarlar
   error: Bağlantı hatası. Lütfen örneğinizi yeniden bağlayın.
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: Bağlantıyı kaldır
   unlink-confirm: Dozzle Cloud bağlantısını kaldırmak istediğinizden emin misiniz? Bu, tüm bulut bildirim hedeflerini kaldıracaktır.

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -101,6 +101,7 @@ button:
   settings: 設定
   cancel: 取消
   redirect: 重新導向
+  retry: Retry
 placeholder:
   search-containers: 搜尋容器 (⌘ + k, ⌃k)
   search: 搜尋
@@ -280,6 +281,7 @@ notifications:
     cloud-settings-link: Dozzle Cloud 設定
     cloud-checking: 正在檢查雲端狀態...
     cloud-relink: 您的 API 金鑰無效或已過期。請刪除並重新關聯您的帳戶。
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: 方案
     cloud-usage: 本期事件數
   empty-state:
@@ -300,5 +302,6 @@ cloud:
   dashboard: 儀表板
   settings: 設定
   error: 連線錯誤。請重新連結您的實例。
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: 取消連結
   unlink-confirm: 確定要取消與 Dozzle Cloud 的連結嗎？這將移除所有雲端通知目標。

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -99,6 +99,7 @@ button:
   settings: 设置
   cancel: 取消
   redirect: 重定向
+  retry: Retry
 placeholder:
   search-containers: 搜索容器 (⌘ + k, ⌃k)
   search: 搜索
@@ -277,6 +278,7 @@ notifications:
     cloud-settings-link: Dozzle Cloud 设置
     cloud-checking: 正在检查云状态...
     cloud-relink: 您的 API 密钥无效或已过期。请删除并重新关联您的账户。
+    cloud-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
     cloud-plan: 计划
     cloud-usage: 本期事件数
   empty-state:
@@ -297,5 +299,6 @@ cloud:
   dashboard: 仪表盘
   settings: 设置
   error: 连接错误。请重新关联您的实例。
+  error-unavailable: Dozzle Cloud is temporarily unavailable. Please try again later.
   unlink: 取消关联
   unlink-confirm: 确定要取消与 Dozzle Cloud 的关联吗？这将移除所有云通知目标。


### PR DESCRIPTION
## Summary
- When Dozzle Cloud is down/unreachable, show "temporarily unavailable, try again later" (warning) instead of "please re-link your instance" (error)
- Auth errors (401/403) still show the re-link prompt as before
- Backend normalizes non-auth cloud errors to 502 with appropriate message
- Added retry button for transient failures in CloudPopover and CloudSettingsCard
- Updated all 17 locale files with new strings

## Test plan
- [ ] Disconnect from cloud (e.g. set `DOLIGENCE_URL` to an unreachable host) and verify warning message + retry button appears
- [ ] Use an invalid API key and verify the red error + re-link prompt still appears
- [ ] Verify retry button successfully recovers when cloud comes back

🤖 Generated with [Claude Code](https://claude.com/claude-code)