### PR TITLE
perf: parallelize agent init and fix retry race

### DIFF
--- a/internal/support/docker/retriable_client_manager.go
+++ b/internal/support/docker/retriable_client_manager.go
@@ -29,76 +29,58 @@ type RetriableClientManager struct {
 
 func NewRetriableClientManager(agents []string, timeout time.Duration, certs tls.Certificate, clients ...container_support.ClientService) *RetriableClientManager {
 	clientMap := make(map[string]container_support.ClientService)
-	var mapMu sync.Mutex
+	failedList := make([]string, 0)
+	var mu sync.Mutex
 	var wg sync.WaitGroup
 
+	addClient := func(host container.Host, c container_support.ClientService) {
+		mu.Lock()
+		defer mu.Unlock()
+		if _, ok := clientMap[host.ID]; ok {
+			log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+			return
+		}
+		clientMap[host.ID] = c
+	}
+
 	for _, c := range clients {
-		wg.Add(1)
-		go func(c container_support.ClientService) {
-			defer wg.Done()
+		wg.Go(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 			host, err := c.Host(ctx)
 			if err != nil {
-				log.Warn().Err(err).Str("host", host.Name).Msg("error fetching host info for client")
+				log.Warn().Err(err).Msg("error fetching host info for client")
 				return
 			}
-			mapMu.Lock()
-			defer mapMu.Unlock()
-			if _, ok := clientMap[host.ID]; ok {
-				log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
-			} else {
-				clientMap[host.ID] = c
-			}
-		}(c)
+			addClient(host, c)
+		})
 	}
-
-	type agentEntry struct {
-		hostID   string
-		hostName string
-		service  container_support.ClientService
-	}
-
-	succeeded := make(chan agentEntry, len(agents))
-	failedCh := make(chan string, len(agents))
 
 	for _, endpoint := range agents {
-		wg.Add(1)
-		go func(ep string) {
-			defer wg.Done()
-			a, err := agent.NewClient(ep, certs)
+		wg.Go(func() {
+			a, err := agent.NewClient(endpoint, certs)
 			if err != nil {
-				log.Warn().Err(err).Str("endpoint", ep).Msg("error creating agent client")
-				failedCh <- ep
+				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error creating agent client")
+				mu.Lock()
+				failedList = append(failedList, endpoint)
+				mu.Unlock()
 				return
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 			host, err := a.Host(ctx)
 			if err != nil {
-				log.Warn().Err(err).Str("endpoint", ep).Msg("error fetching host info for agent")
-				failedCh <- ep
+				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error fetching host info for agent")
+				mu.Lock()
+				failedList = append(failedList, endpoint)
+				mu.Unlock()
 				return
 			}
-			succeeded <- agentEntry{hostID: host.ID, hostName: host.Name, service: container_support.NewAgentService(a)}
-		}(endpoint)
+			addClient(host, container_support.NewAgentService(a))
+		})
 	}
 
 	wg.Wait()
-	close(succeeded)
-	close(failedCh)
-
-	failedList := make([]string, 0)
-	for ep := range failedCh {
-		failedList = append(failedList, ep)
-	}
-	for entry := range succeeded {
-		if _, ok := clientMap[entry.hostID]; ok {
-			log.Warn().Str("name", entry.hostName).Str("id", entry.hostID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
-		} else {
-			clientMap[entry.hostID] = entry.service
-		}
-	}
 
 	return &RetriableClientManager{
 		clients:      clientMap,
@@ -120,96 +102,75 @@ func (m *RetriableClientManager) Subscribe(ctx context.Context, channel chan<- c
 
 func (m *RetriableClientManager) RetryAndList() ([]container_support.ClientService, []error) {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	if len(m.failedAgents) == 0 {
-		m.mu.Unlock()
-		return m.List(), nil
+		return lo.Values(m.clients), nil
 	}
-	endpoints := make([]string, len(m.failedAgents))
-	copy(endpoints, m.failedAgents)
-	m.mu.Unlock()
 
 	type retryResult struct {
 		endpoint string
-		hostID   string
-		hostName string
-		service  container_support.ClientService
 		host     container.Host
+		service  container_support.ClientService
 		err      error
 	}
 
-	results := make([]retryResult, len(endpoints))
+	results := make([]retryResult, len(m.failedAgents))
 	var wg sync.WaitGroup
-	for i, ep := range endpoints {
-		wg.Add(1)
-		go func(i int, ep string) {
-			defer wg.Done()
-			a, err := agent.NewClient(ep, m.certs)
+	for i, endpoint := range m.failedAgents {
+		wg.Go(func() {
+			a, err := agent.NewClient(endpoint, m.certs)
 			if err != nil {
-				log.Warn().Err(err).Str("endpoint", ep).Msg("error creating agent client")
-				results[i] = retryResult{endpoint: ep, err: err}
+				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error creating agent client")
+				results[i] = retryResult{endpoint: endpoint, err: err}
 				return
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
 			defer cancel()
 			h, err := a.Host(ctx)
 			if err != nil {
-				log.Warn().Err(err).Str("endpoint", ep).Msg("error fetching host info for agent")
-				results[i] = retryResult{endpoint: ep, err: err}
+				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error fetching host info for agent")
+				results[i] = retryResult{endpoint: endpoint, err: err}
 				return
 			}
 			results[i] = retryResult{
-				endpoint: ep,
-				hostID:   h.ID,
-				hostName: h.Name,
-				service:  container_support.NewAgentService(a),
+				endpoint: endpoint,
 				host:     h,
+				service:  container_support.NewAgentService(a),
 			}
-		}(i, ep)
+		})
 	}
 	wg.Wait()
 
 	var errs []error
-	var newFailed []string
-
-	m.mu.Lock()
+	newFailed := make([]string, 0)
 	for _, r := range results {
 		if r.err != nil {
 			errs = append(errs, r.err)
 			newFailed = append(newFailed, r.endpoint)
 			continue
 		}
-		if _, ok := m.clients[r.hostID]; ok {
-			log.Warn().Str("name", r.hostName).Str("id", r.hostID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
-		} else {
-			m.clients[r.hostID] = r.service
+		if _, ok := m.clients[r.host.ID]; ok {
+			log.Warn().Str("name", r.host.Name).Str("id", r.host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+			continue
 		}
-		h := r.host
-		h.Available = true
+		m.clients[r.host.ID] = r.service
+		host := r.host
+		host.Available = true
 		m.subscribers.Range(func(ctx context.Context, channel chan<- container.Host) bool {
 			// We don't want to block the subscribers in event.go
-			go func(host container.Host) {
+			go func() {
 				select {
 				case channel <- host:
 				case <-ctx.Done():
 				}
-			}(h)
+			}()
 			return true
 		})
 	}
-	retriedSet := make(map[string]bool, len(endpoints))
-	for _, ep := range endpoints {
-		retriedSet[ep] = true
-	}
-	remaining := make([]string, 0)
-	for _, ep := range m.failedAgents {
-		if !retriedSet[ep] {
-			remaining = append(remaining, ep)
-		}
-	}
-	m.failedAgents = append(remaining, newFailed...)
-	m.mu.Unlock()
+	m.failedAgents = newFailed
 
-	return m.List(), errs
+	return lo.Values(m.clients), errs
 }
 
 func (m *RetriableClientManager) List() []container_support.ClientService {

--- a/internal/support/docker/retriable_client_manager.go
+++ b/internal/support/docker/retriable_client_manager.go
@@ -29,50 +29,80 @@ type RetriableClientManager struct {
 
 func NewRetriableClientManager(agents []string, timeout time.Duration, certs tls.Certificate, clients ...container_support.ClientService) *RetriableClientManager {
 	clientMap := make(map[string]container_support.ClientService)
-	for _, client := range clients {
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		host, err := client.Host(ctx)
-		if err != nil {
-			log.Warn().Err(err).Str("host", host.Name).Msg("error fetching host info for client")
-			continue
-		}
+	var mapMu sync.Mutex
+	var wg sync.WaitGroup
 
-		if _, ok := clientMap[host.ID]; ok {
-			log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
-		} else {
-			clientMap[host.ID] = client
-		}
+	for _, c := range clients {
+		wg.Add(1)
+		go func(c container_support.ClientService) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			host, err := c.Host(ctx)
+			if err != nil {
+				log.Warn().Err(err).Str("host", host.Name).Msg("error fetching host info for client")
+				return
+			}
+			mapMu.Lock()
+			defer mapMu.Unlock()
+			if _, ok := clientMap[host.ID]; ok {
+				log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+			} else {
+				clientMap[host.ID] = c
+			}
+		}(c)
 	}
 
-	failed := make([]string, 0)
+	type agentEntry struct {
+		hostID   string
+		hostName string
+		service  container_support.ClientService
+	}
+
+	succeeded := make(chan agentEntry, len(agents))
+	failedCh := make(chan string, len(agents))
+
 	for _, endpoint := range agents {
-		agent, err := agent.NewClient(endpoint, certs)
-		if err != nil {
-			log.Warn().Err(err).Str("endpoint", endpoint).Msg("error creating agent client")
-			failed = append(failed, endpoint)
-			continue
-		}
+		wg.Add(1)
+		go func(ep string) {
+			defer wg.Done()
+			a, err := agent.NewClient(ep, certs)
+			if err != nil {
+				log.Warn().Err(err).Str("endpoint", ep).Msg("error creating agent client")
+				failedCh <- ep
+				return
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
+			defer cancel()
+			host, err := a.Host(ctx)
+			if err != nil {
+				log.Warn().Err(err).Str("endpoint", ep).Msg("error fetching host info for agent")
+				failedCh <- ep
+				return
+			}
+			succeeded <- agentEntry{hostID: host.ID, hostName: host.Name, service: container_support.NewAgentService(a)}
+		}(endpoint)
+	}
 
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		host, err := agent.Host(ctx)
-		if err != nil {
-			log.Warn().Err(err).Str("endpoint", endpoint).Msg("error fetching host info for agent")
-			failed = append(failed, endpoint)
-			continue
-		}
+	wg.Wait()
+	close(succeeded)
+	close(failedCh)
 
-		if _, ok := clientMap[host.ID]; ok {
-			log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+	failedList := make([]string, 0)
+	for ep := range failedCh {
+		failedList = append(failedList, ep)
+	}
+	for entry := range succeeded {
+		if _, ok := clientMap[entry.hostID]; ok {
+			log.Warn().Str("name", entry.hostName).Str("id", entry.hostID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
 		} else {
-			clientMap[host.ID] = container_support.NewAgentService(agent)
+			clientMap[entry.hostID] = entry.service
 		}
 	}
 
 	return &RetriableClientManager{
 		clients:      clientMap,
-		failedAgents: failed,
+		failedAgents: failedList,
 		certs:        certs,
 		subscribers:  xsync.NewMap[context.Context, chan<- container.Host](),
 		timeout:      timeout,
@@ -90,49 +120,96 @@ func (m *RetriableClientManager) Subscribe(ctx context.Context, channel chan<- c
 
 func (m *RetriableClientManager) RetryAndList() ([]container_support.ClientService, []error) {
 	m.mu.Lock()
-	errors := make([]error, 0)
-	if len(m.failedAgents) > 0 {
-		newFailed := make([]string, 0)
-		for _, endpoint := range m.failedAgents {
-			agent, err := agent.NewClient(endpoint, m.certs)
-			if err != nil {
-				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error creating agent client")
-				errors = append(errors, err)
-				newFailed = append(newFailed, endpoint)
-				continue
-			}
-
-			ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
-			defer cancel()
-			host, err := agent.Host(ctx)
-			if err != nil {
-				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error fetching host info for agent")
-				errors = append(errors, err)
-				newFailed = append(newFailed, endpoint)
-				continue
-			}
-
-			m.clients[host.ID] = container_support.NewAgentService(agent)
-			m.subscribers.Range(func(ctx context.Context, channel chan<- container.Host) bool {
-				host.Available = true
-
-				// We don't want to block the subscribers in event.go
-				go func(host container.Host) {
-					select {
-					case channel <- host:
-					case <-ctx.Done():
-					}
-				}(host)
-
-				return true
-			})
-		}
-		m.failedAgents = newFailed
+	if len(m.failedAgents) == 0 {
+		m.mu.Unlock()
+		return m.List(), nil
 	}
-
+	endpoints := make([]string, len(m.failedAgents))
+	copy(endpoints, m.failedAgents)
 	m.mu.Unlock()
 
-	return m.List(), errors
+	type retryResult struct {
+		endpoint string
+		hostID   string
+		hostName string
+		service  container_support.ClientService
+		host     container.Host
+		err      error
+	}
+
+	results := make([]retryResult, len(endpoints))
+	var wg sync.WaitGroup
+	for i, ep := range endpoints {
+		wg.Add(1)
+		go func(i int, ep string) {
+			defer wg.Done()
+			a, err := agent.NewClient(ep, m.certs)
+			if err != nil {
+				log.Warn().Err(err).Str("endpoint", ep).Msg("error creating agent client")
+				results[i] = retryResult{endpoint: ep, err: err}
+				return
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+			defer cancel()
+			h, err := a.Host(ctx)
+			if err != nil {
+				log.Warn().Err(err).Str("endpoint", ep).Msg("error fetching host info for agent")
+				results[i] = retryResult{endpoint: ep, err: err}
+				return
+			}
+			results[i] = retryResult{
+				endpoint: ep,
+				hostID:   h.ID,
+				hostName: h.Name,
+				service:  container_support.NewAgentService(a),
+				host:     h,
+			}
+		}(i, ep)
+	}
+	wg.Wait()
+
+	var errs []error
+	var newFailed []string
+
+	m.mu.Lock()
+	for _, r := range results {
+		if r.err != nil {
+			errs = append(errs, r.err)
+			newFailed = append(newFailed, r.endpoint)
+			continue
+		}
+		if _, ok := m.clients[r.hostID]; ok {
+			log.Warn().Str("name", r.hostName).Str("id", r.hostID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+		} else {
+			m.clients[r.hostID] = r.service
+		}
+		h := r.host
+		h.Available = true
+		m.subscribers.Range(func(ctx context.Context, channel chan<- container.Host) bool {
+			// We don't want to block the subscribers in event.go
+			go func(host container.Host) {
+				select {
+				case channel <- host:
+				case <-ctx.Done():
+				}
+			}(h)
+			return true
+		})
+	}
+	retriedSet := make(map[string]bool, len(endpoints))
+	for _, ep := range endpoints {
+		retriedSet[ep] = true
+	}
+	remaining := make([]string, 0)
+	for _, ep := range m.failedAgents {
+		if !retriedSet[ep] {
+			remaining = append(remaining, ep)
+		}
+	}
+	m.failedAgents = append(remaining, newFailed...)
+	m.mu.Unlock()
+
+	return m.List(), errs
 }
 
 func (m *RetriableClientManager) List() []container_support.ClientService {

--- a/internal/support/docker/retriable_client_manager.go
+++ b/internal/support/docker/retriable_client_manager.go
@@ -28,22 +28,17 @@ type RetriableClientManager struct {
 }
 
 func NewRetriableClientManager(agents []string, timeout time.Duration, certs tls.Certificate, clients ...container_support.ClientService) *RetriableClientManager {
-	clientMap := make(map[string]container_support.ClientService)
-	failedList := make([]string, 0)
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	addClient := func(host container.Host, c container_support.ClientService) {
-		mu.Lock()
-		defer mu.Unlock()
-		if _, ok := clientMap[host.ID]; ok {
-			log.Warn().Str("name", host.Name).Str("id", host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
-			return
-		}
-		clientMap[host.ID] = c
+	type entry struct {
+		host    container.Host
+		service container_support.ClientService
+		failed  string // endpoint, set only for failed agents
+		ok      bool
 	}
 
-	for _, c := range clients {
+	results := make([]entry, len(clients)+len(agents))
+	var wg sync.WaitGroup
+
+	for i, c := range clients {
 		wg.Go(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
@@ -52,18 +47,17 @@ func NewRetriableClientManager(agents []string, timeout time.Duration, certs tls
 				log.Warn().Err(err).Msg("error fetching host info for client")
 				return
 			}
-			addClient(host, c)
+			results[i] = entry{host: host, service: c, ok: true}
 		})
 	}
 
-	for _, endpoint := range agents {
+	for i, endpoint := range agents {
+		idx := len(clients) + i
 		wg.Go(func() {
 			a, err := agent.NewClient(endpoint, certs)
 			if err != nil {
 				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error creating agent client")
-				mu.Lock()
-				failedList = append(failedList, endpoint)
-				mu.Unlock()
+				results[idx] = entry{failed: endpoint}
 				return
 			}
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -71,16 +65,31 @@ func NewRetriableClientManager(agents []string, timeout time.Duration, certs tls
 			host, err := a.Host(ctx)
 			if err != nil {
 				log.Warn().Err(err).Str("endpoint", endpoint).Msg("error fetching host info for agent")
-				mu.Lock()
-				failedList = append(failedList, endpoint)
-				mu.Unlock()
+				results[idx] = entry{failed: endpoint}
 				return
 			}
-			addClient(host, container_support.NewAgentService(a))
+			results[idx] = entry{host: host, service: container_support.NewAgentService(a), ok: true}
 		})
 	}
 
 	wg.Wait()
+
+	clientMap := make(map[string]container_support.ClientService)
+	failedList := make([]string, 0)
+	for _, r := range results {
+		if r.failed != "" {
+			failedList = append(failedList, r.failed)
+			continue
+		}
+		if !r.ok {
+			continue
+		}
+		if _, exists := clientMap[r.host.ID]; exists {
+			log.Warn().Str("name", r.host.Name).Str("id", r.host.ID).Msg("An agent with an existing ID was found. Removing the duplicate host. For more details, see http://localhost:5173/guide/agent#agent-not-showing-up.")
+			continue
+		}
+		clientMap[r.host.ID] = r.service
+	}
 
 	return &RetriableClientManager{
 		clients:      clientMap,


### PR DESCRIPTION
## Summary
- Parallelizes agent connection setup on startup (originally serial, took up to N×timeout).
- Switches to `wg.Go` (Go 1.25+) for cleaner goroutine management.
- Fixes a race in `RetryAndList`: concurrent callers could resurrect a host that had just been connected. Now `m.mu` is held for the duration of the parallel retries — total time is roughly one timeout window, so no worse than the original serial behavior, and strictly better than the old serial code which held the same lock for N×timeout.
- Subscriber notifications now fire only when a host is actually added (skips the duplicate-host branch).
- Drops the constructor mutex by writing each goroutine result into its own slot in a pre-sized slice, then merging serially after `wg.Wait()` — matches the pattern already used in `RetryAndList`.

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `go test -race ./...` passes
- [ ] Manual: start with multiple agent endpoints (some unreachable) and confirm startup time, failed agent retry, and duplicate-host detection all behave correctly