### PR TITLE
feat(cloud): add network stats to get_running_container_stats

### DIFF
--- a/internal/cloud/tools.go
+++ b/internal/cloud/tools.go
@@ -271,7 +271,7 @@ func AvailableTools(enableActions bool) []*pb.ToolDefinition {
 		},
 		{
 			Name:           toolGetRunningContainerStats,
-			Description:    "Get real-time CPU and memory usage statistics for all currently running Docker containers. Returns current percentages and peak values over the last 5 minutes.",
+			Description:    "Get real-time CPU, memory, and network usage statistics for all currently running Docker containers. Returns current percentages, peak values over the last 5 minutes, and network rx/tx totals plus bytes transferred in the last 5 minutes.",
 			ParametersJson: noParams,
 			Scope:          pb.ToolScope_TOOL_SCOPE_INSTANCE,
 			ReadOnly:       true,

--- a/internal/cloud/tools_containers.go
+++ b/internal/cloud/tools_containers.go
@@ -125,11 +125,20 @@ func executeGetRunningContainerStats(deps ToolDeps) (*pb.CallToolResponse, error
 
 		stats := c.Stats.Data()
 		latest := stats[len(stats)-1]
+		first := stats[0]
 
 		var maxCPU, maxMem float64
 		for _, s := range stats {
 			maxCPU = max(maxCPU, s.CPUPercent)
 			maxMem = max(maxMem, s.MemoryPercent)
+		}
+
+		var rxDelta, txDelta uint64
+		if latest.NetworkRxTotal >= first.NetworkRxTotal {
+			rxDelta = latest.NetworkRxTotal - first.NetworkRxTotal
+		}
+		if latest.NetworkTxTotal >= first.NetworkTxTotal {
+			txDelta = latest.NetworkTxTotal - first.NetworkTxTotal
 		}
 
 		result = append(result, &pb.ContainerStatEntry{
@@ -142,6 +151,10 @@ func executeGetRunningContainerStats(deps ToolDeps) (*pb.CallToolResponse, error
 			MemoryUsage:    latest.MemoryUsage,
 			MaxCpu_5Min:    maxCPU,
 			MaxMemory_5Min: maxMem,
+			NetworkRxTotal: latest.NetworkRxTotal,
+			NetworkTxTotal: latest.NetworkTxTotal,
+			NetworkRx_5Min: rxDelta,
+			NetworkTx_5Min: txDelta,
 		})
 	}
 	return &pb.CallToolResponse{

--- a/internal/container/container_store.go
+++ b/internal/container/container_store.go
@@ -338,14 +338,15 @@ func (s *ContainerStore) init() {
 						if newContainer.State == "running" && c.State != "running" {
 							started = true
 						}
-						c.Name = newContainer.Name
-						c.State = newContainer.State
-						c.Labels = newContainer.Labels
-						c.StartedAt = newContainer.StartedAt
-						c.FinishedAt = newContainer.FinishedAt
-						c.Created = newContainer.Created
-						c.Host = newContainer.Host
-						return c, xsync.UpdateOp
+						copy := *c
+						copy.Name = newContainer.Name
+						copy.State = newContainer.State
+						copy.Labels = newContainer.Labels
+						copy.StartedAt = newContainer.StartedAt
+						copy.FinishedAt = newContainer.FinishedAt
+						copy.Created = newContainer.Created
+						copy.Host = newContainer.Host
+						return &copy, xsync.UpdateOp
 					} else {
 						return c, xsync.CancelOp
 					}
@@ -370,9 +371,10 @@ func (s *ContainerStore) init() {
 				s.containers.Compute(event.ActorID, func(c *Container, loaded bool) (*Container, xsync.ComputeOp) {
 					if loaded {
 						log.Debug().Str("id", c.ID).Msg("container died")
-						c.State = "exited"
-						c.FinishedAt = time.Now()
-						return c, xsync.UpdateOp
+						copy := *c
+						copy.State = "exited"
+						copy.FinishedAt = time.Now()
+						return &copy, xsync.UpdateOp
 					} else {
 						return c, xsync.CancelOp
 					}
@@ -386,8 +388,9 @@ func (s *ContainerStore) init() {
 				s.containers.Compute(event.ActorID, func(c *Container, loaded bool) (*Container, xsync.ComputeOp) {
 					if loaded {
 						log.Debug().Str("id", c.ID).Str("health", healthy).Msg("container health status changed")
-						c.Health = healthy
-						return c, xsync.UpdateOp
+						copy := *c
+						copy.Health = healthy
+						return &copy, xsync.UpdateOp
 					} else {
 						return c, xsync.CancelOp
 					}
@@ -397,8 +400,9 @@ func (s *ContainerStore) init() {
 				s.containers.Compute(event.ActorID, func(c *Container, loaded bool) (*Container, xsync.ComputeOp) {
 					if loaded {
 						log.Debug().Str("id", event.ActorID).Str("name", event.ActorAttributes["name"]).Msg("container renamed")
-						c.Name = event.ActorAttributes["name"]
-						return c, xsync.UpdateOp
+						copy := *c
+						copy.Name = event.ActorAttributes["name"]
+						return &copy, xsync.UpdateOp
 					} else {
 						return c, xsync.CancelOp
 					}

--- a/proto/cloud/cloud.pb.go
+++ b/proto/cloud/cloud.pb.go
@@ -1094,6 +1094,10 @@ type ContainerStatEntry struct {
 	MaxCpu_5Min    float64                `protobuf:"fixed64,7,opt,name=max_cpu_5min,json=maxCpu5min,proto3" json:"max_cpu_5min,omitempty"`
 	MaxMemory_5Min float64                `protobuf:"fixed64,8,opt,name=max_memory_5min,json=maxMemory5min,proto3" json:"max_memory_5min,omitempty"`
 	HostId         string                 `protobuf:"bytes,9,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
+	NetworkRxTotal uint64                 `protobuf:"varint,10,opt,name=network_rx_total,json=networkRxTotal,proto3" json:"network_rx_total,omitempty"`
+	NetworkTxTotal uint64                 `protobuf:"varint,11,opt,name=network_tx_total,json=networkTxTotal,proto3" json:"network_tx_total,omitempty"`
+	NetworkRx_5Min uint64                 `protobuf:"varint,12,opt,name=network_rx_5min,json=networkRx5min,proto3" json:"network_rx_5min,omitempty"`
+	NetworkTx_5Min uint64                 `protobuf:"varint,13,opt,name=network_tx_5min,json=networkTx5min,proto3" json:"network_tx_5min,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1189,6 +1193,34 @@ func (x *ContainerStatEntry) GetHostId() string {
 		return x.HostId
 	}
 	return ""
+}
+
+func (x *ContainerStatEntry) GetNetworkRxTotal() uint64 {
+	if x != nil {
+		return x.NetworkRxTotal
+	}
+	return 0
+}
+
+func (x *ContainerStatEntry) GetNetworkTxTotal() uint64 {
+	if x != nil {
+		return x.NetworkTxTotal
+	}
+	return 0
+}
+
+func (x *ContainerStatEntry) GetNetworkRx_5Min() uint64 {
+	if x != nil {
+		return x.NetworkRx_5Min
+	}
+	return 0
+}
+
+func (x *ContainerStatEntry) GetNetworkTx_5Min() uint64 {
+	if x != nil {
+		return x.NetworkTx_5Min
+	}
+	return 0
 }
 
 type ContainerStatsResult struct {
@@ -1803,7 +1835,7 @@ const file_cloud_proto_rawDesc = "" +
 	"\x14ListContainersResult\x124\n" +
 	"\n" +
 	"containers\x18\x01 \x03(\v2\x14.cloud.ContainerInfoR\n" +
-	"containers\"\x9a\x02\n" +
+	"containers\"\xbe\x03\n" +
 	"\x12ContainerStatEntry\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x12\n" +
@@ -1815,7 +1847,12 @@ const file_cloud_proto_rawDesc = "" +
 	"\fmax_cpu_5min\x18\a \x01(\x01R\n" +
 	"maxCpu5min\x12&\n" +
 	"\x0fmax_memory_5min\x18\b \x01(\x01R\rmaxMemory5min\x12\x17\n" +
-	"\ahost_id\x18\t \x01(\tR\x06hostId\"G\n" +
+	"\ahost_id\x18\t \x01(\tR\x06hostId\x12(\n" +
+	"\x10network_rx_total\x18\n" +
+	" \x01(\x04R\x0enetworkRxTotal\x12(\n" +
+	"\x10network_tx_total\x18\v \x01(\x04R\x0enetworkTxTotal\x12&\n" +
+	"\x0fnetwork_rx_5min\x18\f \x01(\x04R\rnetworkRx5min\x12&\n" +
+	"\x0fnetwork_tx_5min\x18\r \x01(\x04R\rnetworkTx5min\"G\n" +
 	"\x14ContainerStatsResult\x12/\n" +
 	"\x05stats\x18\x01 \x03(\v2\x19.cloud.ContainerStatEntryR\x05stats\"p\n" +
 	"\bLogEntry\x12\x1c\n" +

--- a/protos/cloud.proto
+++ b/protos/cloud.proto
@@ -142,6 +142,10 @@ message ContainerStatEntry {
   double max_cpu_5min = 7;
   double max_memory_5min = 8;
   string host_id = 9;
+  uint64 network_rx_total = 10;
+  uint64 network_tx_total = 11;
+  uint64 network_rx_5min = 12;
+  uint64 network_tx_5min = 13;
 }
 
 message ContainerStatsResult {


### PR DESCRIPTION
## Summary
- Adds `network_rx_total`, `network_tx_total`, `network_rx_5min`, `network_tx_5min` to `ContainerStatEntry` in `protos/cloud.proto`
- `executeGetRunningContainerStats` now populates latest totals and 5-minute deltas (guarded against counter resets)
- Updates tool description so the LLM knows network metrics are available

Note: includes the preceding `fix/container-store-race` commit since this branch was based off it.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./internal/cloud/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)