### PR TITLE
fix: prevent DuckDB MAP inference from breaking log analytics

### DIFF
--- a/assets/components/LogViewer/LogAnalytics.vue
+++ b/assets/components/LogViewer/LogAnalytics.vue
@@ -90,7 +90,7 @@ onMounted(async () => {
 
     state.value = "initializing";
     await conn.query(
-      `CREATE TABLE logs AS SELECT unnest(m) FROM read_json('logs.json', ignore_errors = true, format = 'newline_delimited')`,
+      `CREATE TABLE logs AS SELECT unnest(m) FROM read_json('logs.json', ignore_errors = true, format = 'newline_delimited', map_inference_threshold = -1)`,
     );
 
     state.value = "ready";


### PR DESCRIPTION
## Problem

The log analytics view crashes with:

```
Binder Error: UNNEST() can only be applied to lists, structs and NULL, not MAP(VARCHAR, JSON)
```

DuckDB's `read_json` auto-detection switches a JSON object column from `STRUCT` to `MAP(VARCHAR, ...)` once it sees more than 200 distinct keys across the sample (the default `map_inference_threshold`). `unnest()` doesn't work on `MAP`, so any container emitting JSON logs whose cumulative key set exceeds 200 distinct keys (wide schemas, or IDs used as field names) breaks the analytics tab.

It's not about nesting or per-line key inconsistency, which is why a simple `{"level":"info","msg":"started","ts":1}` doesn't reproduce it. The distinct-key count is cumulative across all log lines in the buffer.

## Fix

Pass `map_inference_threshold = -1` to `read_json`, disabling MAP inference so the message column is always a `STRUCT` (union of all keys, NULLs for missing). `unnest()` then works regardless of key cardinality.

Reproduced and verified locally with DuckDB v1.5.3:

```sql
-- 300 lines, each with a unique key -> fails before, works after
CREATE TABLE logs AS SELECT unnest(m) FROM read_json('logs.json',
  ignore_errors = true, format = 'newline_delimited', map_inference_threshold = -1);
```

Fixes #4745

🤖 Generated with [Claude Code](https://claude.com/claude-code)