### PR TITLE
fix(docker): use cancellable context in ContainerEvents and close event channel

### DIFF
--- a/internal/docker/stats_collector.go
+++ b/internal/docker/stats_collector.go
@@ -115,8 +115,9 @@ func (sc *DockerStatsCollector) Start(parentCtx context.Context) bool {
 	events := make(chan container.ContainerEvent)
 
 	go func() {
+		defer close(events)
 		log.Debug().Str("host", sc.client.Host().Name).Msg("starting to listen to docker events")
-		err := sc.client.ContainerEvents(context.Background(), events)
+		err := sc.client.ContainerEvents(ctx, events)
 		if !errors.Is(err, context.Canceled) {
 			log.Error().Str("host", sc.client.Host().Name).Err(err).Msg("unexpected error while listening to docker events")
 		}


### PR DESCRIPTION


ContainerEvents was previously called with context.Background(), ignoring the collector's lifecycle context. On host disconnect or forceStop(), the event subscription continued running indefinitely.

This change switches to a cancellable context so the subscription properly terminates with the collector lifecycle.

Also adds `defer close(events)` so the consumer goroutine (`for range events`) exits when the producer returns, preventing a second goroutine leak.