### PR TITLE
chore: Update welcome modal chips to intent-driven labels

### DIFF
--- a/assets/components/WelcomeModal.vue
+++ b/assets/components/WelcomeModal.vue
@@ -99,9 +99,10 @@ const submitting = ref(false);
 let feedbackSent = false;
 
 const chipOptions = [
-  { value: "alerts", label: t("cloud.welcome.chip-alerts") },
-  { value: "daily_summary", label: t("cloud.welcome.chip-summary") },
+  { value: "error_alerts", label: t("cloud.welcome.chip-alerts") },
+  { value: "failure_analysis", label: t("cloud.welcome.chip-failure-analysis") },
   { value: "multiple_hosts", label: t("cloud.welcome.chip-hosts") },
+  { value: "remote_access", label: t("cloud.welcome.chip-remote-access") },
   { value: "something_else", label: t("cloud.welcome.chip-other") },
 ];
 

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -308,10 +308,10 @@ cloud:
     question: "Et hurtigt spørgsmål inden vi starter — hvad håber du mest, at Cloud kan hjælpe med?"
     placeholder: "f.eks. Jeg vil vide, når min Plex-container crasher om natten..."
     or-pick: "Eller vælg en:"
-    chip-alerts: Fejlalarmer
-    chip-failure-analysis: Fejlanalyse
-    chip-hosts: Flere værter
-    chip-remote-access: Fjernadgang
+    chip-alerts: Modtage fejlalarmer
+    chip-failure-analysis: Forstå fejl
+    chip-hosts: Overvåge flere værter
+    chip-remote-access: Tilgå logs eksternt
     chip-other: Noget andet
     get-started: Kom i gang
     skip: Spring over for nu

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -308,9 +308,10 @@ cloud:
     question: "Et hurtigt spørgsmål inden vi starter — hvad håber du mest, at Cloud kan hjælpe med?"
     placeholder: "f.eks. Jeg vil vide, når min Plex-container crasher om natten..."
     or-pick: "Eller vælg en:"
-    chip-alerts: Advar mig ved problemer
-    chip-summary: Dagligt resumé
-    chip-hosts: Overvåg flere værter
+    chip-alerts: Fejlalarmer
+    chip-failure-analysis: Fejlanalyse
+    chip-hosts: Flere værter
+    chip-remote-access: Fjernadgang
     chip-other: Noget andet
     get-started: Kom i gang
     skip: Spring over for nu

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -308,10 +308,10 @@ cloud:
     question: "Eine kurze Frage bevor wir loslegen — wobei soll Cloud Ihnen am meisten helfen?"
     placeholder: "z.B. Ich möchte wissen, wenn mein Plex-Container nachts abstürzt..."
     or-pick: "Oder wählen Sie:"
-    chip-alerts: Fehlerwarnungen
-    chip-failure-analysis: Fehleranalyse
-    chip-hosts: Mehrere Hosts
-    chip-remote-access: Fernzugriff
+    chip-alerts: Fehlerwarnungen erhalten
+    chip-failure-analysis: Fehler verstehen
+    chip-hosts: Mehrere Hosts überwachen
+    chip-remote-access: Logs aus der Ferne abrufen
     chip-other: Etwas anderes
     get-started: Loslegen
     skip: Jetzt überspringen

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -308,9 +308,10 @@ cloud:
     question: "Eine kurze Frage bevor wir loslegen — wobei soll Cloud Ihnen am meisten helfen?"
     placeholder: "z.B. Ich möchte wissen, wenn mein Plex-Container nachts abstürzt..."
     or-pick: "Oder wählen Sie:"
-    chip-alerts: Bei Problemen benachrichtigen
-    chip-summary: Tägliche Zusammenfassung
-    chip-hosts: Mehrere Hosts überwachen
+    chip-alerts: Fehlerwarnungen
+    chip-failure-analysis: Fehleranalyse
+    chip-hosts: Mehrere Hosts
+    chip-remote-access: Fernzugriff
     chip-other: Etwas anderes
     get-started: Loslegen
     skip: Jetzt überspringen

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -321,9 +321,10 @@ cloud:
     question: "One quick question before we get started — what's the main thing you're hoping Cloud helps with?"
     placeholder: "e.g. I want to know when my Plex container crashes overnight..."
     or-pick: "Or pick one:"
