### PR TITLE
fix: normalize CPU by core count in metric alerts

### DIFF
--- a/docs/guide/alerts-and-webhooks.md
+++ b/docs/guide/alerts-and-webhooks.md
@@ -176,11 +176,11 @@ Metric alerts fire when a container's CPU or memory usage crosses a threshold. T
 
 Available properties:
 
-| Property      | Type   | Description                                     |
-| ------------- | ------ | ----------------------------------------------- |
-| `cpu`         | number | CPU usage percentage (0–100, per core-adjusted) |
-| `memory`      | number | Memory usage percentage (0–100)                 |
-| `memoryUsage` | number | Memory usage in bytes                           |
+| Property      | Type   | Description                                   |
+| ------------- | ------ | --------------------------------------------- |
+| `cpu`         | number | CPU usage percentage (0–100), matching the UI |
+| `memory`      | number | Memory usage percentage (0–100)               |
+| `memoryUsage` | number | Memory usage in bytes                         |
 
 ### Cooldown & Sample Window
 

--- a/internal/notification/processing.go
+++ b/internal/notification/processing.go
@@ -114,8 +114,18 @@ func (m *Manager) processStatEvents() {
 
 // processStatEvent processes a single stat event and sends notifications for matching metric subscriptions
 func (m *Manager) processStatEvent(event *ContainerStatEvent) {
+	// Normalize CPU by core count so alerts report overall load (0-100%),
+	// matching the UI. Stat.CPUPercent is per-core (100% = one full core).
+	cores := event.Container.CPULimit
+	if cores <= 0 {
+		cores = float64(event.Host.NCPU)
+	}
+	if cores <= 0 {
+		cores = 1
+	}
+
 	notificationStat := types.NotificationStat{
-		CPUPercent:    event.Stat.CPUPercent,
+		CPUPercent:    event.Stat.CPUPercent / cores,
 		MemoryPercent: event.Stat.MemoryPercent,
 		MemoryUsage:   event.Stat.MemoryUsage,
 		Mounts:        FromContainerMounts(event.Container),
@@ -154,8 +164,8 @@ func (m *Manager) processStatEvent(event *ContainerStatEvent) {
 
 		log.Debug().
 			Str("containerID", event.Stat.ID).
-			Float64("cpu", event.Stat.CPUPercent).
-			Float64("memory", event.Stat.MemoryPercent).
+			Float64("cpu", notificationStat.CPUPercent).
+			Float64("memory", notificationStat.MemoryPercent).
 			Str("subscription", sub.Name).
 			Msg("Metric alert triggered")
 


### PR DESCRIPTION
## Summary
- Metric alerts reported per-core CPU load (100% = one full core), so an 8-core container maxed out triggered at ~800% while the UI shows overall 0-100% load. The docs say alerts match the UI.
- Normalizes `CPUPercent` by core count in `processStatEvent`, mirroring the frontend logic: `cpuLimit` if set, else host `nCPU`, else 1.

Closes #4753

## Note
Existing CPU metric thresholds were implicitly tuned against the old per-core scale, so this changes the value users compare against. Worth a changelog mention.

## Test plan
- [ ] `go test -race ./internal/notification/`
- [ ] Verify a CPU metric alert on a multi-core host reports the same percentage the UI shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)