### PR TITLE
feat: distinguish paused container state in UI

### DIFF
--- a/assets/components/ContainerDropdown.vue
+++ b/assets/components/ContainerDropdown.vue
@@ -5,11 +5,12 @@
       <li v-for="other in containers">
         <router-link :to="{ name: '/container/[id]', params: { id: other.id } }" class="text-nowrap">
           <div
-            class="status data-[state=exited]:status-error data-[state=running]:status-success"
+            class="status data-[state=exited]:status-error data-[state=running]:status-success data-[state=paused]:status-warning"
             :data-state="other.state"
           ></div>
           {{ other.name }}
           <div v-if="other.state === 'running'">running</div>
+          <div v-else-if="other.state === 'paused'">paused</div>
           <RelativeTime :date="other.finishedAt" class="text-base-content/70 text-xs" v-else />
         </router-link>
       </li>

--- a/assets/components/ContainerViewer/ContainerTitle.vue
+++ b/assets/components/ContainerViewer/ContainerTitle.vue
@@ -27,12 +27,13 @@
                   <li v-for="other in otherContainers">
                     <router-link :to="{ name: '/container/[id]', params: { id: other.id } }">
                       <div
-                        class="status data-[state=exited]:status-error data-[state=running]:status-success"
+                        class="status data-[state=exited]:status-error data-[state=running]:status-success data-[state=paused]:status-warning"
                         :data-state="other.state"
                       ></div>
                       <div v-if="other.isSwarm">{{ other.swarmId }}</div>
                       <div v-else>{{ other.name }}</div>
                       <div v-if="other.state === 'running'">running</div>
+                      <div v-else-if="other.state === 'paused'">paused</div>
                       <RelativeTime :date="other.finishedAt" class="text-base-content/70 text-xs" v-else />
                     </router-link>
                   </li>

--- a/assets/components/HostMenu.vue
+++ b/assets/components/HostMenu.vue
@@ -152,7 +152,7 @@
                     <svg-spinners:ring-resize v-if="item.isNew" class="text-secondary w-2" />
                     <div
                       v-else
-                      class="status data-[state=exited]:status-error data-[state=running]:status-success"
+                      class="status data-[state=exited]:status-error data-[state=running]:status-success data-[state=paused]:status-warning"
                       :data-state="item.state"
                     ></div>
                     <div class="truncate">

--- a/assets/stores/container.ts
+++ b/assets/stores/container.ts
@@ -77,6 +77,12 @@ export const useContainerStore = defineStore("container", () => {
           case "destroy":
             container.state = "deleted";
             break;
+          case "pause":
+            container.state = "paused";
+            break;
+          case "unpause":
+            container.state = "running";
+            break;
         }
       }
     });

--- a/internal/container/container_store.go
+++ b/internal/container/container_store.go
@@ -414,6 +414,21 @@ func (s *ContainerStore) init() {
 						return c, xsync.CancelOp
 					}
 				})
+			case "pause", "unpause":
+				newState := "paused"
+				if event.Name == "unpause" {
+					newState = "running"
+				}
+				s.containers.Compute(event.ActorID, func(c *Container, loaded bool) (*Container, xsync.ComputeOp) {
+					if loaded {
+						log.Debug().Str("id", c.ID).Str("state", newState).Msg("container state changed")
+						copy := *c
+						copy.State = newState
+						return &copy, xsync.UpdateOp
+					} else {
+						return c, xsync.CancelOp
+					}
+				})
 			case "health_status: healthy", "health_status: unhealthy":
 				healthy := "unhealthy"
 				if event.Name == "health_status: healthy" {

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -71,7 +71,7 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 			}
 			log.Trace().Str("event", event.Name).Str("id", event.ActorID).Msg("container event from store")
 			switch event.Name {
-			case "start", "die", "destroy", "rename":
+			case "start", "die", "destroy", "rename", "pause", "unpause":
 				if event.Name == "start" || event.Name == "rename" {
 					if containers, err := h.hostService.ListContainersForHost(event.Host, userLabels); err == nil {
 						log.Debug().Str("host", event.Host).Int("count", len(containers)).Msg("updating containers for host")


### PR DESCRIPTION
## Summary
- handle docker pause/unpause events in the container store and forward them on the SSE stream
- yellow status indicator for paused containers in sidebar and dropdowns, plus a "paused" label in dropdown rows
- popup already renders state uppercased so it shows "STATE PAUSED" automatically

Closes #4725

## Test plan
- [ ] start a compose project, run `docker compose pause`, verify sidebar circle turns yellow
- [ ] hover the container in the sidebar and confirm popup shows STATE **PAUSED**
- [ ] run `docker compose unpause` and confirm circle returns to green
- [ ] confirm dropdown rows show "paused" text instead of a stale finished-at

🤖 Generated with [Claude Code](https://claude.com/claude-code)