### PR TITLE
fix(cloud): reconnect on unlink/relink so new key takes effect

### DIFF
--- a/internal/cloud/client.go
+++ b/internal/cloud/client.go
@@ -176,6 +176,10 @@ func (c *Client) Run(ctx context.Context) {
 				case <-ctx.Done():
 					return
 				case <-backoffTimer.C:
+				case <-c.startCh:
+					if !backoffTimer.Stop() {
+						<-backoffTimer.C
+					}
 				}
 				backoff = initialBackoff
 				continue
@@ -189,6 +193,11 @@ func (c *Client) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-backoffTimer.C:
+		case <-c.startCh:
+			if !backoffTimer.Stop() {
+				<-backoffTimer.C
+			}
+			backoff = initialBackoff
 		}
 
 		backoff = min(backoff*backoffFactor, maxBackoff)

--- a/internal/web/cloud.go
+++ b/internal/web/cloud.go
@@ -94,6 +94,11 @@ func (h *handler) cloudCallback(w http.ResponseWriter, r *http.Request) {
 	}
 	h.hostService.SetCloudConfig(cc)
 
+	// Drop any existing connection so a relink with a new key takes effect
+	// immediately instead of riding out the old stream.
+	if h.config.OnCloudUpdate != nil {
+		h.config.OnCloudUpdate()
+	}
 	if h.config.OnCloudSetup != nil {
 		h.config.OnCloudSetup()
 	}
@@ -239,6 +244,12 @@ func (h *handler) updateCloudConfig(w http.ResponseWriter, r *http.Request) {
 
 func (h *handler) deleteCloudConfig(w http.ResponseWriter, r *http.Request) {
 	h.hostService.RemoveCloudConfig()
+	// Drop the active cloud connection so the server stops seeing this
+	// instance immediately, instead of riding out the existing stream with
+	// a now-deleted key.
+	if h.config.OnCloudUpdate != nil {
+		h.config.OnCloudUpdate()
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 


### PR DESCRIPTION
## Summary
- Unlinking the cloud only cleared config — the active gRPC stream kept running with the deleted key.
- Relinking only called `Notify`, but `Run()` is blocked inside `connect()` so the signal sat unread; the new key wasn't picked up until restart.
- The 1h `Unauthenticated` pause also ignored `startCh`, extending the window further if the server rejected the deleted key.

Fix: call `OnCloudUpdate` (Reconnect) on both unlink and relink so the active stream is dropped, and let `Notify` interrupt the unauthenticated pause and the regular backoff sleep.

## Test plan
- [x] `go test ./internal/cloud/... ./internal/web/...`
- [ ] Manual: link cloud, unlink, relink — verify gRPC connection re-establishes without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)