### PR TITLE
fix: cloud remove_container on agents and queue burst tool calls

### DIFF
--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -360,6 +360,11 @@ func (c *Client) ContainerAction(ctx context.Context, containerId string, action
 	case container.Restart:
 		containerAction = pb.ContainerAction_Restart
 
+	case container.Remove:
+		containerAction = pb.ContainerAction_Remove
+
+	default:
+		return fmt.Errorf("unknown action: %s", action)
 	}
 
 	_, err := c.client.ContainerAction(ctx, &pb.ContainerActionRequest{ContainerId: containerId, Action: containerAction})

--- a/internal/agent/pb/types.pb.go
+++ b/internal/agent/pb/types.pb.go
@@ -29,6 +29,7 @@ const (
 	ContainerAction_Start   ContainerAction = 0
 	ContainerAction_Stop    ContainerAction = 1
 	ContainerAction_Restart ContainerAction = 2
+	ContainerAction_Remove  ContainerAction = 3
 )
 
 // Enum value maps for ContainerAction.
@@ -37,11 +38,13 @@ var (
 		0: "Start",
 		1: "Stop",
 		2: "Restart",
+		3: "Remove",
 	}
 	ContainerAction_value = map[string]int32{
 		"Start":   0,
 		"Stop":    1,
 		"Restart": 2,
+		"Remove":  3,
 	}
 )
 
@@ -1315,11 +1318,13 @@ const file_types_proto_rawDesc = "" +
 	"\x0esubscriptionId\x18\x01 \x01(\x05R\x0esubscriptionId\x12\"\n" +
 	"\ftriggerCount\x18\x02 \x01(\x03R\ftriggerCount\x12D\n" +
 	"\x0flastTriggeredAt\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x0flastTriggeredAt\x124\n" +
-	"\x15triggeredContainerIds\x18\x04 \x03(\tR\x15triggeredContainerIds*3\n" +
+	"\x15triggeredContainerIds\x18\x04 \x03(\tR\x15triggeredContainerIds*?\n" +
 	"\x0fContainerAction\x12\t\n" +
 	"\x05Start\x10\x00\x12\b\n" +
 	"\x04Stop\x10\x01\x12\v\n" +
-	"\aRestart\x10\x02B\x13Z\x11internal/agent/pbb\x06proto3"
+	"\aRestart\x10\x02\x12\n" +
+	"\n" +
+	"\x06Remove\x10\x03B\x13Z\x11internal/agent/pbb\x06proto3"
 
 var (
 	file_types_proto_rawDescOnce sync.Once

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -300,6 +300,9 @@ func (s *server) ContainerAction(ctx context.Context, in *pb.ContainerActionRequ
 	case pb.ContainerAction_Restart:
 		action = container.Restart
 
+	case pb.ContainerAction_Remove:
+		action = container.Remove
+
 	default:
 		return nil, status.Error(codes.InvalidArgument, "invalid action")
 	}

--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -284,24 +284,15 @@ func (c *Client) connect(ctx context.Context, apiKey string) (wasConnected bool,
 			continue
 		}
 
-		// List tools is fast — handle inline. Tool calls run concurrently with a semaphore.
+		// List tools is fast — handle inline. Tool calls queue behind a semaphore
+		// so bursts (e.g. the LLM firing 25 remove_container calls at once) run
+		// serially enough that Docker doesn't buckle. Acquire blocks inside the
+		// goroutine so the recv loop keeps processing cancel_stream requests.
 		if _, ok := req.Type.(*pb.ToolRequest_CallTool); ok {
-			if !c.toolSem.TryAcquire(1) {
-				resp := &pb.ToolResponse{
-					RequestId: req.RequestId,
-					Type: &pb.ToolResponse_CallTool{
-						CallTool: &pb.CallToolResponse{
-							Success: false,
-							Error:   "too many concurrent tool calls",
-						},
-					},
-				}
-				if err := sendResp(resp); err != nil {
-					return wasConnected, fmt.Errorf("stream send error: %w", err)
-				}
-				continue
-			}
 			wg.Go(func() {
+				if err := c.toolSem.Acquire(streamLifetime, 1); err != nil {
+					return
+				}
 				defer c.toolSem.Release(1)
 				resp := c.handleRequest(streamLifetime, req)
 				if streamLifetime.Err() != nil {

--- a/protos/types.proto
+++ b/protos/types.proto
@@ -97,6 +97,7 @@ enum ContainerAction {
   Start = 0;
   Stop = 1;
   Restart = 2;
+  Remove = 3;
 }
 
 message NotificationSubscription {


### PR DESCRIPTION
## Summary

- Add `Remove` to the agent `ContainerAction` proto enum. The agent client/server switches had no case for it, so remove calls fell through to the zero value (`Start`) — silently starting containers instead of removing them on agent-backed hosts.
- Queue cloud tool calls instead of rejecting them. The cloud client used `TryAcquire` on a 5-slot semaphore, so a burst of 25 `remove_container` calls would return "too many concurrent tool calls" for the last 20. Switched to blocking `Acquire` inside the goroutine so bursts queue without hanging the recv loop (cancel_stream still gets processed).

## Test plan

- [ ] `go test ./internal/agent/... ./internal/cloud/... ./internal/docker/...`
- [ ] Trigger `remove_container` against an agent-backed host via Dozzle Cloud; verify the container is removed (not started)
- [ ] Ask the LLM to remove 20+ stopped containers in one turn; verify all complete (queued serially under the 5-slot semaphore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)