### PR TITLE
feat: implement notification manager support for k8s cluster service

### DIFF
--- a/internal/support/k8s/k8s_cluster_service.go
+++ b/internal/support/k8s/k8s_cluster_service.go
@@ -3,21 +3,28 @@ package k8s_support
 import (
 	"context"
 	"fmt"
+	"os"
+	"sync"
 	"time"
 
 	"github.com/amir20/dozzle/internal/container"
 	"github.com/amir20/dozzle/internal/k8s"
+	"github.com/amir20/dozzle/internal/migration"
 	"github.com/amir20/dozzle/internal/notification"
 	"github.com/amir20/dozzle/internal/notification/dispatcher"
 	container_support "github.com/amir20/dozzle/internal/support/container"
 	"github.com/amir20/dozzle/types"
+	"github.com/rs/zerolog/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type K8sClusterService struct {
-	client  *K8sClientService
-	timeout time.Duration
-	hosts   []container.Host
+	client              *K8sClientService
+	timeout             time.Duration
+	hosts               []container.Host
+	notificationManager *notification.Manager
+	cloudConfig         *notification.CloudConfig
+	cloudMu             sync.RWMutex
 }
 
 func NewK8sClusterService(client *k8s.K8sClient, timeout time.Duration) (*K8sClusterService, error) {
@@ -139,40 +146,155 @@ func (m *K8sClusterService) LocalClientServices() []container_support.ClientServ
 	return []container_support.ClientService{m.client}
 }
 
