### PR TITLE
fix: healthcheck should pass when only agents are configured

### DIFF
--- a/internal/web/healthcheck.go
+++ b/internal/web/healthcheck.go
@@ -15,6 +15,16 @@ func (h *handler) healthcheck(w http.ResponseWriter, r *http.Request) {
 
 	clients := h.hostService.LocalClients()
 
+	if len(clients) == 0 {
+		// No local Docker clients, but if there are any hosts (agents), consider healthy
+		if len(h.hostService.Hosts()) > 0 {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
 	var (
 		anyHealthy atomic.Bool
 		wg         sync.WaitGroup


### PR DESCRIPTION
## Summary
- When no local Docker clients exist but agents are configured, the healthcheck was returning 500 because `LocalClients()` filters out agent clients
- Now returns healthy if any hosts (including agents) are present, since the UI is fully operational with agents
- Fixes #4622

## Test plan
- [ ] Deploy with only agents configured (no local Docker socket) and verify `/healthcheck` returns 200
- [ ] Verify existing behavior unchanged: local Docker clients still get pinged
- [ ] Verify healthcheck returns 500 when no clients at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)