### PR TITLE
feat: add inverse/exclude filter to log search

### DIFF
--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -125,6 +125,8 @@ declare module 'vue' {
     'Mdi:cog': typeof import('~icons/mdi/cog')['default']
     'Mdi:contentCopy': typeof import('~icons/mdi/content-copy')['default']
     'Mdi:docker': typeof import('~icons/mdi/docker')['default']
+    'Mdi:filterOffOutline': typeof import('~icons/mdi/filter-off-outline')['default']
+    'Mdi:filterOutline': typeof import('~icons/mdi/filter-outline')['default']
     'Mdi:flash': typeof import('~icons/mdi/flash')['default']
     'Mdi:gauge': typeof import('~icons/mdi/gauge')['default']
     'Mdi:github': typeof import('~icons/mdi/github')['default']

--- a/assets/components/Search.vue
+++ b/assets/components/Search.vue
@@ -17,6 +17,15 @@
           v-model="searchQueryFilter"
           @keyup.esc="resetSearch()"
         />
+        <button
+          class="btn btn-circle btn-xs"
+          :class="inverseFilter ? 'btn-error' : 'btn-ghost'"
+          @click="toggleInverse()"
+          :title="inverseFilter ? 'Exclude matching (inverse)' : 'Include matching (normal)'"
+        >
+          <mdi:filter-off-outline v-if="inverseFilter" />
+          <mdi:filter-outline v-else />
+        </button>
         <a class="btn btn-circle btn-xs" @click="resetSearch()"> <mdi:close /></a>
       </div>
     </div>
@@ -26,7 +35,7 @@
 <script lang="ts" setup>
 const input = ref<HTMLInputElement>();
 const container = ref<HTMLDivElement>();
-const { searchQueryFilter, showSearch, resetSearch, isValidQuery } = useSearchFilter();
+const { searchQueryFilter, showSearch, resetSearch, isValidQuery, inverseFilter, toggleInverse } = useSearchFilter();
 
 const { style } = useDraggable(container);
 

--- a/assets/composable/downloadUrl.ts
+++ b/assets/composable/downloadUrl.ts
@@ -7,7 +7,7 @@ export function useDownloadUrl(
   levels: Ref<Set<string>>,
   name?: Ref<string> | ComputedRef<string> | string,
 ) {
-  const { debouncedSearchFilter } = useSearchFilter();
+  const { debouncedSearchFilter, inverseFilter } = useSearchFilter();
 
   const downloadUrl = computed(() => {
     const params = new URLSearchParams();
@@ -20,6 +20,7 @@ export function useDownloadUrl(
     // Add filter if search is active
     if (debouncedSearchFilter.value) {
       params.append("filter", debouncedSearchFilter.value);
+      if (inverseFilter.value) params.append("inverse", "true");
     }
 
     // Add levels (multiple values) only if filtered

--- a/assets/composable/eventStreams.ts
+++ b/assets/composable/eventStreams.ts
@@ -17,7 +17,7 @@ import { Container, GroupedContainers } from "@/models/Container";
 import { parseMessage } from "@/composable/loadBetween";
 import { useLogLoader } from "@/composable/logLoader";
 
-const { isSearching, debouncedSearchFilter } = useSearchFilter();
+const { isSearching, debouncedSearchFilter, inverseFilter } = useSearchFilter();
 
 export function useContainerStream(container: Ref<Container>): LogStreamSource {
   const url = computed(() => `/api/hosts/${container.value.host}/containers/${container.value.id}/logs/stream`);
@@ -81,7 +81,10 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
     const params = new URLSearchParams();
     if (streamConfig.value.stdout) params.append("stdout", "1");
     if (streamConfig.value.stderr) params.append("stderr", "1");
-    if (isSearching.value) params.append("filter", debouncedSearchFilter.value);
+    if (isSearching.value) {
+      params.append("filter", debouncedSearchFilter.value);
+      if (inverseFilter.value) params.append("inverse", "true");
+    }
     for (const level of levels.value) {
       params.append("levels", level);
     }

--- a/assets/composable/historicalLogs.ts
+++ b/assets/composable/historicalLogs.ts
@@ -11,13 +11,16 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
   const container = toRef(() => historicalContainer.value.container);
 
   const { streamConfig, levels, loadingMore } = useLoggingContext();
-  const { isSearching, debouncedSearchFilter } = useSearchFilter();
+  const { isSearching, debouncedSearchFilter, inverseFilter } = useSearchFilter();
 
   const params = computed(() => {
     const params = new URLSearchParams();
     if (streamConfig.value.stdout) params.append("stdout", "1");
     if (streamConfig.value.stderr) params.append("stderr", "1");
-    if (isSearching.value) params.append("filter", debouncedSearchFilter.value);
+    if (isSearching.value) {
+      params.append("filter", debouncedSearchFilter.value);
+      if (inverseFilter.value) params.append("inverse", "true");
+    }
     for (const level of levels.value) {
       params.append("levels", level);
     }

--- a/assets/composable/search.ts
+++ b/assets/composable/search.ts
@@ -1,6 +1,7 @@
 const searchQueryFilter = ref<string>("");
 const debouncedSearchFilter = refDebounced(searchQueryFilter);
 const showSearch = ref(false);
+const inverseFilter = ref(false);
 
 const searchParams = new URLSearchParams(window.location.search);
 if (searchParams.get("search") !== null && searchParams.get("search") !== "") {
@@ -10,6 +11,11 @@ if (searchParams.get("search") !== null && searchParams.get("search") !== "") {
 function resetSearch() {
   searchQueryFilter.value = "";
   showSearch.value = false;
+  inverseFilter.value = false;
+}
+
+function toggleInverse() {
+  inverseFilter.value = !inverseFilter.value;
 }
 
 const isSearching = computed(() => showSearch.value && debouncedSearchFilter.value !== "");
@@ -31,5 +37,7 @@ export function useSearchFilter() {
     showSearch,
     resetSearch,
     isSearching,
+    inverseFilter,
+    toggleInverse,
   };
 }

--- a/assets/composable/visible.ts
+++ b/assets/composable/visible.ts
@@ -1,7 +1,7 @@
 import { ComplexLogEntry, type LogMessage, type LogEntry } from "@/models/LogEntry";
 
 export function useVisibleFilter(visibleKeys: Ref<Map<string[], boolean>>) {
-  const { isSearching } = useSearchFilter();
+  const { isSearching, inverseFilter } = useSearchFilter();
   function filteredPayload(messages: Ref<LogEntry<LogMessage>[]>) {
     return computed(() => {
       return messages.value
@@ -14,7 +14,8 @@ export function useVisibleFilter(visibleKeys: Ref<Map<string[], boolean>>) {
         })
         .filter((d) => {
           if (isSearching.value && d instanceof ComplexLogEntry) {
-            return Object.values(d.message).some((v) => JSON.stringify(v)?.includes("<mark>"));
+            const hasMark = Object.values(d.message).some((v) => JSON.stringify(v)?.includes("<mark>"));
+            return inverseFilter.value ? !hasMark : hasMark;
           } else {
             return true;
           }

--- a/internal/cloud/tools_logs.go
+++ b/internal/cloud/tools_logs.go
@@ -19,6 +19,7 @@ type fetchLogsArgs struct {
 	Level       string `json:"level"`
 	Query       string `json:"query"`
 	Regex       string `json:"regex"`
+	Inverse     bool   `json:"inverse"`
 }
 
 func executeFetchContainerLogs(ctx context.Context, argsJSON string, deps ToolDeps) (*pb.CallToolResponse, error) {

--- a/internal/cloud/tools_stream.go
+++ b/internal/cloud/tools_stream.go
@@ -46,11 +46,15 @@ func matchesFilters(event *container.LogEvent, args *fetchLogsArgs, re *regexp.R
 		msg = fmt.Sprintf("%v", event.Message)
 	}
 
-	if args.Query != "" && !containsIgnoreCase(msg, args.Query) {
-		return "", false
+	if args.Query != "" {
+		if args.Inverse == containsIgnoreCase(msg, args.Query) {
+			return "", false
+		}
 	}
-	if re != nil && !re.MatchString(msg) {
-		return "", false
+	if re != nil {
+		if args.Inverse == re.MatchString(msg) {
+			return "", false
+		}
 	}
 
 	return msg, true

--- a/internal/cloud/tools_stream_test.go
+++ b/internal/cloud/tools_stream_test.go
@@ -111,6 +111,102 @@ func TestMatchesFilters_FallbackToMessage(t *testing.T) {
 	assert.Equal(t, "fallback msg", msg)
 }
 
+func TestMatchesFilters_InverseRegex(t *testing.T) {
+	re := regexp.MustCompile(`error`)
+
+	tests := []struct {
+		name    string
+		message string
+		level   string
+		args    fetchLogsArgs
+		re      *regexp.Regexp
+		wantOk  bool
+	}{
+		{
+			name:    "normal mode: regex matches",
+			message: "error: connection refused",
+			level:   "info",
+			args:    fetchLogsArgs{},
+			re:      re,
+			wantOk:  true,
+		},
+		{
+			name:    "normal mode: regex no match",
+			message: "info: all good",
+			level:   "info",
+			args:    fetchLogsArgs{},
+			re:      re,
+			wantOk:  false,
+		},
+		{
+			name:    "inverse mode: regex matches is excluded",
+			message: "error: connection refused",
+			level:   "info",
+			args:    fetchLogsArgs{Inverse: true},
+			re:      re,
+			wantOk:  false,
+		},
+		{
+			name:    "inverse mode: regex no match is included",
+			message: "info: all good",
+			level:   "info",
+			args:    fetchLogsArgs{Inverse: true},
+			re:      re,
+			wantOk:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &container.LogEvent{RawMessage: tt.message, Level: tt.level}
+			_, ok := matchesFilters(event, &tt.args, tt.re)
+			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}
+
+func TestMatchesFilters_InverseQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		args    fetchLogsArgs
+		wantOk  bool
+	}{
+		{
+			name:    "normal query match",
+			message: "hello world",
+			args:    fetchLogsArgs{Query: "hello"},
+			wantOk:  true,
+		},
+		{
+			name:    "normal query no match",
+			message: "foo bar",
+			args:    fetchLogsArgs{Query: "hello"},
+			wantOk:  false,
+		},
+		{
+			name:    "inverse query: match is excluded",
+			message: "hello world",
+			args:    fetchLogsArgs{Query: "hello", Inverse: true},
+			wantOk:  false,
+		},
+		{
+			name:    "inverse query: no match is included",
+			message: "foo bar",
+			args:    fetchLogsArgs{Query: "hello", Inverse: true},
+			wantOk:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &container.LogEvent{RawMessage: tt.message, Level: "info"}
+			_, ok := matchesFilters(event, &tt.args, nil)
+			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}
+
 // StreamMockClientService extends MockClientService to allow controllable StreamLogs behavior
 type StreamMockClientService struct {
 	MockClientService

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -41,8 +41,8 @@ func parseStdTypes(r *http.Request) container.StdType {
 	return stdTypes
 }
 
-func matchesFilter(event *container.LogEvent, regex *regexp.Regexp, levels map[string]struct{}) bool {
-	if regex != nil && !support_web.Search(regex, event) {
+func matchesFilter(event *container.LogEvent, regex *regexp.Regexp, levels map[string]struct{}, inverse bool) bool {
+	if regex != nil && inverse == support_web.Search(regex, event) {
 		return false
 	}
 	_, ok := levels[event.Level]
@@ -94,6 +94,8 @@ func (h *handler) fetchLogsBetweenDates(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
+
+	inverse := r.URL.Query().Get("inverse") == "true"
 
 	onlyComplex := r.URL.Query().Has("jsonOnly")
 	everything := r.URL.Query().Has("everything")
@@ -186,23 +188,23 @@ func (h *handler) fetchLogsBetweenDates(w http.ResponseWriter, r *http.Request) 
 				if _, ok := event.Message.(string); onlyComplex && ok {
 					continue
 				}
-				if regex != nil && !support_web.Search(regex, event) {
-					continue
-				}
-				if len(levels) > 0 {
-					if _, ok := levels[event.Level]; !ok {
-						continue
-					}
-				}
-				if plainText {
-					fmt.Fprintf(writer, "%s\n", event.RawMessage)
-				} else if err := encoder.Encode(event); err != nil {
-					log.Error().Err(err).Msg("error encoding log event")
-				}
+			if regex != nil && inverse == support_web.Search(regex, event) {
 				continue
 			}
+			if len(levels) > 0 {
+				if _, ok := levels[event.Level]; !ok {
+					continue
+				}
+			}
+			if plainText {
+				fmt.Fprintf(writer, "%s\n", event.RawMessage)
+			} else if err := encoder.Encode(event); err != nil {
+				log.Error().Err(err).Msg("error encoding log event")
+			}
+			continue
+		}
 
-			if !matchesFilter(event, regex, levels) {
+		if !matchesFilter(event, regex, levels, inverse) {
 				continue
 			}
 
@@ -379,7 +381,9 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	if !allLogs || regex != nil {
+	inverse := r.URL.Query().Get("inverse") == "true"
+
+	if !allLogs || regex != nil || inverse {
 		absoluteTime = time.Now()
 
 		go func() {
@@ -408,7 +412,7 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 					}
 
 					for log := range logs {
-						if !matchesFilter(log, regex, levels) {
+						if !matchesFilter(log, regex, levels, inverse) {
 							continue
 						}
 						events = append(events, log)
@@ -475,7 +479,7 @@ loop:
 	for {
 		select {
 		case logEvent := <-liveLogs:
-			if !matchesFilter(logEvent, regex, levels) {
+			if !matchesFilter(logEvent, regex, levels, inverse) {
 				continue
 			}
 

--- a/internal/web/logs_test.go
+++ b/internal/web/logs_test.go
@@ -16,7 +16,9 @@ import (
 	"testing"
 
 	"github.com/amir20/dozzle/internal/container"
+	support_web "github.com/amir20/dozzle/internal/support/web"
 	"github.com/beme/abide"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -357,6 +359,81 @@ func Test_handler_between_dates_with_everything_complex(t *testing.T) {
 	reader := strings.NewReader(regexp.MustCompile(`"time":"[^"]*"`).ReplaceAllString(rr.Body.String(), `"time":"<removed>"`))
 	abide.AssertReader(t, t.Name(), reader)
 	mockedClient.AssertExpectations(t)
+}
+
+func Test_matchesFilter_inverse(t *testing.T) {
+	levels := map[string]struct{}{"info": {}}
+
+	regex, err := support_web.ParseRegex("INFO")
+	require.NoError(t, err)
+
+	regex2, err := support_web.ParseRegex("ERROR")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		event   *container.LogEvent
+		regex   *regexp.Regexp
+		levels  map[string]struct{}
+		inverse bool
+		want    bool
+	}{
+		{
+			name:    "normal mode: matching regex and level passes",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   regex,
+			levels:  levels,
+			inverse: false,
+			want:    true,
+		},
+		{
+			name:    "normal mode: non-matching regex fails",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   regex2,
+			levels:  levels,
+			inverse: false,
+			want:    false,
+		},
+		{
+			name:    "inverse mode: matching regex fails (excluded)",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   regex,
+			levels:  levels,
+			inverse: true,
+			want:    false,
+		},
+		{
+			name:    "inverse mode: non-matching regex passes (not excluded)",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   regex2,
+			levels:  levels,
+			inverse: true,
+			want:    true,
+		},
+		{
+			name:    "no regex: inverse is a no-op, level check still applies",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   nil,
+			levels:  levels,
+			inverse: true,
+			want:    true,
+		},
+		{
+			name:    "inverse mode: wrong level fails regardless of regex",
+			event:   &container.LogEvent{Message: "ERROR: oops", Level: "error"},
+			regex:   regex2,
+			levels:  levels,
+			inverse: true,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesFilter(tt.event, tt.regex, tt.levels, tt.inverse)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func makeMessage(message string, stream container.StdType) []byte {


### PR DESCRIPTION
## Summary

Adds a grep `-v` style inverse/exclude filter toggle to the log search panel. When active, logs that match the search pattern are **excluded** instead of included.

This is to address https://github.com/amir20/dozzle/issues/4678.

## Changes

### Backend (Go)
- `internal/web/logs.go`: `matchesFilter()` accepts `inverse bool` using XOR logic (`inverse != support_web.Search(...)`). Parsed at both `fetchLogsBetweenDates` and `streamLogsForContainers` endpoints via `?inverse=true` query param.
- `internal/cloud/tools_logs.go`: Added `Inverse bool` field to `fetchLogsArgs`.
- `internal/cloud/tools_stream.go`: `matchesFilters()` uses XOR for regex + query matching.

### Frontend (Vue 3)
- `assets/composable/search.ts`: Added `inverseFilter` ref and `toggleInverse()`.
- `assets/components/Search.vue`: Inline toggle button with `mdi:filter-off-outline` / `mdi:filter-outline` icons, red tint (`btn-error`) when active.
- URL params propagate `inverse=true` to SSE stream (`eventStreams.ts`), historical fetch (`historicalLogs.ts`), and download (`downloadUrl.ts`) endpoints.
- `visible.ts` flips client-side `<mark>` post-filter for ComplexLogEntry when inverse is active.

### Tests
- `internal/web/logs_test.go`: 6 subtests for `matchesFilter` inverse behavior.
- `internal/cloud/tools_stream_test.go`: 8 subtests for `matchesFilters` inverse (regex + query).

## Motivation

Users monitoring error logs may want to **exclude** verbose noise (e.g., health check pings) rather than include specific patterns. The inline toggle makes this discoverable without needing to remember a `!` prefix convention.
