### PR TITLE
perf: initialize agent connections in parallel on startup

### DIFF
--- a/internal/support/docker/retriable_client_manager.go
+++ b/internal/support/docker/retriable_client_manager.go
@@ -29,50 +29,80 @@ type RetriableClientManager struct {
 
 func NewRetriableClientManager(agents []string, timeout time.Duration, certs tls.Certificate, clients ...container_support.ClientService) *RetriableClientManager {
 	clientMap := make(map[string]container_support.ClientService)
-	for _, client := range clients {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		host, err := client.Host(ctx)
-		if err != nil {
-			log.Warn().Err(err).Str("host", host.Name).Msg("error fetching host info for client")
-			continue
-		}
+	var mapMu sync.Mutex
+	var wg sync.WaitGroup
 
-		if _, ok := clientMap[host.ID]; ok {
-			log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
-		} else {
-			clientMap[host.ID] = client
-		}
+	for _, c := range clients {
+		wg.Add(1)
+		go func(c container_support.ClientService) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			host, err := c.Host(ctx)
+			if err != nil {
+				log.Warn().Err(err).Str("host", host.Name).Msg("error fetching host info for client")
+				return
+			}
+			mapMu.Lock()
+			defer mapMu.Unlock()
+			if _, ok := clientMap[host.ID]; ok {
+				log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+			} else {
+				clientMap[host.ID] = c
+			}
+		}(c)
 	}
 
-	failed := make([]string, 0)
+	type agentEntry struct {
+		hostID   string
+		hostName string
+		service  container_support.ClientService
+	}
+
+	succeeded := make(chan agentEntry, len(agents))
+	failedCh := make(chan string, len(agents))
+
 	for _, endpoint := range agents {
-		agent, err := agent.NewClient(endpoint, certs)
-		if err != nil {
-			log.Warn().Err(err).Str("endpoint", endpoint).Msg("error creating agent client")
-			failed = append(failed, endpoint)
-			continue
-		}
+		wg.Add(1)
+		go func(ep string) {
+			defer wg.Done()
+			a, err := agent.NewClient(ep, certs)
+			if err != nil {
+				log.Warn().Err(err).Str("endpoint", ep).Msg("error creating agent client")
+				failedCh <- ep
+				return
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			host, err := a.Host(ctx)
+			if err != nil {
+				log.Warn().Err(err).Str("endpoint", ep).Msg("error fetching host info for agent")
+				failedCh <- ep
+				return
+			}
+			succeeded <- agentEntry{hostID: host.ID, hostName: host.Name, service: container_support.NewAgentService(a)}
+		}(endpoint)
+	}
 
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		host, err := agent.Host(ctx)
-		if err != nil {
-			log.Warn().Err(err).Str("endpoint", endpoint).Msg("error fetching host info for agent")
-			failed = append(failed, endpoint)
-			continue
-		}
+	wg.Wait()
+	close(succeeded)
+	close(failedCh)
 
-		if _, ok := clientMap[host.ID]; ok {
-			log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+	failedList := make([]string, 0)
+	for ep := range failedCh {
+		failedList = append(failedList, ep)
+	}
+	for entry := range succeeded {
+		if _, ok := clientMap[entry.hostID]; ok {
+			log.Warn().Str("name", entry.hostName).Str("id", entry.hostID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
 		} else {
-			clientMap[host.ID] = container_support.NewAgentService(agent)
+			clientMap[entry.hostID] = entry.service
 		}
 	}
 
 	return &RetriableClientManager{
 		clients:      clientMap,
-		failedAgents: failed,
+		failedAgents: failedList,
 		certs:        certs,
 		subscribers:  xsync.NewMap[context.Context, chan<- container.Host](),
 		timeout:      timeout,
@@ -90,49 +120,96 @@ func (m *RetriableClientManager) Subscribe(ctx context.Context, channel chan<- c
 
 func (m *RetriableClientManager) RetryAndList() ([]container_support.ClientService, []error) {
 	m.mu.Lock()
-	errors := make([]error, 0)
-	if len(m.failedAgents) > 0 {
-		newFailed := make([]string, 0)
-		for _, endpoint := range m.failedAgents {
-			agent, err := agent.NewClient(endpoint, m.certs)
-			if err != nil {
-				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error creating agent client")
-				errors = append(errors, err)
-				newFailed = append(newFailed, endpoint)
-				continue
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
-			defer cancel()
-			host, err := agent.Host(ctx)
-			if err != nil {
-				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error fetching host info for agent")
-				errors = append(errors, err)
-				newFailed = append(newFailed, endpoint)
-				continue
-			}
-
-			m.clients[host.ID] = container_support.NewAgentService(agent)
-			m.subscribers.Range(func(ctx context.Context, channel chan<- container.Host) bool {
-				host.Available = true
-
-				// We don't want to block the subscribers in event.go
-				go func(host container.Host) {
-					select {
-					case channel <- host:
-					case <-ctx.Done():
-					}
-				}(host)
-
-				return true
-			})
-		}
-		m.failedAgents = newFailed
+	if len(m.failedAgents) == 0 {
+		m.mu.Unlock()
+		return m.List(), nil
 	}
-
+	endpoints := make([]string, len(m.failedAgents))
+	copy(endpoints, m.failedAgents)
 	m.mu.Unlock()
 
-	return m.List(), errors
+	type retryResult struct {
+		endpoint string
+		hostID   string
+		hostName string
+		service  container_support.ClientService
+		host     container.Host
+		err      error
+	}
+
+	results := make([]retryResult, len(endpoints))
+	var wg sync.WaitGroup
+	for i, ep := range endpoints {
+		wg.Add(1)
+		go func(i int, ep string) {
+			defer wg.Done()
+			a, err := agent.NewClient(ep, m.certs)
+			if err != nil {
+				log.Warn().Err(err).Str("endpoint", ep).Msg("error creating agent client")
+				results[i] = retryResult{endpoint: ep, err: err}
+				return
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+			defer cancel()
+			h, err := a.Host(ctx)
+			if err != nil {
+				log.Warn().Err(err).Str("endpoint", ep).Msg("error fetching host info for agent")
+				results[i] = retryResult{endpoint: ep, err: err}
+				return
+			}
+			results[i] = retryResult{
+				endpoint: ep,
+				hostID:   h.ID,
+				hostName: h.Name,
+				service:  container_support.NewAgentService(a),
+				host:     h,
+			}
+		}(i, ep)
+	}
+	wg.Wait()
+
+	var errs []error
+	var newFailed []string
+
+	m.mu.Lock()
+	for _, r := range results {
+		if r.err != nil {
+			errs = append(errs, r.err)
+			newFailed = append(newFailed, r.endpoint)
+			continue
+		}
+		if _, ok := m.clients[r.hostID]; ok {
+			log.Warn().Str("name", r.hostName).Str("id", r.hostID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+		} else {
+			m.clients[r.hostID] = r.service
+		}
+		h := r.host
+		h.Available = true
+		m.subscribers.Range(func(ctx context.Context, channel chan<- container.Host) bool {
+			// We don't want to block the subscribers in event.go
+			go func(host container.Host) {
+				select {
+				case channel <- host:
+				case <-ctx.Done():
+				}
+			}(h)
+			return true
+		})
+	}
+	retriedSet := make(map[string]bool, len(endpoints))
+	for _, ep := range endpoints {
+		retriedSet[ep] = true
+	}
+	remaining := make([]string, 0)
+	for _, ep := range m.failedAgents {
+		if !retriedSet[ep] {
+			remaining = append(remaining, ep)
+		}
+	}
+	m.failedAgents = append(remaining, newFailed...)
+	m.mu.Unlock()
+
+	return m.List(), errs
 }
 
 func (m *RetriableClientManager) List() []container_support.ClientService {


### PR DESCRIPTION
## Problem

When Dozzle starts with many remote agents configured, `NewRetriableClientManager` iterates over every endpoint **sequentially**. Each `agent.Host()` call either completes a network round-trip or blocks for the full configured timeout before the loop moves to the next endpoint.

With, say, 10 agents each hitting a 10-second `DeadlineExceeded`, startup takes **100 seconds** instead of 10. The same issue exists in `RetryAndList`, which is called periodically to reconnect failed agents — each retry cycle also stalls for `N × timeout`.

Log evidence from a real deployment (sequential, 10s apart):
```
11:44:37 error fetching host info for agent  proxy-4-1
11:44:48 error fetching host info for agent  proxy-4-3   ← +11s
11:44:48 error fetching host info for agent  proxy-4-4
11:44:58 error fetching host info for agent  proxy-4-6   ← +10s
```

## Fix

Fan out a goroutine per endpoint in both `NewRetriableClientManager` and `RetryAndList`, then collect results once all goroutines finish.

**`NewRetriableClientManager`**
- Spawns one goroutine per `clients` entry and one per `agents` entry.
- A local `sync.Mutex` guards concurrent writes to `clientMap`.
- Results flow through buffered channels; both channels are drained after `wg.Wait()`.

**`RetryAndList`**
- Copies `failedAgents` under a read lock so `List`/`Find` callers are never blocked during network I/O.
- Runs all retries concurrently into a pre-allocated `results` slice (index-safe, no channel needed).
- Acquires the write lock only to merge results and rebuild `failedAgents`, preserving any entries added concurrently.

With the fix, startup time equals the slowest single agent timeout instead of their sum.