### PR TITLE
chore: polish settings and dashboard pages

### DIFF
--- a/assets/pages/index.vue
+++ b/assets/pages/index.vue
@@ -13,7 +13,7 @@
     </section>
 
     <section>
-      <div class="mb-2 flex items-center justify-between">
+      <div class="mb-4 flex items-center justify-between">
         <h2 class="text-lg font-semibold">
           {{ $t("label.container", { count: runningContainers.length }) }}
         </h2>
@@ -42,7 +42,6 @@ const { containers, ready } = storeToRefs(containerStore) as unknown as {
 
 const runningContainers = computed(() => containers.value.filter((c) => c.state === "running"));
 
-// Persist collapse state in localStorage
 const hostsCollapsed = useStorage("DOZZLE_HOSTS_COLLAPSED", false);
 const containersCollapsed = useStorage("DOZZLE_CONTAINERS_COLLAPSED", false);
 
@@ -60,7 +59,9 @@ watchEffect(() => {
 
 .collapse-enter-active,
 .collapse-leave-active {
-  transition: all 0.2s ease;
+  transition:
+    opacity 200ms cubic-bezier(0.22, 1, 0.36, 1),
+    max-height 240ms cubic-bezier(0.22, 1, 0.36, 1);
   overflow: hidden;
 }
 
@@ -68,5 +69,12 @@ watchEffect(() => {
 .collapse-leave-to {
   opacity: 0;
   max-height: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .collapse-enter-active,
+  .collapse-leave-active {
+    transition: none;
+  }
 }
 </style>

--- a/assets/pages/settings.vue
+++ b/assets/pages/settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="@container flex flex-col gap-5 px-4 py-4 md:px-8">
+  <div class="@container flex flex-col gap-8 px-4 py-4 md:px-8">
     <section>
       <Links>
         <template #more-items>
@@ -16,10 +16,10 @@
       </div>
 
       <div class="border-base-content/15 bg-base-200/40 divide-base-content/10 divide-y rounded-lg border">
-        <div class="flex flex-col gap-2 p-5">
+        <div class="flex flex-col gap-2 p-4">
           <div class="flex flex-wrap items-center gap-3">
             <span class="text-2xl font-semibold tracking-tight">Dozzle</span>
-            <span class="status-pill status-pill-neutral">{{ config.version }}</span>
+            <span class="status-pill status-pill-neutral font-mono">{{ config.version }}</span>
             <a
               v-if="hasRelease"
               :href="latestRelease?.htmlUrl"
@@ -36,7 +36,7 @@
               Latest release {{ latestRelease.name }} ·
               {{ new Date(latestRelease.createdAt).toLocaleDateString(undefined, dateFmt) }}
             </template>
-            <template v-else> You're running the latest version. </template>
+            <template v-else>You're running the latest version.</template>
           </div>
         </div>
 
@@ -61,7 +61,7 @@
               href="https://buymeacoffee.com/amirraminfar"
               target="_blank"
               rel="noopener noreferrer"
-              class="btn btn-secondary btn-sm"
+              class="btn btn-sm"
             >
               <mdi:beer /> Buy me a beer
             </a>
@@ -110,7 +110,7 @@
           </label>
           <div class="flex min-h-13 flex-wrap items-center justify-between gap-3 p-4 text-sm font-medium">
             <span>{{ $t("settings.datetime-format") }}</span>
-            <div class="ml-auto flex gap-1.5">
+            <div class="ml-auto flex flex-wrap gap-2">
               <DropdownMenu
                 v-model="dateLocale"
                 :options="[
@@ -222,7 +222,10 @@
           />
         </div>
         <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-          <span>{{ $t("settings.search") }} <key-shortcut char="f" class="align-top"></key-shortcut></span>
+          <span class="inline-flex items-center gap-2">
+            {{ $t("settings.search") }}
+            <key-shortcut char="f" />
+          </span>
           <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="search" />
         </label>
         <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">


### PR DESCRIPTION
## Summary

Restrained polish pass on `assets/pages/settings.vue` and `assets/pages/index.vue` — no behavior changes, no redesign.

**settings.vue**
- Section gap `gap-5` → `gap-8` so the four sections read as distinct groups
- About card: `p-5` → `p-4` to match the row pattern used elsewhere; version pill now `font-mono` to match the release line below it
- Sponsor row: demoted "Buy me a beer" from `btn-secondary` to plain `btn` so the page has a single accent (Sponsor on GitHub) instead of two competing colored CTAs
- Datetime dropdowns: `gap-1.5` → `gap-2` (on spacing scale) and added `flex-wrap` so the two pickers stack cleanly on narrow widths
- Search row: wrapped label + `<key-shortcut>` in `inline-flex items-center gap-2`, dropping the `align-top` hack
- Cleaned stray whitespace inside the "latest version" template

**index.vue**
- Second section margin `mb-2` → `mb-4` to match the first (drift between two visually-identical sections)
- Removed redundant `// Persist collapse state in localStorage` comment
- Replaced `transition: all 0.2s ease` with explicit `opacity` + `max-height` declarations using `cubic-bezier(0.22, 1, 0.36, 1)` (ease-out-quart)
- Added `prefers-reduced-motion: reduce` opt-out

## Test plan

- [ ] Settings page: visual diff at narrow / wide widths, confirm sponsor row reads as one CTA
- [ ] Settings page: datetime dropdowns wrap cleanly on small screens
- [ ] Dashboard: hosts/containers collapse animation feels natural; collapse is instant under reduced-motion
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)