### PR TITLE
chore: Auto-create default alert on welcome modal CTA

### DIFF
--- a/assets/components/Notification/AlertCard.vue
+++ b/assets/components/Notification/AlertCard.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="card bg-base-100 shadow-sm" :class="{ 'opacity-60': !alert.enabled }">
+  <div
+    class="card bg-base-100 shadow-sm"
+    :class="{ 'opacity-60': !alert.enabled, 'highlight-new': isHighlighted }"
+    @animationend="isHighlighted = false"
+  >
     <div class="card-body gap-4 p-5">
       <!-- Header -->
       <div class="flex items-start justify-between">
@@ -104,10 +108,19 @@
 import type { Dispatcher, NotificationRule } from "@/types/notifications";
 import AlertForm from "./AlertForm.vue";
 
-const { alert, onUpdated } = defineProps<{
+const { alert, onUpdated, highlight } = defineProps<{
   alert: NotificationRule;
   onUpdated?: () => void;
+  highlight?: boolean;
 }>();
+
+const isHighlighted = ref(highlight ?? false);
+watch(
+  () => highlight,
+  (v) => {
+    if (v) isHighlighted.value = true;
+  },
+);
 
 const showDrawer = useDrawer();
 const isDeleting = ref(false);
@@ -156,3 +169,18 @@ async function deleteAlert() {
   }
 }
 </script>
+
+<style scoped>
+.card.highlight-new {
+  animation: highlight-fade 3s ease-out;
+}
+
+@keyframes highlight-fade {
+  from {
+    background-color: oklch(from var(--color-secondary) l c h / 0.25);
+  }
+  to {
+    background-color: transparent;
+  }
+}
+</style>

