### PR TITLE
feat: allow oom and kill events through notification listener

### DIFF
--- a/internal/notification/event_listener.go
+++ b/internal/notification/event_listener.go
@@ -16,6 +16,8 @@ var allowedEventNames = map[string]bool{
 	"die":           true,
 	"restart":       true,
 	"health_status": true,
+	"oom":           true,
+	"kill":          true,
 }
 
 type ContainerEventEntry struct {


### PR DESCRIPTION
## Summary

Adds `oom` and `kill` to the `allowedEventNames` whitelist in the container event listener so Docker's native OOM and kill events propagate through Dozzle's notification pipeline.

## Why

Docker emits `oom` and `kill` as separate events from `die`, but the listener at `internal/notification/event_listener.go` was silently dropping them. Today the codebase already hints that `oom` should work end-to-end:

- `internal/cloud/tools.go` advertises `oom` to the LLM as a valid event filter.
- `assets/composable/exprEditor.ts` includes `oom` in the expression autocomplete.

This change closes that mismatch. Purely additive — no event type changes, no schema changes.

## Companion PR

Unblocks an OOM-by-default row in the welcome modal triage rewrite.

## Test plan

- [x] `go test ./internal/notification/...` passes
- [ ] Verify in dev that an OOM event on a real container produces a notification when subscribed