### PR TITLE
feat(notifications): add duplicate destination
  action

### DIFF
--- a/assets/components/Notification/DestinationCard.vue
+++ b/assets/components/Notification/DestinationCard.vue
@@ -28,6 +28,9 @@
               <a @click="editDestination">{{ $t("notifications.destination.edit") }}</a>
             </li>
             <li v-if="destination.type !== 'cloud'">
+              <a @click="duplicateDestination">{{ $t("notifications.destination.duplicate") }}</a>
+            </li>
+            <li v-if="destination.type !== 'cloud'">
               <a class="text-error" @click="deleteDestination">{{ $t("notifications.destination.delete") }}</a>
             </li>
           </ul>
@@ -59,6 +62,21 @@ function editDestination() {
     },
     "md",
   );
+}
+
+async function duplicateDestination() {
+  await fetch(withBase("/api/notifications/dispatchers"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: `Copy of ${destination.name}`,
+      type: destination.type,
+      url: destination.url,
+      template: destination.template,
+      headers: destination.headers,
+    }),
+  });
+  onUpdated?.();
 }
 
 async function deleteDestination() {

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -255,6 +255,7 @@ notifications:
     http-webhook: HTTP Webhook
     dozzle-cloud: Dozzle Cloud
     edit: Edit
+    duplicate: Duplicate
     delete: Delete
   alert-form:
     create-title: Create Alert


### PR DESCRIPTION
Hi @amir20,

This PR adds a "Duplicate" menu item to the destination card
  dropdown (webhook only).

  - Copies name, type, url, template, and headers with a "Copy of …"
  prefix
  - Calls existing POST /api/notifications/dispatchers endpoint
  - Adds `duplicate` i18n key to en.yml
  

I need this all the time, might be useful for other people as well. :)
<img width="2025" height="680" alt="image" src="https://github.com/user-attachments/assets/f7e9dec2-e163-44e9-9846-56f4194f0281" />
