### PR TITLE
fix(ui): flatten JSON-typed log messages in SQL analytics

### DIFF
--- a/assets/components/LogViewer/LogAnalytics.vue
+++ b/assets/components/LogViewer/LogAnalytics.vue
@@ -148,9 +148,33 @@ onMounted(async () => {
     await db.registerFileBuffer("logs.json", arrayBuffer);
 
     state.value = "initializing";
-    await conn.query(
-      `CREATE TABLE logs AS SELECT unnest(m) FROM read_json('logs.json', ignore_errors = true, format = 'newline_delimited', map_inference_threshold = -1)`,
-    );
+
+    // Uniform JSON messages flatten into a STRUCT and unnest() expands them into columns.
+    // Mixed message shapes make DuckDB infer `m` as JSON, which unnest() rejects, so fall
+    // back to flattening the union of object keys by hand.
+    const source = `read_json('logs.json', ignore_errors = true, format = 'newline_delimited', map_inference_threshold = -1)`;
+    try {
+      await conn.query(`CREATE TABLE logs AS SELECT unnest(m) FROM ${source}`);
+    } catch {
+      await conn.query(`DROP TABLE IF EXISTS logs`);
+      await conn.query(`CREATE TABLE raw_logs AS SELECT m::JSON AS m FROM ${source}`);
+      const keyRows = await conn.query<{ key: any }>(
+        `SELECT DISTINCT unnest(json_keys(m)) AS key FROM raw_logs WHERE json_type(m) = 'OBJECT'`,
+      );
+      const keys = keyRows.toArray().map((row) => String(row.key));
+      if (keys.length) {
+        const projection = keys
+          .map((key) => {
+            const ident = key.replace(/"/g, '""');
+            const path = `$."${ident}"`.replace(/'/g, "''");
+            return `json_extract_string(m, '${path}') AS "${ident}"`;
+          })
+          .join(", ");
+        await conn.query(`CREATE TABLE logs AS SELECT ${projection} FROM raw_logs WHERE json_type(m) = 'OBJECT'`);
+      } else {
+        await conn.query(`CREATE TABLE logs AS SELECT m FROM raw_logs`);
+      }
+    }
 
     const described = await conn.query<{ column_name: any; column_type: any }>(`DESCRIBE logs`);
     columns.value = described.toArray().map((row) => ({


### PR DESCRIPTION
## Problem

SQL Analytics crashes for some containers with:

```
Binder Error: UNNEST() can only be applied to lists, structs and NULL, not JSON
LINE 1: CREATE TABLE logs AS SELECT unnest(m) FROM read_json('logs.json', ...)
```

`unnest(m)` only works when DuckDB infers `m` as a `STRUCT`. When a container emits JSON messages with mixed shapes (a differently-shaped object, a key with conflicting value types, or a non-object value), DuckDB types `m` as `JSON` instead, and `unnest()` rejects it. The earlier `map_inference_threshold = -1` (#4746) only ruled out the `MAP` fallback, not the `JSON` one.

## Fix

Try the struct unnest first (unchanged fast path for uniform messages). On failure, flatten the union of object keys by hand with `json_keys` + `json_extract_string`. Dotted keys (e.g. `http.request.method`) are quoted in the JSON path (`$."http.request.method"`) so DuckDB reads them as field names instead of nested paths.

## Verification

- Reproduced locally; panel loads with the fix.
- Ran the real failing data through the bundled `@duckdb/duckdb-wasm` engine: old query throws, new logic flattens correctly.
- Uniform messages still take the fast struct path (no behavior change).
- `pnpm typecheck` clean, 113 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)