### PR TITLE
docs: add /data volume mount to README install examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Dozzle is a small container (7 MB compressed). Pull the latest release with:
 
 The simplest way to use Dozzle is to run the Docker container. Mount the Docker Unix socket with `--volume` to `/var/run/docker.sock`:
 
-    $ docker run --name dozzle -d --volume=/var/run/docker.sock:/var/run/docker.sock -p 8080:8080 amir20/dozzle:latest
+    $ docker run --name dozzle -d --volume=/var/run/docker.sock:/var/run/docker.sock -v dozzle_data:/data -p 8080:8080 amir20/dozzle:latest
 
 Dozzle will be available at [http://localhost:8080/](http://localhost:8080/).
 
@@ -53,8 +53,11 @@ Here is a Docker Compose example:
         image: amir20/dozzle:latest
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
+          - dozzle_data:/data
         ports:
           - 8080:8080
+    volumes:
+      dozzle_data:
 
 For advanced options like [authentication](https://dozzle.dev/guide/authentication), [remote hosts](https://dozzle.dev/guide/remote-hosts), or common [questions](https://dozzle.dev/guide/faq), see the documentation at [dozzle.dev](https://dozzle.dev/guide/getting-started).
 


### PR DESCRIPTION
## Summary
- Adds `dozzle_data:/data` volume mount to both the `docker run` and Docker Compose examples in the README
- Without this, the instance ID isn't persisted across restarts, which causes duplicate Cloud registrations (reported in #4659)

## Test plan
- [x] Verified compose snippet matches the pattern in `docs/guide/getting-started.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)