-// Notification methods - not yet implemented for k8s
-func (m *K8sClusterService) AddSubscription(sub *notification.Subscription) error {
+const notificationConfigPath = "./data/notifications.yml"
+const cloudConfigPath = "./data/cloud.yml"
 
-	// TODO Implement notification subscription for k8s mode
-	return fmt.Errorf("notifications not supported in k8s mode")
+// StartNotificationManager initializes and starts the notification manager for k8s mode
+func (m *K8sClusterService) StartNotificationManager(ctx context.Context) error {
+	clients := m.LocalClientServices()
+	listener := notification.NewContainerLogListener(ctx, clients)
+	statsListener := notification.NewContainerStatsListener(ctx, clients)
+	eventListener := notification.NewContainerEventListener(ctx, clients)
+	m.notificationManager = notification.NewManager(listener, statsListener, eventListener)
+
+	// Migrate old config format before loading
+	migration.MigrateCloudConfig(notificationConfigPath, cloudConfigPath)
+
+	// Start first so matcher is available for LoadConfig
+	if err := m.notificationManager.Start(); err != nil {
+		return err
+	}
+
+	// Load notification config
+	if file, err := os.Open(notificationConfigPath); err == nil {
+		defer file.Close()
+		if err := m.notificationManager.LoadConfig(file); err != nil {
+			log.Warn().Err(err).Msg("Could not load notification config")
+		} else {
+			log.Debug().Str("path", notificationConfigPath).Msg("Loaded notification config")
+		}
+	}
+
+	// Load cloud config
+	if file, err := os.Open(cloudConfigPath); err == nil {
+		defer file.Close()
+		cc, err := notification.LoadCloudConfig(file)
+		if err != nil {
+			log.Warn().Err(err).Msg("Could not load cloud config")
+		} else {
+			m.cloudConfig = &cc
+			m.setCloudDispatcherFromConfig(&cc)
+			log.Debug().Str("path", cloudConfigPath).Msg("Loaded cloud config")
+		}
+	}
+
+	return nil
+}
+
+func (m *K8sClusterService) saveNotificationConfig() {
+	if err := os.MkdirAll("./data", 0755); err != nil {
+		log.Error().Err(err).Msg("Could not create data directory")
+		return
+	}
+
+	file, err := os.Create(notificationConfigPath)
+	if err != nil {
+		log.Error().Err(err).Msg("Could not create notification config file")
+		return
+	}
+	defer file.Close()
+
+	if err := m.notificationManager.WriteConfig(file); err != nil {
+		log.Error().Err(err).Msg("Could not write notification config")
+	}
+}
+
+func (m *K8sClusterService) saveCloudConfig() {
+	m.cloudMu.RLock()
+	cc := m.cloudConfig
+	m.cloudMu.RUnlock()
+
+	if cc == nil {
+		return
+	}
+
+	if err := os.MkdirAll("./data", 0755); err != nil {
+		log.Error().Err(err).Msg("Could not create data directory")
+		return
+	}
+
+	file, err := os.Create(cloudConfigPath)
+	if err != nil {
+		log.Error().Err(err).Msg("Could not create cloud config file")
+		return
+	}
+	defer file.Close()
+
+	if err := notification.WriteCloudConfig(file, *cc); err != nil {
+		log.Error().Err(err).Msg("Could not write cloud config")
+	}
+}
+
+func (m *K8sClusterService) setCloudDispatcherFromConfig(cc *notification.CloudConfig) {
+	d, err := dispatcher.NewCloudDispatcher("Dozzle Cloud", cc.APIKey, cc.Prefix, cc.ExpiresAt)
+	if err != nil {
+		log.Error().Err(err).Msg("Could not create cloud dispatcher from config")
+		return
+	}
+	m.notificationManager.SetCloudDispatcher(d)
+}
+
+func (m *K8sClusterService) AddSubscription(sub *notification.Subscription) error {
+	if err := m.notificationManager.AddSubscription(sub); err != nil {
+		return err
+	}
+	m.saveNotificationConfig()
+	return nil
 }
 
 func (m *K8sClusterService) RemoveSubscription(id int) {
+	m.notificationManager.RemoveSubscription(id)
+	m.saveNotificationConfig()
 }
 
 func (m *K8sClusterService) ReplaceSubscription(sub *notification.Subscription) error {
-	return fmt.Errorf("notifications not supported in k8s mode")
+	if err := m.notificationManager.ReplaceSubscription(sub); err != nil {
+		return err
+	}
+	m.saveNotificationConfig()
+	return nil
 }
 
 func (m *K8sClusterService) UpdateSubscription(id int, updates map[string]any) error {
-	return fmt.Errorf("notifications not supported in k8s mode")
+	if err := m.notificationManager.UpdateSubscription(id, updates); err != nil {
+		return err
+	}
+	m.saveNotificationConfig()
+	return nil
 }
 
 func (m *K8sClusterService) Subscriptions() []*notification.Subscription {
-	return []*notification.Subscription{}
+	return m.notificationManager.Subscriptions()
 }
 
 func (m *K8sClusterService) AddDispatcher(d dispatcher.Dispatcher) int {
-	return 0
+	id := m.notificationManager.AddDispatcher(d)
+	m.saveNotificationConfig()
+	return id
 }
 
 func (m *K8sClusterService) UpdateDispatcher(id int, d dispatcher.Dispatcher) {
+	m.notificationManager.UpdateDispatcher(id, d)
+	m.saveNotificationConfig()
 }
 
 func (m *K8sClusterService) RemoveDispatcher(id int) {
+	m.notificationManager.RemoveDispatcher(id)
+	m.saveNotificationConfig()
 }
 
 func (m *K8sClusterService) Dispatchers() []notification.DispatcherConfig {
-	return []notification.DispatcherConfig{}
+	return m.notificationManager.Dispatchers()
 }
 
 func (m *K8sClusterService) FetchAgentNotificationStats() map[int]types.SubscriptionStats {
@@ -180,13 +302,25 @@ func (m *K8sClusterService) FetchAgentNotificationStats() map[int]types.Subscrip
 }
 
 func (m *K8sClusterService) CloudConfig() *notification.CloudConfig {
-	return nil
+	m.cloudMu.RLock()
+	defer m.cloudMu.RUnlock()
+	return m.cloudConfig
 }
 
 func (m *K8sClusterService) SetCloudConfig(cc *notification.CloudConfig) {
-	// Not supported in k8s mode
+	m.cloudMu.Lock()
+	m.cloudConfig = cc
+	m.cloudMu.Unlock()
+	m.setCloudDispatcherFromConfig(cc)
+	m.saveCloudConfig()
 }
 
 func (m *K8sClusterService) RemoveCloudConfig() {
-	// Not supported in k8s mode
+	m.cloudMu.Lock()
+	m.cloudConfig = nil
+	m.cloudMu.Unlock()
+	m.notificationManager.ClearCloudDispatcher()
+	if err := os.Remove(cloudConfigPath); err != nil && !os.IsNotExist(err) {
+		log.Error().Err(err).Msg("Could not remove cloud config file")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -122,6 +122,10 @@ func main() {
 			log.Fatal().Err(err).Msg("Could not create k8s cluster service")
 		}
 
+		if err := clusterService.StartNotificationManager(ctx); err != nil {
+			log.Fatal().Err(err).Msg("Could not start notification manager")
+		}
+
 		go cli.StartEvent(args, "k8s", localClient, "")
 		hostService = clusterService
 	} else {


### PR DESCRIPTION
## Summary

Notifications and alerts (log-based, metric-based, event-based, and cloud dispatchers)
were completely non-functional in `DOZZLE_MODE=k8s`. This PR wires up the notification
manager for Kubernetes deployments, bringing feature parity with server and swarm modes.

## Problem

When running Dozzle on Kubernetes (e.g., EKS with containerd), the alerting pipeline
was never initialized:

1. `main.go` called `StartNotificationManager()` for server and swarm modes, but
   skipped it entirely for k8s mode.
2. `K8sClusterService` implemented the `HostService` notification interface with
   stubs — all methods returned errors like `"notifications not supported in k8s mode"`
   or empty slices.

This meant:
- Dispatchers (Slack webhooks, etc.) could not be persisted — `AddDispatcher` returned 0
- Subscriptions were silently discarded — `AddSubscription` returned an error
- `Subscriptions()` and `Dispatchers()` always returned empty lists
- Cloud config was ignored — `SetCloudConfig` was a no-op
- No log/stats/event listeners were created, so no alerts would ever fire

The underlying K8s client already supports everything the notification system needs:
`ContainerEvents()` uses the Kubernetes Watch API, stats flow through
`K8sStatsCollector`, and `StreamLogs()` works through the Kubernetes API. The wiring
was simply never done.

## Changes

### `main.go`
- Added `clusterService.StartNotificationManager(ctx)` call in the k8s mode block,
  matching the existing pattern in server (line 72) and swarm (line 88) modes.

### `internal/support/k8s/k8s_cluster_service.go`
- Added `notificationManager`, `cloudConfig`, and `cloudMu` fields to
  `K8sClusterService` struct.
- Implemented `StartNotificationManager()` which:
  - Creates log, stats, and event listeners from the existing `K8sClientService`
  - Runs the cloud config migration (`notifications.yml` → `cloud.yml` split)
  - Starts the notification manager
  - Loads persisted notification and cloud configs from `./data/`
- Replaced all stub notification methods with real implementations that delegate to
  the notification manager and persist config to disk (same pattern as
  `MultiHostService`).
- Implemented cloud config methods (`CloudConfig`, `SetCloudConfig`,
  `RemoveCloudConfig`) with proper mutex-protected access and disk persistence.

## What now works in k8s mode

- Creating and managing webhook dispatchers (Slack, etc.)
- Creating log-based, metric-based, and event-based alert subscriptions
- Alert evaluation against live Kubernetes pod logs and events
- Cloud dispatcher integration (Dozzle Cloud)
- Config persistence across restarts (`./data/notifications.yml`, `./data/cloud.yml`)

## Verified
- Verified on EKS and GKE clusters and I am able to get the Slack notifications 

## Test plan

- [ ] `go vet ./internal/...` passes cleanly
- [ ] `go test ./internal/...` passes (existing notification tests unaffected)
- [ ] Deploy to a k8s cluster and confirm:
  - [ ] Create a webhook dispatcher (e.g., Slack) via the UI
  - [ ] Create a log-based alert subscription targeting a test pod
  - [ ] Generate matching log output and verify the notification fires
  - [ ] Restart Dozzle and confirm dispatchers/subscriptions persist
  - [ ] Test the "Test" button on a dispatcher
