### PR TITLE
fix: avoid _grpc_config DNS lookups from agent healthcheck

### DIFF
--- a/internal/support/cli/health_command.go
+++ b/internal/support/cli/health_command.go
@@ -18,7 +18,7 @@ func (h *HealthcheckCmd) Run(args Args, embeddedCerts embed.FS) error {
 	if data, err := os.ReadFile(agentAddrFile); err == nil {
 		agentAddress := string(data)
 		if host, port, err := net.SplitHostPort(agentAddress); err == nil && (host == "" || host == "::" || host == "0.0.0.0") {
-			agentAddress = "localhost:" + port
+			agentAddress = "127.0.0.1:" + port
 		}
 		certs, err := ReadCertificates(embeddedCerts, args.CertPath, args.KeyPath)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Agent healthcheck dialed `localhost:7007`, which makes gRPC-Go's DNS resolver issue a `_grpc_config.localhost` TXT lookup on every dial (gRFC A2 service-config discovery). At a 5s healthcheck interval this floods host DNS logs.
- Switching to `127.0.0.1` skips the DNS resolver entirely — no TXT probe, no spam.

Fixes #4636

## Test plan
- [ ] Build agent, run with healthcheck, verify no `_grpc_config.*` DNS queries
- [ ] Confirm healthcheck still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)