### PR TITLE
feat: add inverse/exclude filter to log search

### DIFF
--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -125,6 +125,8 @@ declare module 'vue' {
     'Mdi:cog': typeof import('~icons/mdi/cog')['default']
     'Mdi:contentCopy': typeof import('~icons/mdi/content-copy')['default']
     'Mdi:docker': typeof import('~icons/mdi/docker')['default']
+    'Mdi:filterOffOutline': typeof import('~icons/mdi/filter-off-outline')['default']
+    'Mdi:filterOutline': typeof import('~icons/mdi/filter-outline')['default']
     'Mdi:flash': typeof import('~icons/mdi/flash')['default']
     'Mdi:gauge': typeof import('~icons/mdi/gauge')['default']
     'Mdi:github': typeof import('~icons/mdi/github')['default']

--- a/assets/components/Search.vue
+++ b/assets/components/Search.vue
@@ -21,7 +21,7 @@
           class="btn btn-circle btn-xs"
           :class="inverseFilter ? 'btn-error' : 'btn-ghost'"
           @click="toggleInverse()"
-          :title="inverseFilter ? 'Exclude matching (inverse)' : 'Include matching (normal)'"
+          :title="inverseFilter ? $t('toolbar.inverse-on') : $t('toolbar.inverse-off')"
         >
           <mdi:filter-off-outline v-if="inverseFilter" />
           <mdi:filter-outline v-else />

--- a/assets/components/Search.vue
+++ b/assets/components/Search.vue
@@ -17,6 +17,15 @@
           v-model="searchQueryFilter"
           @keyup.esc="resetSearch()"
         />
+        <button
+          class="btn btn-circle btn-xs"
+          :class="inverseFilter ? 'btn-error' : 'btn-ghost'"
+          @click="toggleInverse()"
+          :title="inverseFilter ? 'Exclude matching (inverse)' : 'Include matching (normal)'"
+        >
+          <mdi:filter-off-outline v-if="inverseFilter" />
+          <mdi:filter-outline v-else />
+        </button>
         <a class="btn btn-circle btn-xs" @click="resetSearch()"> <mdi:close /></a>
       </div>
     </div>
@@ -26,7 +35,7 @@
 <script lang="ts" setup>
 const input = ref<HTMLInputElement>();
 const container = ref<HTMLDivElement>();
-const { searchQueryFilter, showSearch, resetSearch, isValidQuery } = useSearchFilter();
+const { searchQueryFilter, showSearch, resetSearch, isValidQuery, inverseFilter, toggleInverse } = useSearchFilter();
 
 const { style } = useDraggable(container);
 

--- a/assets/composable/downloadUrl.ts
+++ b/assets/composable/downloadUrl.ts
@@ -7,7 +7,7 @@ export function useDownloadUrl(
   levels: Ref<Set<string>>,
   name?: Ref<string> | ComputedRef<string> | string,
 ) {
-  const { debouncedSearchFilter } = useSearchFilter();
+  const { debouncedSearchFilter, inverseFilter } = useSearchFilter();
 
   const downloadUrl = computed(() => {
     const params = new URLSearchParams();
@@ -20,6 +20,7 @@ export function useDownloadUrl(
     // Add filter if search is active
     if (debouncedSearchFilter.value) {
       params.append("filter", debouncedSearchFilter.value);
+      if (inverseFilter.value) params.append("inverse", "true");
     }
 
     // Add levels (multiple values) only if filtered

--- a/assets/composable/eventStreams.ts
+++ b/assets/composable/eventStreams.ts
@@ -17,7 +17,7 @@ import { Container, GroupedContainers } from "@/models/Container";
 import { parseMessage } from "@/composable/loadBetween";
 import { useLogLoader } from "@/composable/logLoader";
 
-const { isSearching, debouncedSearchFilter } = useSearchFilter();
+const { isSearching, debouncedSearchFilter, inverseFilter } = useSearchFilter();
 
 export function useContainerStream(container: Ref<Container>): LogStreamSource {
   const url = computed(() => `/api/hosts/${container.value.host}/containers/${container.value.id}/logs/stream`);
@@ -81,7 +81,10 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
     const params = new URLSearchParams();
     if (streamConfig.value.stdout) params.append("stdout", "1");
     if (streamConfig.value.stderr) params.append("stderr", "1");
-    if (isSearching.value) params.append("filter", debouncedSearchFilter.value);
+    if (isSearching.value) {
+      params.append("filter", debouncedSearchFilter.value);
+      if (inverseFilter.value) params.append("inverse", "true");
+    }
     for (const level of levels.value) {
       params.append("levels", level);
     }

--- a/assets/composable/historicalLogs.ts
+++ b/assets/composable/historicalLogs.ts
@@ -11,13 +11,16 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
   const container = toRef(() => historicalContainer.value.container);
 
   const { streamConfig, levels, loadingMore } = useLoggingContext();
-  const { isSearching, debouncedSearchFilter } = useSearchFilter();
+  const { isSearching, debouncedSearchFilter, inverseFilter } = useSearchFilter();
 
   const params = computed(() => {
     const params = new URLSearchParams();
     if (streamConfig.value.stdout) params.append("stdout", "1");
     if (streamConfig.value.stderr) params.append("stderr", "1");
-    if (isSearching.value) params.append("filter", debouncedSearchFilter.value);
+    if (isSearching.value) {
+      params.append("filter", debouncedSearchFilter.value);
+      if (inverseFilter.value) params.append("inverse", "true");
+    }
     for (const level of levels.value) {
       params.append("levels", level);
     }

--- a/assets/composable/search.ts
+++ b/assets/composable/search.ts
@@ -1,6 +1,7 @@
 const searchQueryFilter = ref<string>("");
 const debouncedSearchFilter = refDebounced(searchQueryFilter);
 const showSearch = ref(false);
+const inverseFilter = ref(false);
 
 const searchParams = new URLSearchParams(window.location.search);
 if (searchParams.get("search") !== null && searchParams.get("search") !== "") {
@@ -10,6 +11,11 @@ if (searchParams.get("search") !== null && searchParams.get("search") !== "") {
 function resetSearch() {
   searchQueryFilter.value = "";
   showSearch.value = false;
+  inverseFilter.value = false;
+}
+
+function toggleInverse() {
+  inverseFilter.value = !inverseFilter.value;
 }
 
 const isSearching = computed(() => showSearch.value && debouncedSearchFilter.value !== "");
@@ -31,5 +37,7 @@ export function useSearchFilter() {
     showSearch,
     resetSearch,
     isSearching,
+    inverseFilter,
+    toggleInverse,
   };
 }

--- a/assets/composable/visible.ts
+++ b/assets/composable/visible.ts
@@ -1,7 +1,7 @@
 import { ComplexLogEntry, type LogMessage, type LogEntry } from "@/models/LogEntry";
 
 export function useVisibleFilter(visibleKeys: Ref<Map<string[], boolean>>) {
-  const { isSearching } = useSearchFilter();
+  const { isSearching, inverseFilter } = useSearchFilter();
   function filteredPayload(messages: Ref<LogEntry<LogMessage>[]>) {
     return computed(() => {
       return messages.value
@@ -14,7 +14,8 @@ export function useVisibleFilter(visibleKeys: Ref<Map<string[], boolean>>) {
         })
         .filter((d) => {
           if (isSearching.value && d instanceof ComplexLogEntry) {
-            return Object.values(d.message).some((v) => JSON.stringify(v)?.includes("<mark>"));
+            const hasMark = Object.values(d.message).some((v) => JSON.stringify(v)?.includes("<mark>"));
+            return inverseFilter.value ? !hasMark : hasMark;
           } else {
             return true;
           }

--- a/internal/cloud/tools_logs.go
+++ b/internal/cloud/tools_logs.go
@@ -19,6 +19,7 @@ type fetchLogsArgs struct {
 	Level       string `json:"level"`
 	Query       string `json:"query"`
 	Regex       string `json:"regex"`
+	Inverse     bool   `json:"inverse"`
 }
 
 func executeFetchContainerLogs(ctx context.Context, argsJSON string, deps ToolDeps) (*pb.CallToolResponse, error) {

--- a/internal/cloud/tools_stream.go
+++ b/internal/cloud/tools_stream.go
@@ -47,12 +47,14 @@ func matchesFilters(event *container.LogEvent, args *fetchLogsArgs, re *regexp.R
 	}
 
 	if args.Query != "" {
-		if args.Inverse == containsIgnoreCase(msg, args.Query) {
+		matched := containsIgnoreCase(msg, args.Query)
+		if matched == args.Inverse {
 			return "", false
 		}
 	}
 	if re != nil {
-		if args.Inverse == re.MatchString(msg) {
+		matched := re.MatchString(msg)
+		if matched == args.Inverse {
 			return "", false
 		}
 	}

--- a/internal/cloud/tools_stream.go
+++ b/internal/cloud/tools_stream.go
@@ -46,11 +46,15 @@ func matchesFilters(event *container.LogEvent, args *fetchLogsArgs, re *regexp.R
 		msg = fmt.Sprintf("%v", event.Message)
 	}
 
-	if args.Query != "" && !containsIgnoreCase(msg, args.Query) {
-		return "", false
+	if args.Query != "" {
+		if args.Inverse == containsIgnoreCase(msg, args.Query) {
+			return "", false
+		}
 	}
-	if re != nil && !re.MatchString(msg) {
-		return "", false
+	if re != nil {
+		if args.Inverse == re.MatchString(msg) {
+			return "", false
+		}
 	}
 
 	return msg, true

--- a/internal/cloud/tools_stream_test.go
+++ b/internal/cloud/tools_stream_test.go
@@ -111,6 +111,102 @@ func TestMatchesFilters_FallbackToMessage(t *testing.T) {
 	assert.Equal(t, "fallback msg", msg)
 }
 
+func TestMatchesFilters_InverseRegex(t *testing.T) {
+	re := regexp.MustCompile(`error`)
+
+	tests := []struct {
+		name    string
+		message string
+		level   string
+		args    fetchLogsArgs
+		re      *regexp.Regexp
+		wantOk  bool
+	}{
+		{
+			name:    "normal mode: regex matches",
+			message: "error: connection refused",
+			level:   "info",
+			args:    fetchLogsArgs{},
+			re:      re,
+			wantOk:  true,
+		},
+		{
+			name:    "normal mode: regex no match",
+			message: "info: all good",
+			level:   "info",
+			args:    fetchLogsArgs{},
+			re:      re,
+			wantOk:  false,
+		},
+		{
+			name:    "inverse mode: regex matches is excluded",
+			message: "error: connection refused",
+			level:   "info",
+			args:    fetchLogsArgs{Inverse: true},
+			re:      re,
+			wantOk:  false,
+		},
+		{
+			name:    "inverse mode: regex no match is included",
+			message: "info: all good",
+			level:   "info",
+			args:    fetchLogsArgs{Inverse: true},
+			re:      re,
+			wantOk:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &container.LogEvent{RawMessage: tt.message, Level: tt.level}
+			_, ok := matchesFilters(event, &tt.args, tt.re)
+			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}
+
+func TestMatchesFilters_InverseQuery(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+		args    fetchLogsArgs
+		wantOk  bool
+	}{
+		{
+			name:    "normal query match",
+			message: "hello world",
+			args:    fetchLogsArgs{Query: "hello"},
+			wantOk:  true,
+		},
+		{
+			name:    "normal query no match",
+			message: "foo bar",
+			args:    fetchLogsArgs{Query: "hello"},
+			wantOk:  false,
+		},
+		{
+			name:    "inverse query: match is excluded",
+			message: "hello world",
+			args:    fetchLogsArgs{Query: "hello", Inverse: true},
+			wantOk:  false,
+		},
+		{
+			name:    "inverse query: no match is included",
+			message: "foo bar",
+			args:    fetchLogsArgs{Query: "hello", Inverse: true},
+			wantOk:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &container.LogEvent{RawMessage: tt.message, Level: "info"}
+			_, ok := matchesFilters(event, &tt.args, nil)
+			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}
+
 // StreamMockClientService extends MockClientService to allow controllable StreamLogs behavior
 type StreamMockClientService struct {
 	MockClientService

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -188,23 +188,23 @@ func (h *handler) fetchLogsBetweenDates(w http.ResponseWriter, r *http.Request) 
 				if _, ok := event.Message.(string); onlyComplex && ok {
 					continue
 				}
-			if regex != nil && inverse == support_web.Search(regex, event) {
-				continue
-			}
-			if len(levels) > 0 {
-				if _, ok := levels[event.Level]; !ok {
+				if regex != nil && inverse == support_web.Search(regex, event) {
 					continue
 				}
+				if len(levels) > 0 {
+					if _, ok := levels[event.Level]; !ok {
+						continue
+					}
+				}
+				if plainText {
+					fmt.Fprintf(writer, "%s\n", event.RawMessage)
+				} else if err := encoder.Encode(event); err != nil {
+					log.Error().Err(err).Msg("error encoding log event")
+				}
+				continue
 			}
-			if plainText {
-				fmt.Fprintf(writer, "%s\n", event.RawMessage)
-			} else if err := encoder.Encode(event); err != nil {
-				log.Error().Err(err).Msg("error encoding log event")
-			}
-			continue
-		}
 
-		if !matchesFilter(event, regex, levels, inverse) {
+			if !matchesFilter(event, regex, levels, inverse) {
 				continue
 			}
 

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -41,8 +41,8 @@ func parseStdTypes(r *http.Request) container.StdType {
 	return stdTypes
 }
 
-func matchesFilter(event *container.LogEvent, regex *regexp.Regexp, levels map[string]struct{}) bool {
-	if regex != nil && !support_web.Search(regex, event) {
+func matchesFilter(event *container.LogEvent, regex *regexp.Regexp, levels map[string]struct{}, inverse bool) bool {
+	if regex != nil && inverse == support_web.Search(regex, event) {
 		return false
 	}
 	_, ok := levels[event.Level]
@@ -94,6 +94,8 @@ func (h *handler) fetchLogsBetweenDates(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 	}
+
+	inverse := r.URL.Query().Get("inverse") == "true"
 
 	onlyComplex := r.URL.Query().Has("jsonOnly")
 	everything := r.URL.Query().Has("everything")
@@ -186,23 +188,23 @@ func (h *handler) fetchLogsBetweenDates(w http.ResponseWriter, r *http.Request) 
 				if _, ok := event.Message.(string); onlyComplex && ok {
 					continue
 				}
-				if regex != nil && !support_web.Search(regex, event) {
-					continue
-				}
-				if len(levels) > 0 {
-					if _, ok := levels[event.Level]; !ok {
-						continue
-					}
-				}
-				if plainText {
-					fmt.Fprintf(writer, "%s\n", event.RawMessage)
-				} else if err := encoder.Encode(event); err != nil {
-					log.Error().Err(err).Msg("error encoding log event")
-				}
+			if regex != nil && inverse == support_web.Search(regex, event) {
 				continue
 			}
+			if len(levels) > 0 {
+				if _, ok := levels[event.Level]; !ok {
+					continue
+				}
+			}
+			if plainText {
+				fmt.Fprintf(writer, "%s\n", event.RawMessage)
+			} else if err := encoder.Encode(event); err != nil {
+				log.Error().Err(err).Msg("error encoding log event")
+			}
+			continue
+		}
 
-			if !matchesFilter(event, regex, levels) {
+		if !matchesFilter(event, regex, levels, inverse) {
 				continue
 			}
 
@@ -379,7 +381,9 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	if !allLogs || regex != nil {
+	inverse := r.URL.Query().Get("inverse") == "true"
+
+	if !allLogs || regex != nil || inverse {
 		absoluteTime = time.Now()
 
 		go func() {
@@ -408,7 +412,7 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 					}
 
 					for log := range logs {
-						if !matchesFilter(log, regex, levels) {
+						if !matchesFilter(log, regex, levels, inverse) {
 							continue
 						}
 						events = append(events, log)
@@ -475,7 +479,7 @@ loop:
 	for {
 		select {
 		case logEvent := <-liveLogs:
-			if !matchesFilter(logEvent, regex, levels) {
+			if !matchesFilter(logEvent, regex, levels, inverse) {
 				continue
 			}
 

--- a/internal/web/logs_test.go
+++ b/internal/web/logs_test.go
@@ -16,7 +16,9 @@ import (
 	"testing"
 
 	"github.com/amir20/dozzle/internal/container"
+	support_web "github.com/amir20/dozzle/internal/support/web"
 	"github.com/beme/abide"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -357,6 +359,81 @@ func Test_handler_between_dates_with_everything_complex(t *testing.T) {
 	reader := strings.NewReader(regexp.MustCompile(`"time":"[^"]*"`).ReplaceAllString(rr.Body.String(), `"time":"<removed>"`))
 	abide.AssertReader(t, t.Name(), reader)
 	mockedClient.AssertExpectations(t)
+}
+
+func Test_matchesFilter_inverse(t *testing.T) {
+	levels := map[string]struct{}{"info": {}}
+
+	regex, err := support_web.ParseRegex("INFO")
+	require.NoError(t, err)
+
+	regex2, err := support_web.ParseRegex("ERROR")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		event   *container.LogEvent
+		regex   *regexp.Regexp
+		levels  map[string]struct{}
+		inverse bool
+		want    bool
+	}{
+		{
+			name:    "normal mode: matching regex and level passes",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   regex,
+			levels:  levels,
+			inverse: false,
+			want:    true,
+		},
+		{
+			name:    "normal mode: non-matching regex fails",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   regex2,
+			levels:  levels,
+			inverse: false,
+			want:    false,
+		},
+		{
+			name:    "inverse mode: matching regex fails (excluded)",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   regex,
+			levels:  levels,
+			inverse: true,
+			want:    false,
+		},
+		{
+			name:    "inverse mode: non-matching regex passes (not excluded)",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   regex2,
+			levels:  levels,
+			inverse: true,
+			want:    true,
+		},
+		{
+			name:    "no regex: inverse is a no-op, level check still applies",
+			event:   &container.LogEvent{Message: "INFO: all good", Level: "info"},
+			regex:   nil,
+			levels:  levels,
+			inverse: true,
+			want:    true,
+		},
+		{
+			name:    "inverse mode: wrong level fails regardless of regex",
+			event:   &container.LogEvent{Message: "ERROR: oops", Level: "error"},
+			regex:   regex2,
+			levels:  levels,
+			inverse: true,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesFilter(tt.event, tt.regex, tt.levels, tt.inverse)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func makeMessage(message string, stream container.StdType) []byte {

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Download
   download-filtered: Download Filtrerede Logs
   search: Søg
+  inverse-on: Ekskluder matchende (inverteret)
+  inverse-off: Inkluder matchende (normal)
   show: Vis kun {std}
   show-all: Vis alle streams
   stop: Stop

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Herunterladen
   download-filtered: Gefilterte Logs Herunterladen
   search: Suchen
+  inverse-on: Übereinstimmungen ausschließen (invertiert)
+  inverse-off: Übereinstimmungen einschließen (normal)
   show: Zeige nur {std}
   show-all: Zeige alle Streams
   stop: Stop

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Download
   download-filtered: Download Filtered Logs
   search: Search
+  inverse-on: Exclude matching (inverse)
+  inverse-off: Include matching (normal)
   show: Show {std}
   show-all: Show all
   stop: Stop

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Descargar
   download-filtered: Descargar Logs Filtrados
   search: Buscar
+  inverse-on: Excluir coincidencias (inverso)
+  inverse-off: Incluir coincidencias (normal)
   show: Mostrar {std}
   show-all: Mostrar todo
   stop: Detener

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Téléchargement
   download-filtered: Télécharger Logs Filtrés
   search: Chercher
+  inverse-on: Exclure les correspondances (inverse)
+  inverse-off: Inclure les correspondances (normal)
   show: Montrer seulement {std}
   show-all: Afficher tous les flux
   stop: Stop

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Unduh
   download-filtered: Unduh Log yang Difilter
   search: Cari
+  inverse-on: Kecualikan yang cocok (inversi)
+  inverse-off: Sertakan yang cocok (normal)
   show: Tampilkan {std}
   show-all: Tampilkan semua
   stop: Hentikan

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Scarica
   download-filtered: Scarica Log Filtrati
   search: Cerca
+  inverse-on: Escludi corrispondenze (inverso)
+  inverse-off: Includi corrispondenze (normale)
   show: Mostra solo {std}
   show-all: Mostra tutto
   stop: Stop

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -3,6 +3,8 @@ toolbar:
   download: 다운로드
   download-filtered: 필터링된 로그 다운로드
   search: 검색
+  inverse-on: 일치 항목 제외 (반전)
+  inverse-off: 일치 항목 포함 (일반)
   show: "{std} 보기"
   show-all: 전체 보기
   stop: 중지

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Downloaden
   download-filtered: Gefilterde Logs Downloaden
   search: Zoeken
+  inverse-on: Overeenkomsten uitsluiten (omgekeerd)
+  inverse-off: Overeenkomsten opnemen (normaal)
   show: Toon {std}
   show-all: Toon alles
   stop: Stoppen

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Pobierz
   download-filtered: Pobierz Filtrowane Logi
   search: Szukaj
+  inverse-on: Wyklucz pasujące (odwrotnie)
+  inverse-off: Uwzględnij pasujące (normalnie)
   show: Pokaż tylko {std}
   show-all: Pokaż wszystko
   stop: Stop

--- a/locales/pr.yml
+++ b/locales/pr.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Descarregar
   download-filtered: Descarregar Logs Filtrados
   search: Pesquisa
+  inverse-on: Excluir correspondências (inverso)
+  inverse-off: Incluir correspondências (normal)
   show: Mostrar apenas {std}
   show-all: Mostrar todos os fluxos
   stop: Parar

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Baixar
   download-filtered: Baixar Logs Filtrados
   search: Pesquisar
+  inverse-on: Excluir correspondências (inverso)
+  inverse-off: Incluir correspondências (normal)
   show: Mostrar {std}
   show-all: Mostrar tudo
   stop: Parar

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Скачать
   download-filtered: Скачать Отфильтрованные Логи
   search: Поиск
+  inverse-on: Исключить совпадения (инверсия)
+  inverse-off: Включить совпадения (обычно)
   show: Показать только {std}
   show-all: Показать все потоки
   stop: Остановить

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -3,6 +3,8 @@ toolbar:
   download: Prenesi
   download-filtered: Prenesi Filtrirane Dnevnike
   search: Iskanje
+  inverse-on: Izključi ujemanja (obratno)
+  inverse-off: Vključi ujemanja (običajno)
   show: Prikaži {std}
   show-all: Prikaži vse
   stop: Ustavi

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -3,6 +3,8 @@ toolbar:
   download: İndir
   download-filtered: Filtrelenmiş Logları İndir
   search: Ara
+  inverse-on: Eşleşenleri hariç tut (ters)
+  inverse-off: Eşleşenleri dahil et (normal)
   show: Sadece {std} göster
   show-all: Tüm akışları göster
   stop: Durdur

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -3,6 +3,8 @@ toolbar:
   download: 下載
   download-filtered: 下載篩選的日誌
   search: 搜尋
+  inverse-on: 排除符合項目（反向）
+  inverse-off: 包含符合項目（一般）
   show: 僅顯示 {std}
   show-all: 顯示全部
   stop: 停止

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -3,6 +3,8 @@ toolbar:
   download: 下载
   download-filtered: 下载筛选的日志
   search: 搜索
+  inverse-on: 排除匹配项（反向）
+  inverse-off: 包含匹配项（正常）
   show: 显示 {std}
   show-all: 显示全部
   stop: 停止


### PR DESCRIPTION
## Summary
Follow-up fixes on top of #4689 (lingfish's inverse filter):

- Add `toolbar.inverse-on` / `toolbar.inverse-off` to all 17 locales; switch the new tooltip in `Search.vue` from hardcoded English to `$t()`.
- Run `gofmt -w internal/web/logs.go` (indentation broken in the merge of new `inverse` arg into the `for event := range events` loop).
- Extract `matched := ...` in `tools_stream.go` `matchesFilters` for readability — `matched == args.Inverse` reads more cleanly than the inverted equality.

Note: this branch carries lingfish's commit too; once #4689 merges, the diff here collapses to just these fixes.

## Test plan
- [x] `go test ./internal/cloud/... ./internal/web/...` passes
- [ ] Frontend tooltip renders translated string in non-English locale
- [ ] `gofmt -d internal/web/logs.go` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)