### PR TITLE
fix(security): block 0.0.0.0/8 and broadcast in SSRF webhook guard

### DIFF
--- a/internal/notification/dispatcher/webhook.go
+++ b/internal/notification/dispatcher/webhook.go
@@ -26,13 +26,28 @@ import (
 // live on private LANs.
 var errBlockedAddress = errors.New("webhook target resolves to a blocked address range")
 
+// zeroNetV4 covers 0.0.0.0/8 — on Linux these route to the local host.
+var zeroNetV4 = &net.IPNet{IP: net.IP{0, 0, 0, 0}, Mask: net.CIDRMask(8, 32)}
+
 func isBlockedIP(ip net.IP) bool {
-	return ip.IsLoopback() ||
+	if ip.IsLoopback() ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
 		ip.IsMulticast() ||
 		ip.IsInterfaceLocalMulticast() ||
-		ip.IsUnspecified()
+		ip.IsUnspecified() {
+		return true
+	}
+	// 0.0.0.0/8: only 0.0.0.0 is caught by IsUnspecified; 0.x.x.x routes to
+	// localhost on Linux and is abusable as an SSRF vector.
+	if v4 := ip.To4(); v4 != nil && zeroNetV4.Contains(v4) {
+		return true
+	}
+	// 255.255.255.255 limited broadcast
+	if ip.Equal(net.IPv4bcast) {
+		return true
+	}
+	return false
 }
 
 func safeDialContext(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/internal/notification/dispatcher/webhook_test.go
+++ b/internal/notification/dispatcher/webhook_test.go
@@ -226,6 +226,9 @@ func TestIsBlockedIP(t *testing.T) {
 		"fe80::1",
 		"224.0.0.1",
 		"0.0.0.0",
+		"0.1.2.3",       // 0.0.0.0/8 — routes to localhost on Linux
+		"0.255.255.255", // top of 0.0.0.0/8
+		"255.255.255.255", // limited broadcast
 	}
 	for _, s := range blocked {
 		ip := net.ParseIP(s)


### PR DESCRIPTION
Problem
                                                                                                                                                              
  isBlockedIP in the webhook SSRF guard missed two address ranges:
                                                                                                                                                              
  - 0.0.0.0/8 — only the exact address 0.0.0.0 was caught by IsUnspecified(). Addresses like 0.1.2.3 through 0.255.255.255 were allowed through. On Linux, these route to the local host, making them a viable SSRF bypass vector.                                                                                     
  - 255.255.255.255 — limited broadcast address, not covered by any existing check.                                                                           
                                                                                                                                                              
  An attacker controlling a webhook URL (or DNS) could point to http://0.1.2.3/ to reach local services on the Dozzle host.                                   
                                                                                                                                                              
  Fix                                                                                                                                                         
                                                            
  - Added zeroNetV4 (0.0.0.0/8) CIDR check in isBlockedIP for IPv4 addresses                                                                                  
  - Added explicit block for net.IPv4bcast (255.255.255.255)
  - Extended TestIsBlockedIP to cover 0.1.2.3, 0.255.255.255, and 255.255.255.255                                                                             
                                                                                                                                                              
  Scope                                                                                                                                                       
                                                                                                                                                              
 No behavior change for legitimate webhooks. RFC1918 private ranges (192.168.x.x, 10.x.x.x, 172.16-31.x.x) remain allowed.                                   
  