-    chip-alerts: Alert me when things break
-    chip-summary: Daily summary
-    chip-hosts: Monitor multiple hosts
+    chip-alerts: Error alerts
+    chip-failure-analysis: Failure analysis
+    chip-hosts: Multiple hosts
+    chip-remote-access: Remote access
     chip-other: Something else
     get-started: Get Started
     skip: Skip for now

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -321,10 +321,10 @@ cloud:
     question: "One quick question before we get started — what's the main thing you're hoping Cloud helps with?"
     placeholder: "e.g. I want to know when my Plex container crashes overnight..."
     or-pick: "Or pick one:"
-    chip-alerts: Error alerts
-    chip-failure-analysis: Failure analysis
-    chip-hosts: Multiple hosts
-    chip-remote-access: Remote access
+    chip-alerts: Get error alerts
+    chip-failure-analysis: Understand failures
+    chip-hosts: Monitor multiple hosts
+    chip-remote-access: Access logs remotely
     chip-other: Something else
     get-started: Get Started
     skip: Skip for now

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -308,10 +308,10 @@ cloud:
     question: "Una pregunta rápida antes de empezar — ¿para qué quieres usar Cloud principalmente?"
     placeholder: "ej. Quiero saber cuando mi contenedor Plex se cae por la noche..."
     or-pick: "O elige una opción:"
-    chip-alerts: Alertas de errores
-    chip-failure-analysis: Análisis de fallos
-    chip-hosts: Varios hosts
-    chip-remote-access: Acceso remoto
+    chip-alerts: Recibir alertas de errores
+    chip-failure-analysis: Entender fallos
+    chip-hosts: Monitorear varios hosts
+    chip-remote-access: Acceder a logs remotamente
     chip-other: Otra cosa
     get-started: Empezar
     skip: Saltar por ahora

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -308,9 +308,10 @@ cloud:
     question: "Una pregunta rápida antes de empezar — ¿para qué quieres usar Cloud principalmente?"
     placeholder: "ej. Quiero saber cuando mi contenedor Plex se cae por la noche..."
     or-pick: "O elige una opción:"
-    chip-alerts: Avisarme cuando algo falle
-    chip-summary: Resumen diario
-    chip-hosts: Monitorear varios hosts
+    chip-alerts: Alertas de errores
+    chip-failure-analysis: Análisis de fallos
+    chip-hosts: Varios hosts
+    chip-remote-access: Acceso remoto
     chip-other: Otra cosa
     get-started: Empezar
     skip: Saltar por ahora

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -308,10 +308,10 @@ cloud:
     question: "Une petite question avant de commencer — qu'attendez-vous principalement de Cloud ?"
     placeholder: "ex. Je veux savoir quand mon conteneur Plex plante pendant la nuit..."
     or-pick: "Ou choisissez :"
-    chip-alerts: Alertes d'erreurs
-    chip-failure-analysis: Analyse des pannes
-    chip-hosts: Plusieurs hôtes
-    chip-remote-access: Accès à distance
+    chip-alerts: Recevoir des alertes
+    chip-failure-analysis: Comprendre les pannes
+    chip-hosts: Surveiller plusieurs hôtes
+    chip-remote-access: Accéder aux logs à distance
     chip-other: Autre chose
     get-started: Commencer
     skip: Passer pour l'instant

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -308,9 +308,10 @@ cloud:
     question: "Une petite question avant de commencer — qu'attendez-vous principalement de Cloud ?"
     placeholder: "ex. Je veux savoir quand mon conteneur Plex plante pendant la nuit..."
     or-pick: "Ou choisissez :"
-    chip-alerts: M'alerter en cas de problème
-    chip-summary: Résumé quotidien
-    chip-hosts: Surveiller plusieurs hôtes
+    chip-alerts: Alertes d'erreurs
+    chip-failure-analysis: Analyse des pannes
+    chip-hosts: Plusieurs hôtes
+    chip-remote-access: Accès à distance
     chip-other: Autre chose
     get-started: Commencer
     skip: Passer pour l'instant

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -320,10 +320,10 @@ cloud:
     question: "Satu pertanyaan cepat sebelum mulai — apa yang paling Anda harapkan dari Cloud?"
     placeholder: "mis. Saya ingin tahu ketika kontainer Plex saya crash di malam hari..."
     or-pick: "Atau pilih satu:"