--- a/assets/components/WelcomeModal.spec.ts
+++ b/assets/components/WelcomeModal.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createI18n } from "vue-i18n";
+import { useRouter } from "vue-router";
+import WelcomeModal from "./WelcomeModal.vue";
+
+vi.mock("vue-router");
+
+vi.mock("@/stores/config", () => ({
+  __esModule: true,
+  default: { base: "" },
+  withBase: (path: string) => path,
+}));
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  fallbackLocale: "en",
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: { en: { cloud: { welcome: { "default-alert-name": "Container exited with error" } } } },
+});
+
+function mountModal() {
+  return mount(WelcomeModal, {
+    global: {
+      plugins: [i18n],
+    },
+  });
+}
+
+describe("<WelcomeModal /> Create First Alert", () => {
+  const pushSpy = vi.fn();
+
+  beforeEach(() => {
+    // jsdom's HTMLDialogElement lacks .close()/.showModal() — stub them so WelcomeModal's close() works.
+    if (!HTMLDialogElement.prototype.close) {
+      HTMLDialogElement.prototype.close = function () {};
+    }
+    if (!HTMLDialogElement.prototype.showModal) {
+      HTMLDialogElement.prototype.showModal = function () {};
+    }
+    vi.mocked(useRouter).mockReturnValue({
+      push: pushSpy,
+    } as unknown as ReturnType<typeof useRouter>);
+    pushSpy.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  test("POSTs default rule with cloud dispatcher id and routes to /notifications?highlight=<id>", async () => {
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/notifications/dispatchers")) {
+        return new Response(JSON.stringify([{ id: 7, type: "cloud", name: "Dozzle Cloud" }]), { status: 200 });
+      }
+      if (u.includes("/api/notifications/rules")) {
+        return new Response(JSON.stringify({ id: 42 }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const wrapper = mountModal();
+    const vm = wrapper.vm as unknown as { step: "step1" | "step2" } & Record<string, unknown>;
+    // jump to step2 to expose the CTA
+    vm.step = "step2";
+    await wrapper.vm.$nextTick();
+
+    const cta = wrapper.findAll("button").find((b) => b.text().toLowerCase().includes("create"));
+    expect(cta).toBeDefined();
+    await cta!.trigger("click");
+    // allow async fetch chain to settle
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    const postCall = fetchMock.mock.calls.find((c) => String(c[0]).includes("/api/notifications/rules"));
+    expect(postCall).toBeDefined();
+    const body = JSON.parse((postCall![1] as RequestInit).body as string);
+    expect(body).toMatchObject({
+      enabled: true,
+      dispatcherId: 7,
+      eventExpression: 'name == "die" && attributes["exitCode"] != "0"',
+      cooldown: 0,
+      sampleWindow: 0,
+    });
+
+    expect(pushSpy).toHaveBeenCalledWith({ path: "/notifications", query: { highlight: "42" } });
+  });
+
+  test("falls back to ?action=create-alert when POST fails", async () => {
+    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/notifications/dispatchers")) {
+        return new Response(JSON.stringify([{ id: 7, type: "cloud", name: "Dozzle Cloud" }]), { status: 200 });
+      }
+      if (u.includes("/api/notifications/rules")) {
+        return new Response("{}", { status: 500 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const wrapper = mountModal();
+    const vm = wrapper.vm as unknown as { step: "step1" | "step2" } & Record<string, unknown>;
+    vm.step = "step2";
+    await wrapper.vm.$nextTick();
+
+    const cta = wrapper.findAll("button").find((b) => b.text().toLowerCase().includes("create"));
+    await cta!.trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(pushSpy).toHaveBeenCalledWith({ path: "/notifications", query: { action: "create-alert" } });
+  });
+});

--- a/assets/components/WelcomeModal.spec.ts
+++ b/assets/components/WelcomeModal.spec.ts
@@ -51,7 +51,7 @@ describe("<WelcomeModal /> Create First Alert", () => {
   });
 
   test("POSTs default rule with cloud dispatcher id and routes to /notifications?highlight=<id>", async () => {
-    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (url: RequestInfo | URL, _init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notifications/dispatchers")) {
         return new Response(JSON.stringify([{ id: 7, type: "cloud", name: "Dozzle Cloud" }]), { status: 200 });
@@ -92,7 +92,7 @@ describe("<WelcomeModal /> Create First Alert", () => {
   });
 
   test("falls back to ?action=create-alert when POST fails", async () => {
-    const fetchMock = vi.fn(async (url: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (url: RequestInfo | URL, _init?: RequestInit) => {
       const u = String(url);
       if (u.includes("/api/notifications/dispatchers")) {
         return new Response(JSON.stringify([{ id: 7, type: "cloud", name: "Dozzle Cloud" }]), { status: 200 });

--- a/assets/components/WelcomeModal.vue
+++ b/assets/components/WelcomeModal.vue
@@ -90,6 +90,7 @@ const cloudUrl = __CLOUD_URL__;
 const { t } = useI18n();
 const router = useRouter();
 const route = useRoute();
+const { showToast } = useToast();
 
 const modal = ref<HTMLDialogElement>();
 const step = ref<"step1" | "step2">("step1");
@@ -206,6 +207,13 @@ async function createFirstAlert() {
 
     router.push({ path: "/notifications", query: { highlight: String(rule.id) } });
   } catch {
+    showToast(
+      {
+        type: "warning",
+        message: t("notifications.default-alert-failed"),
+      },
+      { expire: 6000 },
+    );
     router.push({ path: "/notifications", query: { action: "create-alert" } });
   }
 }

--- a/assets/components/WelcomeModal.vue
+++ b/assets/components/WelcomeModal.vue
@@ -195,7 +195,7 @@ async function createFirstAlert() {
         enabled: true,
         dispatcherId: cloud.id,
         logExpression: "",
-        containerExpression: "",
+        containerExpression: "true",
         eventExpression: 'name == "die" && attributes["exitCode"] != "0"',
         metricExpression: "",
         cooldown: 0,

--- a/assets/components/WelcomeModal.vue
+++ b/assets/components/WelcomeModal.vue
@@ -177,9 +177,37 @@ async function skipFeedback() {
   }
 }
 
-function createFirstAlert() {
+async function createFirstAlert() {
   close();
-  router.push({ path: "/notifications", query: { action: "create-alert" } });
+  try {
+    const dispatchersRes = await fetch(withBase("/api/notifications/dispatchers"));
+    if (!dispatchersRes.ok) throw new Error("dispatchers fetch failed");
+    const dispatchers: Array<{ id: number; type: string }> = await dispatchersRes.json();
+    const cloud = dispatchers.find((d) => d.type === "cloud");
+    if (!cloud) throw new Error("cloud dispatcher missing");
+
+    const ruleRes = await fetch(withBase("/api/notifications/rules"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: t("cloud.welcome.default-alert-name"),
+        enabled: true,
+        dispatcherId: cloud.id,
+        logExpression: "",
+        containerExpression: "",
+        eventExpression: 'name == "die" && attributes["exitCode"] != "0"',
+        metricExpression: "",
+        cooldown: 0,
+        sampleWindow: 0,
+      }),
+    });
+    if (!ruleRes.ok) throw new Error("rule POST failed");
+    const rule: { id: number } = await ruleRes.json();
+
+    router.push({ path: "/notifications", query: { highlight: String(rule.id) } });
+  } catch {
+    router.push({ path: "/notifications", query: { action: "create-alert" } });
+  }
 }
 
 function open() {

--- a/assets/pages/notifications.vue
+++ b/assets/pages/notifications.vue
@@ -71,7 +71,13 @@
 
         <!-- Alerts List -->
         <div class="space-y-4">
-          <AlertCard v-for="alert in filteredAlerts" :key="alert.id" :alert="alert" :on-updated="fetchAlerts" />
+          <AlertCard
+            v-for="alert in filteredAlerts"
+            :key="alert.id"
+            :alert="alert"
+            :on-updated="fetchAlerts"
+            :highlight="alert.id === highlightId"
+          />
           <button
             class="card card-border border-base-content/30 hover:border-base-content/50 w-full cursor-pointer border-dashed transition-colors"
             @click="openCreateAlert"
@@ -115,6 +121,31 @@ async function fetchAll() {
   await Promise.all([fetchAlerts(), fetchDispatchers()]);
 }
 
+const highlightId = ref<number | null>(null);
+const { showToast } = useToast();
+
+function consumeHighlight(value: unknown) {
+  if (typeof value !== "string" || !value) return false;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return false;
+  highlightId.value = parsed;
+  router.replace({ query: {} });
+  showToast(
+    {
+      type: "info",
+      message: t("notifications.default-alert-created"),
+    },
+    { expire: 8000 },
+  );
+  return true;
+}
+
+function consumeAction(action: unknown) {
+  if (action !== "create-alert") return;
+  router.replace({ query: {} });
+  openCreateAlertPrefilled();
+}
+
 onMounted(async () => {
   await fetchAll();
   const hash = window.location.hash;
@@ -122,20 +153,19 @@ onMounted(async () => {
     router.replace({ hash: "" });
   }
 
-  if (route.query.action === "create-alert") {
-    router.replace({ query: {} });
-    openCreateAlertPrefilled();
+  if (!consumeHighlight(route.query.highlight)) {
+    consumeAction(route.query.action);
   }
 });
 
 watch(
+  () => route.query.highlight,
+  (value) => consumeHighlight(value),
+);
+
+watch(
   () => route.query.action,
-  (action) => {
-    if (action === "create-alert") {
-      router.replace({ query: {} });
-      openCreateAlertPrefilled();
-    }
-  },
+  (action) => consumeAction(action),
 );
 
 // Local state

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -188,6 +188,8 @@ notifications:
     enabled: Aktiveret ({count})
     paused: Pauset ({count})
   no-alerts: Ingen alarmer konfigureret endnu. Opret en for at komme i gang.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Pauset
     containers: Containere
@@ -325,4 +327,5 @@ cloud:
     checklist-agent-title: Prøv AI-assistenten
     checklist-agent-desc: "Forbind Telegram eller Discord og chat med dine containere. Diagnosticér fejl, tjek tilstand og udfør handlinger som genstart af tjenester."
     create-alert: Opret din første advarsel
+    default-alert-name: Container exited with error
     later: "Det gør jeg senere"

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -188,6 +188,8 @@ notifications:
     enabled: Aktiviert ({count})
     paused: Pausiert ({count})
   no-alerts: Noch keine Alarme konfiguriert. Erstellen Sie einen, um loszulegen.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Pausiert
     containers: Container
@@ -325,4 +327,5 @@ cloud:
     checklist-agent-title: KI-Assistent ausprobieren
     checklist-agent-desc: "Verbinden Sie Telegram oder Discord und chatten Sie mit Ihren Containern. Fehler diagnostizieren, Zustand prüfen und Aktionen wie Neustarts ausführen."
     create-alert: Erste Benachrichtigung erstellen
+    default-alert-name: Container exited with error
     later: "Das mache ich später"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -194,6 +194,8 @@ notifications:
   add-alert: Add alert
   prefill-name: Error alerts
   prefill-expression: level == "error"
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   filter:
     all: All ({count})
     enabled: Enabled ({count})
@@ -338,4 +340,5 @@ cloud:
     checklist-agent-title: Try the AI assistant
     checklist-agent-desc: "Connect Telegram or Discord and chat with your containers. Diagnose errors, check health, and take actions like restarting services."
     create-alert: Create Your First Alert
+    default-alert-name: Container exited with error
     later: "I'll do this later"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -188,6 +188,8 @@ notifications:
     enabled: Habilitados ({count})
     paused: Pausados ({count})
   no-alerts: Aún no hay alertas configuradas. Cree una para comenzar.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Pausado
     containers: Contenedores
@@ -325,4 +327,5 @@ cloud:
     checklist-agent-title: Probar el asistente de IA
     checklist-agent-desc: "Conecta Telegram o Discord y chatea con tus contenedores. Diagnostica errores, comprueba el estado y realiza acciones como reiniciar servicios."
     create-alert: Crear tu primera alerta
+    default-alert-name: Container exited with error
     later: "Lo haré después"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -188,6 +188,8 @@ notifications:
     enabled: Activés ({count})
     paused: En pause ({count})
   no-alerts: Aucune alerte configurée. Créez-en une pour commencer.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: En pause
     containers: Conteneurs
@@ -325,4 +327,5 @@ cloud:
     checklist-agent-title: Essayer l'assistant IA
     checklist-agent-desc: "Connectez Telegram ou Discord et discutez avec vos conteneurs. Diagnostiquez les erreurs, vérifiez l'état et effectuez des actions comme le redémarrage de services."
     create-alert: Créer votre première alerte
+    default-alert-name: Container exited with error
     later: "Je ferai ça plus tard"

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -200,6 +200,8 @@ notifications:
     enabled: Diaktifkan ({count})
     paused: Dijeda ({count})
   no-alerts: Belum ada peringatan yang dikonfigurasi. Buat satu untuk memulai.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Dijeda
     containers: Kontainer
@@ -337,4 +339,5 @@ cloud:
     checklist-agent-title: Coba asisten AI
     checklist-agent-desc: "Hubungkan Telegram atau Discord dan ngobrol dengan kontainer Anda. Diagnosis error, periksa kesehatan, dan lakukan tindakan seperti restart layanan."
     create-alert: Buat peringatan pertama Anda
+    default-alert-name: Container exited with error
     later: "Nanti saja"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -188,6 +188,8 @@ notifications:
     enabled: Abilitati ({count})
     paused: In pausa ({count})
   no-alerts: Nessun avviso configurato. Creane uno per iniziare.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: In pausa
     containers: Container
@@ -325,4 +327,5 @@ cloud:
     checklist-agent-title: Prova l'assistente IA
     checklist-agent-desc: "Collega Telegram o Discord e chatta con i tuoi container. Diagnostica errori, controlla lo stato ed esegui azioni come il riavvio dei servizi."
     create-alert: Crea il tuo primo avviso
+    default-alert-name: Container exited with error
     later: "Lo farò dopo"

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -191,6 +191,8 @@ notifications:
     enabled: 활성화됨 ({count})
     paused: 일시정지됨 ({count})
   no-alerts: 아직 설정된 알림이 없습니다. 시작하려면 하나를 만드세요.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: 일시정지됨
     containers: 컨테이너
@@ -328,4 +330,5 @@ cloud:
     checklist-agent-title: AI 어시스턴트 사용해 보기
     checklist-agent-desc: "Telegram 또는 Discord를 연결하고 컨테이너와 대화하세요. 오류를 진단하고, 상태를 확인하고, 서비스 재시작 등의 작업을 수행하세요."
     create-alert: 첫 번째 알림 만들기
+    default-alert-name: Container exited with error
     later: "나중에 할게요"

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -189,6 +189,8 @@ notifications:
     enabled: Ingeschakeld ({count})
     paused: Gepauzeerd ({count})
   no-alerts: Nog geen waarschuwingen geconfigureerd. Maak er een om te beginnen.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Gepauzeerd
     containers: Containers
@@ -326,4 +328,5 @@ cloud:
     checklist-agent-title: Probeer de AI-assistent
     checklist-agent-desc: "Verbind Telegram of Discord en chat met je containers. Diagnosticeer fouten, controleer de status en voer acties uit zoals het herstarten van services."
     create-alert: Maak je eerste melding
+    default-alert-name: Container exited with error
     later: "Dat doe ik later"

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -195,6 +195,8 @@ notifications:
     enabled: Włączone ({count})
     paused: Wstrzymane ({count})
   no-alerts: Brak skonfigurowanych alertów. Utwórz jeden, aby rozpocząć.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Wstrzymany
     containers: Kontenery
@@ -332,4 +334,5 @@ cloud:
     checklist-agent-title: Wypróbuj asystenta AI
     checklist-agent-desc: "Połącz Telegram lub Discord i rozmawiaj ze swoimi kontenerami. Diagnozuj błędy, sprawdzaj stan i wykonuj akcje jak restart usług."
     create-alert: Utwórz pierwszy alert
+    default-alert-name: Container exited with error
     later: "Zrobię to później"

--- a/locales/pr.yml
+++ b/locales/pr.yml
@@ -197,6 +197,8 @@ notifications:
     enabled: Ativados ({count})
     paused: Pausados ({count})
   no-alerts: Ainda não há alertas configurados. Crie um para começar.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Pausado
     containers: Contentores
@@ -334,4 +336,5 @@ cloud:
     checklist-agent-title: Try the AI first mate
     checklist-agent-desc: "Connect Telegram or Discord and chat with yer containers. Diagnose errors, check the ship's health, and take actions like restartin' services."
     create-alert: Create Yer First Alert
+    default-alert-name: Container exited with error
     later: "I'll do this later, arrr"

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -187,6 +187,8 @@ notifications:
     enabled: Habilitados ({count})
     paused: Pausados ({count})
   no-alerts: Nenhum alerta configurado ainda. Crie um para começar.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Pausado
     containers: Containers
@@ -324,4 +326,5 @@ cloud:
     checklist-agent-title: Experimente o assistente de IA
     checklist-agent-desc: "Conecte Telegram ou Discord e converse com seus containers. Diagnostique erros, verifique o estado e execute ações como reiniciar serviços."
     create-alert: Crie seu primeiro alerta
+    default-alert-name: Container exited with error
     later: "Farei isso depois"

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -188,6 +188,8 @@ notifications:
     enabled: Включены ({count})
     paused: Приостановлены ({count})
   no-alerts: Оповещения ещё не настроены. Создайте одно для начала.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Приостановлено
     containers: Контейнеры
@@ -325,4 +327,5 @@ cloud:
     checklist-agent-title: Попробуйте ИИ-ассистента
     checklist-agent-desc: "Подключите Telegram или Discord и общайтесь с вашими контейнерами. Диагностируйте ошибки, проверяйте состояние и выполняйте действия, такие как перезапуск сервисов."
     create-alert: Создайте первое оповещение
+    default-alert-name: Container exited with error
     later: "Сделаю это позже"

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -193,6 +193,8 @@ notifications:
     enabled: Omogočeni ({count})
     paused: Ustavljeni ({count})
   no-alerts: Opozorila še niso nastavljena. Ustvarite enega za začetek.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Ustavljeno
     containers: Zabojniki
@@ -330,4 +332,5 @@ cloud:
     checklist-agent-title: Preizkusite AI pomočnika
     checklist-agent-desc: "Povežite Telegram ali Discord in klepetajte s svojimi vsebniki. Diagnosticirajte napake, preverite stanje in izvajajte dejanja kot ponovni zagon storitev."
     create-alert: Ustvarite prvo opozorilo
+    default-alert-name: Container exited with error
     later: "To bom naredil pozneje"

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -188,6 +188,8 @@ notifications:
     enabled: Etkin ({count})
     paused: Duraklatılmış ({count})
   no-alerts: Henüz uyarı yapılandırılmadı. Başlamak için bir tane oluşturun.
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: Duraklatıldı
     containers: Konteynerler
@@ -325,4 +327,5 @@ cloud:
     checklist-agent-title: Yapay zeka asistanını deneyin
     checklist-agent-desc: "Telegram veya Discord'u bağlayın ve konteynerlerinizle sohbet edin. Hataları teşhis edin, durumu kontrol edin ve servis yeniden başlatma gibi işlemler yapın."
     create-alert: İlk uyarınızı oluşturun
+    default-alert-name: Container exited with error
     later: "Bunu daha sonra yapacağım"

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -191,6 +191,8 @@ notifications:
     enabled: 已啟用 ({count})
     paused: 已暫停 ({count})
   no-alerts: 尚未設定任何警報。建立一個以開始使用。
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: 已暫停
     containers: 容器
@@ -328,4 +330,5 @@ cloud:
     checklist-agent-title: 試試 AI 助理
     checklist-agent-desc: "連接 Telegram 或 Discord，與您的容器對話。診斷錯誤、檢查健康狀態並執行重啟服務等操作。"
     create-alert: 建立您的第一個警示
+    default-alert-name: Container exited with error
     later: "稍後再說"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -188,6 +188,8 @@ notifications:
     enabled: 已启用 ({count})
     paused: 已暂停 ({count})
   no-alerts: 尚未配置任何警报。创建一个以开始使用。
+  default-alert-created: "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
+  default-alert-failed: "Couldn't auto-create your alert — here's the form instead."
   alert:
     paused: 已暂停
     containers: 容器
@@ -325,4 +327,5 @@ cloud:
     checklist-agent-title: 试试 AI 助手
     checklist-agent-desc: "连接 Telegram 或 Discord，与您的容器对话。诊断错误、检查健康状态并执行重启服务等操作。"
     create-alert: 创建您的第一个警报
+    default-alert-name: Container exited with error
     later: "稍后再说"


### PR DESCRIPTION
## Summary

Replaces the Welcome Modal's "Create Your First Alert" button with a one-click flow that auto-creates a "container exit with non-zero code" subscription against the cloud dispatcher and lands the user on `/notifications` with the new rule pulse-highlighted.

- `WelcomeModal.vue` → fetches dispatchers, POSTs default rule (event expression `name == "die" && attributes["exitCode"] != "0"`), routes to `/notifications?highlight=<id>`; falls back to existing `?action=create-alert` prefilled drawer on any failure, with a warning toast.
- `AlertCard.vue` → accepts an optional `highlight` prop; on `true` it plays the 3s `highlight-fade` keyframe (mirrors `HostMenu.vue`) and resets via `@animationend`.
- `notifications.vue` → consumes `?highlight=<id>` on mount + watcher, clears the query param, shows an info toast with the spec-verbatim copy, and passes `:highlight` into the matching `AlertCard`.
- 3 new i18n keys added to `en.yml` and mirrored into the 16 sibling locales as English fallbacks (same pattern as prior `cloud.welcome.*` rollout).

Spec: `docs/superpowers/specs/2026-04-17-default-cloud-subscription-design.md`
Plan: `docs/superpowers/plans/2026-04-17-default-cloud-subscription.md`

## Test plan

Automated (green):
- [x] `pnpm typecheck`
- [x] `TZ=UTC pnpm test` — 12/12 passing, including 2 new `WelcomeModal.spec.ts` tests (happy path asserts POST body shape + push to `?highlight=<id>`; fallback asserts push to `?action=create-alert` on 500)
- [x] `pnpm build` — all 17 locales bundle cleanly

Manual (for reviewer):
- [ ] Clear `profile/*` from localStorage → reload with a cloud-linked instance so the WelcomeModal re-triggers
- [ ] Click through step 1/2 → "Create Your First Alert" → confirm: `POST /api/notifications/rules` fires with the spec payload, URL briefly becomes `/notifications?highlight=<id>`, the new `AlertCard` pulses secondary color for ~3s, info toast appears with "We created a default alert for you. You'll get notified when any container exits with an error. Edit or pause it anytime."
- [ ] DevTools → Network → block `/api/notifications/rules` → repeat the flow → confirm: URL lands at `/notifications?action=create-alert`, prefilled drawer opens, warning toast "Couldn't auto-create your alert — here's the form instead." appears
- [ ] `docker run --rm alpine sh -c 'exit 1'` → confirm the default alert fires to the cloud dispatcher (email by default)