### PR TITLE
fix: set Secure flag on jwt cookie when request is HTTPS

### DIFF
--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -23,6 +24,7 @@ func (h *handler) createToken(w http.ResponseWriter, r *http.Request) {
 			HttpOnly: true,
 			Path:     "/",
 			SameSite: http.SameSiteLaxMode,
+			Secure:   isHTTPS(r),
 			Expires:  expires,
 		})
 		log.Info().Str("user", user).Msg("Token created")
@@ -41,8 +43,18 @@ func (h *handler) deleteToken(w http.ResponseWriter, r *http.Request) {
 		HttpOnly: true,
 		Path:     "/",
 		SameSite: http.SameSiteLaxMode,
+		Secure:   isHTTPS(r),
 		Expires:  time.Unix(0, 0),
 	})
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte(http.StatusText(http.StatusOK)))
+}
+
+// isHTTPS reports whether the original client request used HTTPS, accounting
+// for TLS terminated at an upstream reverse proxy via X-Forwarded-Proto.
+func isHTTPS(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 }


### PR DESCRIPTION
## What

Set the `Secure` flag on the `jwt` cookie when the client request is HTTPS.

## How

Adds an `isHTTPS(r)` helper that detects HTTPS per-request:
- `r.TLS != nil` — direct TLS connection to Dozzle, or
- `X-Forwarded-Proto: https` — TLS terminated at an upstream reverse proxy (the common Dozzle setup)

Both `createToken` and `deleteToken` cookies now set `Secure: isHTTPS(r)`. Plain HTTP logins (local/dev) are unaffected.

Cookie is already `HttpOnly` + `SameSite=Lax`, so a spoofed `X-Forwarded-Proto` only downgrades to a non-secure cookie at worst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)