-    chip-alerts: Peringatan error
-    chip-failure-analysis: Analisis kegagalan
-    chip-hosts: Beberapa host
-    chip-remote-access: Akses jarak jauh
+    chip-alerts: Dapatkan peringatan error
+    chip-failure-analysis: Pahami kegagalan
+    chip-hosts: Pantau beberapa host
+    chip-remote-access: Akses log dari jarak jauh
     chip-other: Lainnya
     get-started: Mulai
     skip: Lewati untuk sekarang

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -320,9 +320,10 @@ cloud:
     question: "Satu pertanyaan cepat sebelum mulai — apa yang paling Anda harapkan dari Cloud?"
     placeholder: "mis. Saya ingin tahu ketika kontainer Plex saya crash di malam hari..."
     or-pick: "Atau pilih satu:"
-    chip-alerts: Beri tahu saya saat ada masalah
-    chip-summary: Ringkasan harian
-    chip-hosts: Pantau beberapa host
+    chip-alerts: Peringatan error
+    chip-failure-analysis: Analisis kegagalan
+    chip-hosts: Beberapa host
+    chip-remote-access: Akses jarak jauh
     chip-other: Lainnya
     get-started: Mulai
     skip: Lewati untuk sekarang

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -308,9 +308,10 @@ cloud:
     question: "Una domanda veloce prima di iniziare — per cosa vorresti usare Cloud principalmente?"
     placeholder: "es. Voglio sapere quando il mio container Plex si blocca di notte..."
     or-pick: "Oppure scegli:"
-    chip-alerts: Avvisami quando qualcosa si rompe
-    chip-summary: Riepilogo giornaliero
-    chip-hosts: Monitorare più host
+    chip-alerts: Avvisi di errore
+    chip-failure-analysis: Analisi dei guasti
+    chip-hosts: Host multipli
+    chip-remote-access: Accesso remoto
     chip-other: Altro
     get-started: Inizia
     skip: Salta per ora

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -308,10 +308,10 @@ cloud:
     question: "Una domanda veloce prima di iniziare — per cosa vorresti usare Cloud principalmente?"
     placeholder: "es. Voglio sapere quando il mio container Plex si blocca di notte..."
     or-pick: "Oppure scegli:"
-    chip-alerts: Avvisi di errore
-    chip-failure-analysis: Analisi dei guasti
-    chip-hosts: Host multipli
-    chip-remote-access: Accesso remoto
+    chip-alerts: Ricevere avvisi di errore
+    chip-failure-analysis: Capire i guasti
+    chip-hosts: Monitorare più host
+    chip-remote-access: Accedere ai log da remoto
     chip-other: Altro
     get-started: Inizia
     skip: Salta per ora

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -311,9 +311,10 @@ cloud:
     question: "시작하기 전에 간단한 질문 — Cloud를 주로 어떤 용도로 사용하고 싶으신가요?"
     placeholder: "예: Plex 컨테이너가 밤에 중단되면 알고 싶어요..."
     or-pick: "또는 하나를 선택하세요:"
-    chip-alerts: 문제 발생 시 알림
-    chip-summary: 일일 요약
-    chip-hosts: 여러 호스트 모니터링
+    chip-alerts: 오류 알림
+    chip-failure-analysis: 장애 분석
+    chip-hosts: 다중 호스트
+    chip-remote-access: 원격 접속
     chip-other: 기타
     get-started: 시작하기
     skip: 나중에 하기

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -311,10 +311,10 @@ cloud:
     question: "시작하기 전에 간단한 질문 — Cloud를 주로 어떤 용도로 사용하고 싶으신가요?"
     placeholder: "예: Plex 컨테이너가 밤에 중단되면 알고 싶어요..."
     or-pick: "또는 하나를 선택하세요:"
-    chip-alerts: 오류 알림
-    chip-failure-analysis: 장애 분석
-    chip-hosts: 다중 호스트
-    chip-remote-access: 원격 접속
+    chip-alerts: 오류 알림 받기
+    chip-failure-analysis: 장애 원인 파악
+    chip-hosts: 여러 호스트 모니터링
+    chip-remote-access: 원격으로 로그 접근
     chip-other: 기타
     get-started: 시작하기
     skip: 나중에 하기

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -309,9 +309,10 @@ cloud:
     question: "Een snelle vraag voordat we beginnen — waarvoor wil je Cloud het meest gebruiken?"
     placeholder: "bijv. Ik wil weten wanneer mijn Plex-container 's nachts crasht..."
     or-pick: "Of kies er een:"
