### PR TITLE
fix(web): reject cross-origin WebSocket upgrades on attach/exec

### DIFF
--- a/internal/web/terminal.go
+++ b/internal/web/terminal.go
@@ -12,12 +12,13 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// upgrader uses gorilla/websocket's default same-origin CheckOrigin.
+// Allowing arbitrary origins enables Cross-Site WebSocket Hijacking against
+// /attach and /exec when the user is authenticated (the JWT cookie is
+// SameSite=Lax, which still attaches on same-site cross-origin requests).
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		return true
-	},
 }
 
 func (h *handler) attach(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/terminal_test.go
+++ b/internal/web/terminal_test.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newUpgradeServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		conn.Close()
+	}))
+}
+
+func dialUpgrade(t *testing.T, srv *httptest.Server, origin string) (*http.Response, error) {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	header := http.Header{}
+	if origin != "" {
+		header.Set("Origin", origin)
+	}
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if conn != nil {
+		conn.Close()
+	}
+	return resp, err
+}
+
+func TestUpgrader_SameOriginSucceeds(t *testing.T) {
+	srv := newUpgradeServer(t)
+	defer srv.Close()
+
+	resp, err := dialUpgrade(t, srv, srv.URL)
+	require.NoError(t, err)
+	if resp != nil {
+		assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	}
+}
+
+func TestUpgrader_NoOriginSucceeds(t *testing.T) {
+	// Non-browser clients (curl, scripts) don't send Origin — must still work.
+	srv := newUpgradeServer(t)
+	defer srv.Close()
+
+	resp, err := dialUpgrade(t, srv, "")
+	require.NoError(t, err)
+	if resp != nil {
+		assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	}
+}
+
+func TestUpgrader_CrossOriginRejected(t *testing.T) {
+	srv := newUpgradeServer(t)
+	defer srv.Close()
+
+	resp, err := dialUpgrade(t, srv, "http://evil.example.com")
+	assert.Error(t, err, "cross-origin upgrade must be rejected")
+	if resp != nil {
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	}
+}
+
+func TestUpgrader_DifferentPortSameHostRejected(t *testing.T) {
+	// Same-site different-origin (e.g. localhost:8888 vs localhost:9090) is
+	// the realistic CSWSH vector. The default origin check rejects it because
+	// host:port differs from the request's Host header.
+	srv := newUpgradeServer(t)
+	defer srv.Close()
+
+	resp, err := dialUpgrade(t, srv, "http://localhost:1")
+	assert.Error(t, err, "different-port same-host upgrade must be rejected")
+	if resp != nil {
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

The WebSocket upgrader for `/attach` and `/exec` overrode `CheckOrigin` to always return `true`, which disabled the only browser-side defense against Cross-Site WebSocket Hijacking. The JWT cookie is `SameSite=Lax`, which is correct for most flows but still attaches the cookie on same-site cross-origin requests (sibling subdomains under the same eTLD+1, or other services sharing `localhost`). With both in place, a page the victim visits could open an authenticated WebSocket to Dozzle and gain shell access in any container the victim is authorized to use.

The fix drops the custom `CheckOrigin` and uses gorilla/websocket's default, which:

- accepts same-origin browser clients (the Dozzle UI continues to work)
- accepts non-browser clients with no `Origin` header (CLI/scripted callers continue to work)
- rejects cross-origin browser requests with `403`

`SameSite=Lax` on the JWT cookie is intentionally kept — bumping to `Strict` would break the common UX of clicking a Dozzle link from another tab/app and staying logged in.

## Test plan

- [x] `go test -race ./internal/web/...` passes
- [x] New `terminal_test.go` covers same-origin success, no-Origin success, cross-origin rejection, and same-host different-port rejection
- [ ] Manual: open a container terminal in the Dozzle UI — still works
- [ ] Manual: from a page on a different origin, attempt to open a WebSocket to `/attach` or `/exec` — `403` returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)