### PR TITLE
feat: host grouping support

### DIFF
--- a/assets/components/HostMenu.vue
+++ b/assets/components/HostMenu.vue
@@ -49,13 +49,34 @@
   <SlideTransition :slide-right="!!sessionHost">
     <template #left>
       <ul class="menu p-0">
-        <li v-for="host in hosts" :key="host.id">
-          <a @click.prevent="setHost(host.id)" :class="{ 'text-base-content/50 pointer-events-none': !host.available }">
-            <HostIcon :type="host.type" />
-            {{ host.name }}
-            <span class="badge badge-error badge-xs p-1.5" v-if="!host.available">offline</span>
-          </a>
-        </li>
+        <template v-if="!hasHostGroups">
+          <li v-for="host in hosts" :key="host.id">
+            <a @click.prevent="setHost(host.id)" :class="{ 'text-base-content/50 pointer-events-none': !host.available }">
+              <HostIcon :type="host.type" />
+              {{ host.name }}
+              <span class="badge badge-error badge-xs p-1.5" v-if="!host.available">offline</span>
+            </a>
+          </li>
+        </template>
+        <template v-else v-for="[groupName, groupHosts] in groupedHostEntries" :key="groupName || '__ungrouped__'">
+          <li v-if="groupName" class="menu-title flex items-center justify-between px-0 pr-1">
+            <span>{{ groupName }}</span>
+            <router-link
+              :to="{ name: '/host-group/[name]', params: { name: groupName } }"
+              class="btn btn-square btn-outline btn-primary btn-xs"
+              :title="$t('tooltip.merge-all')"
+            >
+              <ph:arrows-merge />
+            </router-link>
+          </li>
+          <li v-for="host in groupHosts" :key="host.id">
+            <a @click.prevent="setHost(host.id)" :class="{ 'text-base-content/50 pointer-events-none': !host.available }">
+              <HostIcon :type="host.type" />
+              {{ host.name }}
+              <span class="badge badge-error badge-xs p-1.5" v-if="!host.available">offline</span>
+            </a>
+          </li>
+        </template>
       </ul>
     </template>
     <template #right>
@@ -145,6 +166,28 @@ const pinnedStore = usePinnedLogsStore();
 const { hosts } = useHosts();
 
 const setHost = (host: string | null) => (sessionHost.value = host);