-    chip-alerts: Waarschuw me bij problemen
-    chip-summary: Dagelijkse samenvatting
-    chip-hosts: Meerdere hosts monitoren
+    chip-alerts: Foutmeldingen
+    chip-failure-analysis: Foutanalyse
+    chip-hosts: Meerdere hosts
+    chip-remote-access: Externe toegang
     chip-other: Iets anders
     get-started: Aan de slag
     skip: Nu overslaan

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -309,10 +309,10 @@ cloud:
     question: "Een snelle vraag voordat we beginnen — waarvoor wil je Cloud het meest gebruiken?"
     placeholder: "bijv. Ik wil weten wanneer mijn Plex-container 's nachts crasht..."
     or-pick: "Of kies er een:"
-    chip-alerts: Foutmeldingen
-    chip-failure-analysis: Foutanalyse
-    chip-hosts: Meerdere hosts
-    chip-remote-access: Externe toegang
+    chip-alerts: Foutwaarschuwingen ontvangen
+    chip-failure-analysis: Fouten begrijpen
+    chip-hosts: Meerdere hosts monitoren
+    chip-remote-access: Logs op afstand bekijken
     chip-other: Iets anders
     get-started: Aan de slag
     skip: Nu overslaan

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -315,10 +315,10 @@ cloud:
     question: "Szybkie pytanie zanim zaczniemy — do czego głównie chcesz używać Cloud?"
     placeholder: "np. Chcę wiedzieć, gdy mój kontener Plex padnie w nocy..."
     or-pick: "Lub wybierz:"
-    chip-alerts: Alerty błędów
-    chip-failure-analysis: Analiza awarii
-    chip-hosts: Wiele hostów
-    chip-remote-access: Zdalny dostęp
+    chip-alerts: Otrzymywać alerty błędów
+    chip-failure-analysis: Zrozumieć awarie
+    chip-hosts: Monitorować wiele hostów
+    chip-remote-access: Dostęp do logów zdalnie
     chip-other: Coś innego
     get-started: Rozpocznij
     skip: Pomiń na razie

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -315,9 +315,10 @@ cloud:
     question: "Szybkie pytanie zanim zaczniemy — do czego głównie chcesz używać Cloud?"
     placeholder: "np. Chcę wiedzieć, gdy mój kontener Plex padnie w nocy..."
     or-pick: "Lub wybierz:"
-    chip-alerts: Powiadom mnie o awariach
-    chip-summary: Codzienne podsumowanie
-    chip-hosts: Monitorowanie wielu hostów
+    chip-alerts: Alerty błędów
+    chip-failure-analysis: Analiza awarii
+    chip-hosts: Wiele hostów
+    chip-remote-access: Zdalny dostęp
     chip-other: Coś innego
     get-started: Rozpocznij
     skip: Pomiń na razie

--- a/locales/pr.yml
+++ b/locales/pr.yml
@@ -317,9 +317,10 @@ cloud:
     question: "One quick question before we set sail — what be ye hopin' Cloud helps with most?"
     placeholder: "e.g. I want to know when me Plex container capsizes overnight..."
     or-pick: "Or pick one, matey:"
-    chip-alerts: Alert me when things go overboard
-    chip-summary: Daily ship's log
-    chip-hosts: Watch over multiple vessels
+    chip-alerts: Error signals
+    chip-failure-analysis: Wreck investigation
+    chip-hosts: Multiple vessels
+    chip-remote-access: Sail from afar
     chip-other: Somethin' else
     get-started: Set Sail
     skip: Skip fer now

--- a/locales/pr.yml
+++ b/locales/pr.yml
@@ -317,10 +317,10 @@ cloud:
     question: "One quick question before we set sail — what be ye hopin' Cloud helps with most?"
     placeholder: "e.g. I want to know when me Plex container capsizes overnight..."
     or-pick: "Or pick one, matey:"
-    chip-alerts: Error signals
-    chip-failure-analysis: Wreck investigation
-    chip-hosts: Multiple vessels
-    chip-remote-access: Sail from afar
+    chip-alerts: Get error signals
+    chip-failure-analysis: Understand wrecks
+    chip-hosts: Watch multiple vessels
+    chip-remote-access: Read logs from afar
     chip-other: Somethin' else
     get-started: Set Sail
     skip: Skip fer now

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -307,10 +307,10 @@ cloud:
     question: "Uma pergunta rápida antes de começar — para que você mais quer usar o Cloud?"
     placeholder: "ex. Quero saber quando meu container Plex cai durante a noite..."
     or-pick: "Ou escolha uma opção:"
