### PR TITLE
fix: debounce SSE connection error toast

### DIFF
--- a/assets/stores/container.ts
+++ b/assets/stores/container.ts
@@ -31,21 +31,26 @@ export const useContainerStore = defineStore("container", () => {
     return containers.value.filter(filter);
   });
 
+  let errorTimer: ReturnType<typeof setTimeout> | null = null;
+
   function connect() {
     es?.close();
     ready.value = false;
     es = new EventSource(withBase("/api/events/stream"));
     es.addEventListener("error", (e) => {
-      if (es?.readyState === EventSource.CONNECTING) {
-        showToast(
-          {
-            id: "events-stream",
-            message: t("error.events-stream.message"),
-            title: t("error.events-stream.title"),
-            type: "error",
-          },
-          { once: true },
-        );
+      if (es?.readyState === EventSource.CONNECTING && errorTimer === null) {
+        errorTimer = setTimeout(() => {
+          errorTimer = null;
+          showToast(
+            {
+              id: "events-stream",
+              message: t("error.events-stream.message"),
+              title: t("error.events-stream.title"),
+              type: "error",
+            },
+            { once: true },
+          );
+        }, 5000);
       }
     });
 
@@ -102,6 +107,10 @@ export const useContainerStore = defineStore("container", () => {
     });
 
     es.onopen = () => {
+      if (errorTimer !== null) {
+        clearTimeout(errorTimer);
+        errorTimer = null;
+      }
       removeToast("events-stream");
       if (containers.value.length > 0) {
         containers.value = [];


### PR DESCRIPTION
## Summary
- Wraps the "Unexpected Error" toast in a 5s timer so transient EventSource disconnects (mobile network blips, cell↔wifi handoff, backgrounded tabs) no longer flash a false-positive error
- Timer is cancelled in `onopen` when the stream recovers in time

## Test plan
- [ ] Open Dozzle on mobile, lock/unlock the device, confirm no toast appears for short reconnects
- [ ] Stop the backend for >5s and confirm the toast still appears
- [ ] Restart the backend and confirm the toast clears via `onopen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)