### PR TITLE
test: apply Go modernizations across test files

### DIFF
--- a/internal/auth/proxy_test.go
+++ b/internal/auth/proxy_test.go
@@ -30,7 +30,7 @@ func TestForwardProxyAuthRejectsInvalidFilter(t *testing.T) {
 
 func TestUserFromContextInvalidFilterReturnsNil(t *testing.T) {
 	tokenAuth := jwtauth.New("HS256", []byte("secret"), nil)
-	_, tokenString, err := tokenAuth.Encode(map[string]interface{}{
+	_, tokenString, err := tokenAuth.Encode(map[string]any{
 		"username": "alice",
 		"email":    "alice@example.com",
 		"name":     "Alice",

--- a/internal/deploy/manager_test.go
+++ b/internal/deploy/manager_test.go
@@ -321,7 +321,7 @@ func TestManager_Deploy_SerializesSameProject(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	errs := make(chan error, 2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 			errs <- mgr.Deploy(context.Background(), "shared", []byte(testCompose), nil)
@@ -373,7 +373,7 @@ func TestManager_Deploy_ParallelizesDifferentProjects(t *testing.T) {
 	}()
 
 	// Both must reach the docker call before either is released.
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		select {
 		case <-reached:
 		case <-time.After(2 * time.Second):


### PR DESCRIPTION
## Summary

- Ran `golang.org/x/tools` `modernize` over the test suite and applied the safe fixes:
  - `range`-over-int loops in `internal/deploy/manager_test.go` (Go 1.22)
  - `map[string]interface{}` to `map[string]any` in `internal/auth/proxy_test.go`
- The `internal/cloud/log_streamer_test.go` modernizations the analyzer also flagged are excluded here, they're already handled on the `cloud-min-level-label` branch (#4729) to avoid a merge conflict.

## Test plan

- [x] `go test ./internal/auth/ ./internal/deploy/`