### PR TITLE
fix: keep search toolbar button working when ⌘F shortcut is disabled

### DIFF
--- a/assets/components/Search.vue
+++ b/assets/components/Search.vue
@@ -1,12 +1,6 @@
 <template>
   <transition name="slide">
-    <div
-      class="fixed z-50 flex w-full justify-end p-2"
-      v-show="showSearch"
-      v-if="search"
-      ref="container"
-      :style="style"
-    >
+    <div class="fixed z-50 flex w-full justify-end p-2" v-show="showSearch" ref="container" :style="style">
       <div class="input input-primary flex items-center shadow-lg" :class="!isValidQuery ? 'input-warning' : ''">
         <mdi:magnify />
         <input
@@ -40,6 +34,7 @@ const { searchQueryFilter, showSearch, resetSearch, isValidQuery, inverseFilter,
 const { style } = useDraggable(container);
 
 onKeyStroke("f", (e) => {
+  if (!search.value) return;
   if ((e.ctrlKey || e.metaKey) && !e.shiftKey) {
     showSearch.value = true;
     nextTick(() => input.value?.focus() || input.value?.select());


### PR DESCRIPTION
## Summary
- `Search.vue` was gated with `v-if="search"`, so disabling the "Enable searching with Dozzle using ⌘F" setting removed the search bar from the DOM. The toolbar Search button still flipped `showSearch`, but there was nothing to show.
- only gate the keybinding on `search`; keep the component rendered so the toolbar button keeps working.

Fixes #4718

## Test plan
- [ ] Disable `Enable searching with Dozzle using ⌘F` in Settings
- [ ] Confirm ⌘F no longer opens the search bar
- [ ] Confirm clicking the Search button in the toolbar still opens it

🤖 Generated with [Claude Code](https://claude.com/claude-code)