### PR TITLE
ci(renovate): group playwright npm and docker image together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,11 @@
   "extends": ["config:recommended", "schedule:weekly", "group:allNonMajor", ":automergeMinor"],
   "rangeStrategy": "bump",
   "minimumReleaseAge": "24 hours",
-  "ignoreDeps": []
+  "ignoreDeps": [],
+  "packageRules": [
+    {
+      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
+      "groupName": "playwright"
+    }
+  ]
 }


### PR DESCRIPTION
Groups `@playwright/test` and the `mcr.microsoft.com/playwright` docker image into a single `playwright` renovate group so they bump in the same PR.

This is the follow-up to #4793, where the npm package updated to 1.61.0 but the docker image in docker-compose.yml stayed at v1.60.0-jammy, so the runner couldn't find the browser build and integration tests failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)