### PR TITLE
fix(ui): null in JSON array crashes ComplexLogItem

### DIFF
--- a/assets/components/LogViewer/ComplexLogItem.spec.ts
+++ b/assets/components/LogViewer/ComplexLogItem.spec.ts
@@ -53,6 +53,11 @@ describe("<ComplexLogItem />", () => {
     expect(wrapper.find(".array").text()).toContain("b");
   });
 
+  test("renders null inside an array without throwing", () => {
+    const wrapper = mountItem({ tags: ["a", null, "b"] } as any);
+    expect(wrapper.find(".array").text()).toContain("null");
+  });
+
   test("shows a placeholder when every value is hidden", () => {
     const visibleKeys = ref(new Map<string[], boolean>([[["a"], false]]));
     const wrapper = mountItem({ a: 1 }, visibleKeys);

--- a/assets/components/LogViewer/ComplexLogItem.vue
+++ b/assets/components/LogViewer/ComplexLogItem.vue
@@ -15,7 +15,7 @@
             class="after:text-base-content/70 not-last:after:content-[',']"
           >
             <ReuseTemplate :data="item" v-if="isObject(item) || Array.isArray(item)" />
-            <span v-else class="value" :class="typeof item" v-html="stripAnsi(item.toString())"></span>
+            <span v-else class="value" :class="typeof item" v-html="stripAnsi(String(item))"></span>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
Follow-up to #4779. The object-value branch was switched to `String(value)`, but the array-item branch still used `item.toString()`. A JSON array containing `null` falls through the `isObject` / `Array.isArray` guard and hits `null.toString()`, throwing at runtime (`TypeError: Cannot read properties of null`).

Same fix: `String(item)`.

Added a regression test that mounts `{ tags: ["a", null, "b"] }` — it throws without the fix and passes with it.

`pnpm typecheck` clean, `ComplexLogItem.spec.ts` 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)