### PR TITLE
fix: update key binds

### DIFF
--- a/assets/components/ContainerViewer/ContainerActionsToolbar.vue
+++ b/assets/components/ContainerViewer/ContainerActionsToolbar.vue
@@ -18,7 +18,7 @@
       <li v-if="!historical">
         <a @click="clear()">
           <octicon:trash-24 /> {{ $t("toolbar.clear") }}
-          <KeyShortcut char="k" :modifiers="['shift', 'meta']" />
+          <KeyShortcut char="l" :modifiers="['shift', 'meta']" />
         </a>
       </li>
       <li v-if="hasComplexLogs">
@@ -299,7 +299,7 @@ async function copyLogs() {
   await navigator.clipboard.write([new ClipboardItem({ "text/plain": blobPromise })]);
 }
 
-onKeyStroke("f", (e) => {
+onKeyStroke(["f", "F"], (e) => {
   if (hasComplexLogs.value) {
     if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
       showDrawer(LogAnalytics, { container }, "lg");
@@ -308,14 +308,14 @@ onKeyStroke("f", (e) => {
   }
 });
 if (enableShell) {
-  onKeyStroke("a", (e) => {
+  onKeyStroke(["a", "A"], (e) => {
     if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
       showDrawer(Terminal, { container, action: "attach" }, "lg");
       e.preventDefault();
     }
   });
 
-  onKeyStroke("e", (e) => {
+  onKeyStroke(["e", "E"], (e) => {
     if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
       showDrawer(Terminal, { container, action: "exec" }, "lg");
       e.preventDefault();

--- a/assets/components/LogViewer/MultiContainerActionToolbar.vue
+++ b/assets/components/LogViewer/MultiContainerActionToolbar.vue
@@ -12,7 +12,7 @@
       <li>
         <a @click="clear()">
           <octicon:trash-24 /> {{ $t("toolbar.clear") }}
-          <KeyShortcut char="k" :modifiers="['shift', 'meta']" />
+          <KeyShortcut char="l" :modifiers="['shift', 'meta']" />
         </a>
       </li>
       <li v-if="enableDownload">

--- a/assets/components/LogViewer/ViewerWithSource.vue
+++ b/assets/components/LogViewer/ViewerWithSource.vue
@@ -21,7 +21,7 @@ defineExpose({
   clear: () => source.value?.clear(),
 });
 
-onKeyStroke("k", (e) => {
+onKeyStroke(["l", "L"], (e) => {
   if ((e.ctrlKey || e.metaKey) && e.shiftKey) {
     source.value?.clear();
     e.preventDefault();


### PR DESCRIPTION
### Description
* Fixes [#4693](https://github.com/amir20/dozzle/issues/4693)

### Notes
* I have extremely limited experience with Go, so forgive me if this seems more obvious to a more experienced developer.  I was not able to build this package using only the instructions at [Building](https://github.com/amir20/dozzle#building):
  > missing go.sum entry for module providing package google.golang.org/grpc/cmd/protoc-gen-go-grpc; to add:
  >        go mod download google.golang.org/grpc/cmd/protoc-gen-go-grpc
* I first had to use command `go mod tidy` prior to `go install tool`.  I noticed that this changed a few other files in the repository, and I don't understand the changes well enough to know whether this step may cause other problems.  The workaround allowed me to build and test this PR, though.  You may want to consider reviewing your build instructions.
* I'm not sure if this works on other browsers, but during my testing on Firefox I discovered that none of your defined keystroke event handlers intended to catch Shift-modified keystrokes were working.  I updated any applicable `onKeyStroke` invocations.


### Changes
* `assets/components/ContainerViewer/ContainerActionsToolbar.vue`
  > * Updated UI to reflect new key bind
  > * Updated `onKeyStroke` parameters to detect presence of Shift-modified keystrokes

* `assets/components/LogViewer/MultiContainerActionToolbar.vue`
  > * Updated UI to reflect new key bind

* `assets/components/LogViewer/ViewerWithSource.vue`
  > * Updated logic to detect new key bind