-    chip-alerts: Alertas de erros
-    chip-failure-analysis: Análise de falhas
-    chip-hosts: Vários hosts
-    chip-remote-access: Acesso remoto
+    chip-alerts: Receber alertas de erros
+    chip-failure-analysis: Entender falhas
+    chip-hosts: Monitorar vários hosts
+    chip-remote-access: Acessar logs remotamente
     chip-other: Outra coisa
     get-started: Começar
     skip: Pular por agora

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -307,9 +307,10 @@ cloud:
     question: "Uma pergunta rápida antes de começar — para que você mais quer usar o Cloud?"
     placeholder: "ex. Quero saber quando meu container Plex cai durante a noite..."
     or-pick: "Ou escolha uma opção:"
-    chip-alerts: Me alertar quando algo quebrar
-    chip-summary: Resumo diário
-    chip-hosts: Monitorar vários hosts
+    chip-alerts: Alertas de erros
+    chip-failure-analysis: Análise de falhas
+    chip-hosts: Vários hosts
+    chip-remote-access: Acesso remoto
     chip-other: Outra coisa
     get-started: Começar
     skip: Pular por agora

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -308,9 +308,10 @@ cloud:
     question: "Один быстрый вопрос перед началом — для чего вы хотите использовать Cloud?"
     placeholder: "напр. Хочу знать, когда мой контейнер Plex падает ночью..."
     or-pick: "Или выберите:"
-    chip-alerts: Уведомлять о сбоях
-    chip-summary: Ежедневная сводка
-    chip-hosts: Мониторинг нескольких хостов
+    chip-alerts: Оповещения об ошибках
+    chip-failure-analysis: Анализ сбоев
+    chip-hosts: Несколько хостов
+    chip-remote-access: Удалённый доступ
     chip-other: Другое
     get-started: Начать
     skip: Пропустить

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -308,10 +308,10 @@ cloud:
     question: "Один быстрый вопрос перед началом — для чего вы хотите использовать Cloud?"
     placeholder: "напр. Хочу знать, когда мой контейнер Plex падает ночью..."
     or-pick: "Или выберите:"
-    chip-alerts: Оповещения об ошибках
-    chip-failure-analysis: Анализ сбоев
-    chip-hosts: Несколько хостов
-    chip-remote-access: Удалённый доступ
+    chip-alerts: Получать оповещения об ошибках
+    chip-failure-analysis: Понимать причины сбоев
+    chip-hosts: Мониторинг нескольких хостов
+    chip-remote-access: Доступ к логам удалённо
     chip-other: Другое
     get-started: Начать
     skip: Пропустить

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -313,10 +313,10 @@ cloud:
     question: "Hitro vprašanje preden začnemo — za kaj želite Cloud najbolj uporabljati?"
     placeholder: "npr. Želim vedeti, ko se moj Plex vsebnik ponoči sesuje..."
     or-pick: "Ali izberite:"
-    chip-alerts: Opozorila o napakah
-    chip-failure-analysis: Analiza okvar
-    chip-hosts: Več gostiteljev
-    chip-remote-access: Oddaljeni dostop
+    chip-alerts: Prejemati opozorila o napakah
+    chip-failure-analysis: Razumeti okvare
+    chip-hosts: Spremljati več gostiteljev
+    chip-remote-access: Dostop do dnevnikov na daljavo
     chip-other: Nekaj drugega
     get-started: Začni
     skip: Preskoči za zdaj

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -313,9 +313,10 @@ cloud:
     question: "Hitro vprašanje preden začnemo — za kaj želite Cloud najbolj uporabljati?"
     placeholder: "npr. Želim vedeti, ko se moj Plex vsebnik ponoči sesuje..."
     or-pick: "Ali izberite:"
-    chip-alerts: Opozori me ob težavah
-    chip-summary: Dnevni povzetek
-    chip-hosts: Spremljanje več gostiteljev
+    chip-alerts: Opozorila o napakah
+    chip-failure-analysis: Analiza okvar
+    chip-hosts: Več gostiteljev
+    chip-remote-access: Oddaljeni dostop
     chip-other: Nekaj drugega
     get-started: Začni
     skip: Preskoči za zdaj

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -308,9 +308,10 @@ cloud:
     question: "Başlamadan önce kısa bir soru — Cloud'u en çok ne için kullanmak istiyorsunuz?"
     placeholder: "örn. Plex konteynerim gece çöktüğünde bilmek istiyorum..."
     or-pick: "Veya birini seçin:"