+
+const hasHostGroups = computed(() => Object.values(hosts.value).some((h) => h.group));
+
+const groupedHostEntries = computed(() => {
+  const groups: Record<string, (typeof hosts.value)[string][]> = {};
+  const ungrouped: (typeof hosts.value)[string][] = [];
+
+  for (const host of Object.values(hosts.value)) {
+    if (host.group) {
+      groups[host.group] ||= [];
+      groups[host.group].push(host);
+    } else {
+      ungrouped.push(host);
+    }
+  }
+
+  const entries = Object.entries(groups).sort(([a], [b]) => a.localeCompare(b)) as [string, typeof ungrouped][];
+  if (ungrouped.length > 0) {
+    entries.push(["", ungrouped]);
+  }
+  return entries;
+});
 
 const collapsedGroups = useProfileStorage("collapsedGroups", new Set<string>());
 const updateCollapsedGroups = (event: Event, label: string) => {

--- a/assets/components/HostViewer/HostGroupLog.vue
+++ b/assets/components/HostViewer/HostGroupLog.vue
@@ -1,0 +1,55 @@
+<template>
+  <ScrollableView :scrollable="scrollable" v-if="groupHosts.length > 0">
+    <template #header>
+      <div class="mx-2 flex items-center gap-2 md:ml-4">
+        <div class="flex flex-1 items-center gap-1.5 truncate md:gap-2">
+          <ph:computer-tower />
+          <div class="inline-flex font-mono text-sm">
+            <div class="font-semibold">{{ name }}</div>
+          </div>
+          <Tag class="font-mono max-md:hidden" size="small">
+            {{ $t("label.host-count", groupHosts.length) }}
+          </Tag>
+          <Tag class="font-mono max-md:hidden" size="small">
+            {{ $t("label.container", containers.length) }}
+          </Tag>
+        </div>
+        <MultiContainerStat class="ml-auto" :containers="containers" />
+        <MultiContainerActionToolbar class="max-md:hidden" :name="name" @clear="viewer?.clear()" />
+      </div>
+    </template>
+    <template #default>
+      <ViewerWithSource
+        ref="viewer"
+        :stream-source="useHostGroupStream"
+        :entity="groupRef"
+        :visible-keys="new Map<string[], boolean>()"
+      />
+    </template>
+  </ScrollableView>
+</template>
+
+<script lang="ts" setup>
+import ViewerWithSource from "@/components/LogViewer/ViewerWithSource.vue";
+import { useHostGroupStream } from "@/composable/eventStreams";
+import { ComponentExposed } from "vue-component-type-helpers";
+
+const { name, scrollable = false } = defineProps<{
+  name: string;
+  scrollable?: boolean;
+}>();
+
+const { hosts } = useHosts();
+const store = useContainerStore();
+const { containersByHost } = storeToRefs(store);
+
+const groupHosts = computed(() => Object.values(hosts.value).filter((h) => h.group === name));
+const groupRef = computed(() => ({ name }));
+
+const containers = computed(() =>
+  groupHosts.value.flatMap((h) => containersByHost.value?.[h.id]?.filter((c) => c.state === "running") ?? []),
+);
+
+const viewer = useTemplateRef<ComponentExposed<typeof ViewerWithSource>>("viewer");
+provideLoggingContext(containers, { showContainerName: true, showHostname: true });
+</script>

--- a/assets/composable/eventStreams.ts
+++ b/assets/composable/eventStreams.ts
@@ -28,6 +28,10 @@ export function useHostStream(host: Ref<Host>): LogStreamSource {
   return useLogStream(computed(() => `/api/hosts/${host.value.id}/logs/stream`));
 }
 
+export function useHostGroupStream(group: Ref<{ name: string }>): LogStreamSource {
+  return useLogStream(computed(() => `/api/host-groups/${group.value.name}/logs/stream`));
+}
+
 export function useStackStream(stack: Ref<Stack>): LogStreamSource {
   const labels = computed(() => `com.docker.stack.namespace:${stack.value.name}`);
   return useLogStream(computed(() => `/api/labels/${labels.value}/logs/stream`));

--- a/assets/pages/host-group/[name].vue
+++ b/assets/pages/host-group/[name].vue
@@ -1,0 +1,25 @@
+<template>
+  <Search />
+  <HostGroupLog :name="route.params.name" :scrollable="pinnedLogs.length > 0" />
+</template>
+
+<script lang="ts" setup>
+const route = useRoute("/host-group/[name]");
+
+const pinnedLogsStore = usePinnedLogsStore();
+const { pinnedLogs } = storeToRefs(pinnedLogsStore);
+const { hosts } = useHosts();
+
+const groupHosts = computed(() => Object.values(hosts.value).filter((h) => h.group === route.params.name));
+
+watchEffect(() => {
+  if (groupHosts.value.length > 0) {
+    setTitle(route.params.name + " group");
+  }
+});
+</script>
+
+<route lang="yaml">
+meta:
+  menu: host
+</route>

--- a/assets/stores/hosts.ts
+++ b/assets/stores/hosts.ts
@@ -8,6 +8,7 @@ export type Host = {
   available: boolean;
   dockerVersion: string;
   agentVersion: string;
+  group?: string;
 };
 
 const hosts = ref(

--- a/assets/typed-router.d.ts
+++ b/assets/typed-router.d.ts
@@ -62,6 +62,13 @@ declare module 'vue-router/auto-routes' {
       { name: ParamValue<false> },
       | never
     >,
+    '/host-group/[name]': RouteRecordInfo<
+      '/host-group/[name]',
+      '/host-group/:name',
+      { name: ParamValue<true> },
+      { name: ParamValue<false> },
+      | never
+    >,
     '/host/[id]': RouteRecordInfo<
       '/host/[id]',
       '/host/:id',
@@ -172,6 +179,12 @@ declare module 'vue-router/auto-routes' {
     'assets/pages/group/[name].vue': {
       routes:
         | '/group/[name]'
+      views:
+        | never
+    }
+    'assets/pages/host-group/[name].vue': {
+      routes:
+        | '/host-group/[name]'
       views:
         | never
     }

--- a/internal/container/host.go
+++ b/internal/container/host.go
@@ -26,6 +26,7 @@ type Host struct {
 	Type          string   `json:"type"`
 	Available     bool     `json:"available"`
 	Swarm         bool     `json:"-"`
+	Group         string   `json:"group,omitempty"`
 }
 
 func (h Host) String() string {
@@ -34,7 +35,7 @@ func (h Host) String() string {
 
 func ParseConnection(connection string) (Host, error) {
 	parts := strings.Split(connection, "|")
-	if len(parts) > 2 {
+	if len(parts) > 3 {
 		return Host{}, fmt.Errorf("invalid connection string: %s", connection)
 	}
 
@@ -44,8 +45,13 @@ func ParseConnection(connection string) (Host, error) {
 	}
 
 	name := remoteUrl.Hostname()
-	if len(parts) == 2 {
+	if len(parts) >= 2 && parts[1] != "" {
 		name = parts[1]
+	}
+
+	group := ""
+	if len(parts) == 3 {
+		group = parts[2]
 	}
 
 	basePath, err := filepath.Abs("./certs")
@@ -79,6 +85,7 @@ func ParseConnection(connection string) (Host, error) {
 		KeyPath:    keyPath,
 		ValidCerts: hasCerts,
 		Endpoint:   remoteUrl.String(),
+		Group:      group,
 	}, nil
 
 }

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -302,6 +302,22 @@ func (h *handler) streamGroupedLogs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *handler) streamHostGroupLogs(w http.ResponseWriter, r *http.Request) {
+	group := chi.URLParam(r, "group")
+
+	hostIDs := make(map[string]struct{})
+	for _, host := range h.hostService.Hosts() {
+		if host.Group == group {
+			hostIDs[host.ID] = struct{}{}
+		}
+	}
+
+	h.streamLogsForContainers(w, r, func(c *container.Container) bool {
+		_, ok := hostIDs[c.Host]
+		return c.State == "running" && ok
+	})
+}
+
 func (h *handler) streamHostLogs(w http.ResponseWriter, r *http.Request) {
 	host := hostKey(r)
 	h.streamLogsForContainers(w, r, func(container *container.Container) bool {

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -144,6 +144,7 @@ func createRouter(h *handler) *chi.Mux {
 				r.Get("/containers/{hostIds}/download", h.downloadLogs) // formatted as host:container,host:container
 				r.Get("/labels/{labels}/logs/stream", h.streamLogsWithLabels)
 				r.Get("/groups/{group}/logs/stream", h.streamGroupedLogs)
+				r.Get("/host-groups/{group}/logs/stream", h.streamHostGroupLogs)
 				r.Get("/events/stream", h.streamEvents)
 
 				// Action


### PR DESCRIPTION
## Problem

When running Dozzle in a multi-host setup, all hosts are displayed as a flat list in the sidebar. Users who manage many hosts often want to organize them logically — by environment (production/staging), by geographic location, by team, or by project. Without grouping, navigating large fleets of hosts becomes cumbersome.

Additionally, there is no way to view combined logs from all hosts in a logical group in one place, which is a common operational need when, for example, all production nodes should be monitored together.

## Solution

This PR adds **optional host grouping** — a lightweight feature that organizes hosts into named sections in the sidebar and provides a dedicated page for viewing merged logs across all hosts in a group.

### Configuration

The feature extends the existing `--remote-host` connection string format with an optional third field:

```
# Existing formats — unchanged, fully backward-compatible
--remote-host tcp://host:2375
--remote-host tcp://host:2375|CustomName

# New: with group
--remote-host tcp://host1:2375|Web-1|Production
--remote-host tcp://host2:2375|Web-2|Production
--remote-host tcp://host3:2375|Dev-1|Development

# Name can be omitted while keeping a group (hostname used as name)
--remote-host tcp://host1:2375||Production
```

The same works with `DOZZLE_REMOTE_HOST` environment variable.

### Behavior

**No groups configured** (default): the sidebar renders exactly as before — a flat list of hosts. Zero visual or behavioral change.

**Groups configured**: hosts are organized into labeled sections in the sidebar. Each section header shows the group name and a merge button (⇄) that navigates to a page showing combined live logs from all hosts in the group. Hosts without a group are shown below the named sections without a header.

### Changes

**Backend**
- `Host` struct: new `Group string` field (`json:"group,omitempty"`) — absent in JSON when not set
- `ParseConnection`: accepts `url|name|group` format (max 3 parts); existing `url` and `url|name` formats unchanged
- New handler `streamHostGroupLogs` at `GET /api/host-groups/{group}/logs/stream` — filters running containers to those whose host belongs to the requested group; protected by the same auth middleware as all other streaming endpoints
- Host group data is passed to the frontend as part of the existing `config.hosts` JSON (no new API endpoints for config)

**Frontend**
- `Host` type: optional `group?: string` field
- `HostMenu.vue`: when at least one host has a group, switches to grouped rendering with section headers and per-group merge buttons; when no groups exist, renders the existing flat list unchanged
- `useHostGroupStream` composable: connects to the new streaming endpoint
- `HostGroupLog.vue` component: displays merged logs for a host group with host/container counts in the header
- `/host-group/[name]` page: route for the group log view

## Compatibility

- Fully backward-compatible — no configuration changes required for existing users
- No new required flags or environment variables
- No changes to existing API endpoints
- No changes to the container grouping feature (`dev.dozzle.group` label)