-    chip-alerts: Sorun olduğunda uyar
-    chip-summary: Günlük özet
-    chip-hosts: Birden fazla sunucu izle
+    chip-alerts: Hata uyarıları
+    chip-failure-analysis: Arıza analizi
+    chip-hosts: Birden fazla sunucu
+    chip-remote-access: Uzaktan erişim
     chip-other: Başka bir şey
     get-started: Başla
     skip: Şimdilik geç

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -308,10 +308,10 @@ cloud:
     question: "Başlamadan önce kısa bir soru — Cloud'u en çok ne için kullanmak istiyorsunuz?"
     placeholder: "örn. Plex konteynerim gece çöktüğünde bilmek istiyorum..."
     or-pick: "Veya birini seçin:"
-    chip-alerts: Hata uyarıları
-    chip-failure-analysis: Arıza analizi
-    chip-hosts: Birden fazla sunucu
-    chip-remote-access: Uzaktan erişim
+    chip-alerts: Hata uyarıları almak
+    chip-failure-analysis: Arızaları anlamak
+    chip-hosts: Birden fazla sunucu izlemek
+    chip-remote-access: Loglara uzaktan erişmek
     chip-other: Başka bir şey
     get-started: Başla
     skip: Şimdilik geç

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -311,9 +311,10 @@ cloud:
     question: "開始之前問個小問題——您最希望 Cloud 幫您做什麼？"
     placeholder: "例如：我想知道我的 Plex 容器是否在夜間當機..."
     or-pick: "或選擇一項："
-    chip-alerts: 出現故障時通知我
-    chip-summary: 每日摘要
-    chip-hosts: 監控多個主機
+    chip-alerts: 錯誤告警
+    chip-failure-analysis: 故障分析
+    chip-hosts: 多主機
+    chip-remote-access: 遠端存取
     chip-other: 其他
     get-started: 開始使用
     skip: 暫時跳過

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -311,10 +311,10 @@ cloud:
     question: "開始之前問個小問題——您最希望 Cloud 幫您做什麼？"
     placeholder: "例如：我想知道我的 Plex 容器是否在夜間當機..."
     or-pick: "或選擇一項："
-    chip-alerts: 錯誤告警
-    chip-failure-analysis: 故障分析
-    chip-hosts: 多主機
-    chip-remote-access: 遠端存取
+    chip-alerts: 取得錯誤告警
+    chip-failure-analysis: 了解故障原因
+    chip-hosts: 監控多個主機
+    chip-remote-access: 遠端查看日誌
     chip-other: 其他
     get-started: 開始使用
     skip: 暫時跳過

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -308,10 +308,10 @@ cloud:
     question: "开始之前问个小问题——您最希望 Cloud 帮您做什么？"
     placeholder: "例如：我想知道我的 Plex 容器是否在夜间崩溃..."
     or-pick: "或选择一项："
-    chip-alerts: 错误告警
-    chip-failure-analysis: 故障分析
-    chip-hosts: 多主机
-    chip-remote-access: 远程访问
+    chip-alerts: 获取错误告警
+    chip-failure-analysis: 了解故障原因
+    chip-hosts: 监控多个主机
+    chip-remote-access: 远程查看日志
     chip-other: 其他
     get-started: 开始使用
     skip: 暂时跳过

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -308,9 +308,10 @@ cloud:
     question: "开始之前问个小问题——您最希望 Cloud 帮您做什么？"
     placeholder: "例如：我想知道我的 Plex 容器是否在夜间崩溃..."
     or-pick: "或选择一项："
-    chip-alerts: 出现故障时通知我
-    chip-summary: 每日摘要
-    chip-hosts: 监控多个主机
+    chip-alerts: 错误告警
+    chip-failure-analysis: 故障分析
+    chip-hosts: 多主机
+    chip-remote-access: 远程访问
     chip-other: 其他
     get-started: 开始使用
     skip: 暂时跳过


### PR DESCRIPTION
## Summary
- Replace solution-oriented chip labels with user-intent noun phrases: "Error alerts", "Failure analysis", "Multiple hosts", "Remote access", "Something else"
- Remove "Daily summary" chip, add "Failure analysis" and "Remote access" chips
- Updated all 17 locale files with translated labels

## Test plan
- [ ] Open the welcome modal after linking a cloud instance
- [ ] Verify all 5 chips render correctly in English
- [ ] Spot-check a few other locales (e.g. DE, FR, ZH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)