### PR TITLE
fix(web): apply per-user label filter to events stream stats/lifecycle channels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ fake_assets:
 test: fake_assets generate
 	go test -cover -race -count 1 -timeout 40s ./...
 
+.PHONY: test-update
+test-update: fake_assets generate
+	go test -cover -race -count 1 -timeout 5s ./... -- -- -u
+
 .PHONY: build
 build: dist generate
 	CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/amir20/dozzle/internal/support/cli.Version=local"

--- a/internal/web/__snapshots__/web.snapshot
+++ b/internal/web/__snapshots__/web.snapshot
@@ -137,10 +137,6 @@ event: containers-changed
 data: [{"id":"visible","name":"visible","image":"test","command":"","created":"0001-01-01T00:00:00Z","startedAt":"0001-01-01T00:00:00Z","finishedAt":"0001-01-01T00:00:00Z","state":"","stats":[],"memoryLimit":0,"cpuLimit":0}]
 
 
-event: containers-changed
-data: [{"id":"visible","name":"visible","image":"test","command":"","created":"0001-01-01T00:00:00Z","startedAt":"0001-01-01T00:00:00Z","finishedAt":"0001-01-01T00:00:00Z","state":"","stats":[],"memoryLimit":0,"cpuLimit":0}]
-
-
 event: container-event
 data: {"name":"start","host":"localhost","actorId":"visible","time":"0001-01-01T00:00:00Z"}
 

--- a/internal/web/__snapshots__/web.snapshot
+++ b/internal/web/__snapshots__/web.snapshot
@@ -119,6 +119,31 @@ X-Accel-Buffering: no
 event: containers-changed
 data: []
 
+/* snapshot: Test_handler_streamEvents_filtered */
+HTTP/1.1 200 OK
+Connection: close
+Cache-Control: no-transform
+Cache-Control: no-cache
+Connection: keep-alive
+Content-Security-Policy: default-src 'self' 'wasm-unsafe-eval' blob: https://cdn.jsdelivr.net https://*.duckdb.org; style-src 'self' 'unsafe-inline' blob:; img-src 'self' data:; font-src 'self' data:;
+Content-Type: text/event-stream
+X-Accel-Buffering: no
+
+event: containers-changed
+data: [{"id":"visible","name":"visible","image":"test","command":"","created":"0001-01-01T00:00:00Z","startedAt":"0001-01-01T00:00:00Z","finishedAt":"0001-01-01T00:00:00Z","state":"","stats":[],"memoryLimit":0,"cpuLimit":0}]
+
+
+event: containers-changed
+data: [{"id":"visible","name":"visible","image":"test","command":"","created":"0001-01-01T00:00:00Z","startedAt":"0001-01-01T00:00:00Z","finishedAt":"0001-01-01T00:00:00Z","state":"","stats":[],"memoryLimit":0,"cpuLimit":0}]
+
+
+event: containers-changed
+data: [{"id":"visible","name":"visible","image":"test","command":"","created":"0001-01-01T00:00:00Z","startedAt":"0001-01-01T00:00:00Z","finishedAt":"0001-01-01T00:00:00Z","state":"","stats":[],"memoryLimit":0,"cpuLimit":0}]
+
+
+event: container-event
+data: {"name":"start","host":"localhost","actorId":"visible","time":"0001-01-01T00:00:00Z"}
+
 /* snapshot: Test_handler_streamEvents_happy */
 HTTP/1.1 200 OK
 Connection: close
@@ -130,11 +155,11 @@ Content-Type: text/event-stream
 X-Accel-Buffering: no
 
 event: containers-changed
-data: []
+data: [{"id":"1234","name":"test","image":"test","command":"","created":"0001-01-01T00:00:00Z","startedAt":"0001-01-01T00:00:00Z","finishedAt":"0001-01-01T00:00:00Z","state":"","stats":[],"memoryLimit":0,"cpuLimit":0}]
 
 
 event: containers-changed
-data: []
+data: [{"id":"1234","name":"test","image":"test","command":"","created":"0001-01-01T00:00:00Z","startedAt":"0001-01-01T00:00:00Z","finishedAt":"0001-01-01T00:00:00Z","state":"","stats":[],"memoryLimit":0,"cpuLimit":0}]
 
 
 event: container-event

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -38,6 +38,44 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 
 	allContainers, errors := h.hostService.ListAllContainers(userLabels)
 
+	// Track the set of container IDs the caller is allowed to see (per host) so
+	// that the container-stat and container-event channels honor the same label
+	// filter as the container list. Without this, telemetry and lifecycle events
+	// for out-of-scope containers leak to restricted users.
+	visibleByHost := make(map[string]map[string]struct{})
+	setVisible := func(host string, containers []container.Container) {
+		ids := make(map[string]struct{}, len(containers))
+		for _, c := range containers {
+			ids[c.ID] = struct{}{}
+		}
+		visibleByHost[host] = ids
+	}
+	isVisible := func(host, id string) bool {
+		if host != "" {
+			ids, ok := visibleByHost[host]
+			if !ok {
+				return false
+			}
+			_, ok = ids[id]
+			return ok
+		}
+		// container-stat payloads carry no host, so fall back to scanning all hosts
+		for _, ids := range visibleByHost {
+			if _, ok := ids[id]; ok {
+				return true
+			}
+		}
+		return false
+	}
+
+	grouped := make(map[string][]container.Container)
+	for _, c := range allContainers {
+		grouped[c.Host] = append(grouped[c.Host], c)
+	}
+	for host, containers := range grouped {
+		setVisible(host, containers)
+	}
+
 	for _, err := range errors {
 		log.Warn().Err(err).Msg("error listing containers")
 		if hostNotAvailableError, ok := err.(*docker_support.HostUnavailableError); ok {
@@ -61,6 +99,9 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		case stat := <-stats:
+			if !isVisible("", stat.ID) {
+				continue
+			}
 			if err := sseWriter.Event("container-stat", stat); err != nil {
 				log.Error().Err(err).Msg("error writing event to event stream")
 				return
@@ -75,11 +116,16 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 				if event.Name == "start" || event.Name == "rename" {
 					if containers, err := h.hostService.ListContainersForHost(event.Host, userLabels); err == nil {
 						log.Debug().Str("host", event.Host).Int("count", len(containers)).Msg("updating containers for host")
+						setVisible(event.Host, containers)
 						if err := sseWriter.Event("containers-changed", containers); err != nil {
 							log.Error().Err(err).Msg("error writing containers to event stream")
 							return
 						}
 					}
+				}
+
+				if !isVisible(event.Host, event.ActorID) {
+					continue
 				}
 
 				if err := sseWriter.Event("container-event", event); err != nil {
@@ -88,11 +134,17 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 				}
 
 			case "update":
+				if event.Container == nil || !isVisible(event.Host, event.Container.ID) {
+					continue
+				}
 				if err := sseWriter.Event("container-updated", event.Container); err != nil {
 					log.Error().Err(err).Msg("error writing event to event stream")
 					return
 				}
 			case "health_status: healthy", "health_status: unhealthy":
+				if !isVisible(event.Host, event.ActorID) {
+					continue
+				}
 				healthy := "unhealthy"
 				if event.Name == "health_status: healthy" {
 					healthy = "healthy"

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -38,10 +38,7 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 
 	allContainers, errors := h.hostService.ListAllContainers(userLabels)
 
-	// Track the set of container IDs the caller is allowed to see (per host) so
-	// that the container-stat and container-event channels honor the same label
-	// filter as the container list. Without this, telemetry and lifecycle events
-	// for out-of-scope containers leak to restricted users.
+	// per-host set of container IDs the caller may see, so stat/event channels stay filtered like the list
 	visibleByHost := make(map[string]map[string]struct{})
 	setVisible := func(host string, containers []container.Container) {
 		ids := make(map[string]struct{}, len(containers))
@@ -68,12 +65,13 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 		return false
 	}
 
-	grouped := make(map[string][]container.Container)
 	for _, c := range allContainers {
-		grouped[c.Host] = append(grouped[c.Host], c)
-	}
-	for host, containers := range grouped {
-		setVisible(host, containers)
+		ids, ok := visibleByHost[c.Host]
+		if !ok {
+			ids = make(map[string]struct{})
+			visibleByHost[c.Host] = ids
+		}
+		ids[c.ID] = struct{}{}
 	}
 
 	for _, err := range errors {
@@ -113,19 +111,26 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 			log.Trace().Str("event", event.Name).Str("id", event.ActorID).Msg("container event from store")
 			switch event.Name {
 			case "start", "die", "destroy", "rename", "pause", "unpause":
+				var refreshed []container.Container
 				if event.Name == "start" || event.Name == "rename" {
 					if containers, err := h.hostService.ListContainersForHost(event.Host, userLabels); err == nil {
 						log.Debug().Str("host", event.Host).Int("count", len(containers)).Msg("updating containers for host")
 						setVisible(event.Host, containers)
-						if err := sseWriter.Event("containers-changed", containers); err != nil {
-							log.Error().Err(err).Msg("error writing containers to event stream")
-							return
-						}
+						refreshed = containers
 					}
 				}
 
+				// gate both containers-changed and the raw event so out-of-scope
+				// containers don't leak via payload or as a timing side-channel
 				if !isVisible(event.Host, event.ActorID) {
 					continue
+				}
+
+				if refreshed != nil {
+					if err := sseWriter.Event("containers-changed", refreshed); err != nil {
+						log.Error().Err(err).Msg("error writing containers to event stream")
+						return
+					}
 				}
 
 				if err := sseWriter.Event("container-event", event); err != nil {

--- a/internal/web/events_test.go
+++ b/internal/web/events_test.go
@@ -24,7 +24,9 @@ func Test_handler_streamEvents_happy(t *testing.T) {
 
 	mockedClient := new(MockedClient)
 
-	mockedClient.On("ListContainers", mock.Anything, mock.Anything).Return([]container.Container{}, nil)
+	mockedClient.On("ListContainers", mock.Anything, mock.Anything).Return([]container.Container{
+		{ID: "1234", Name: "test", Image: "test", Host: "localhost"},
+	}, nil)
 	mockedClient.On("ContainerEvents", mock.Anything, mock.AnythingOfType("chan<- container.ContainerEvent")).Return(nil).Run(func(args mock.Arguments) {
 		messages := args.Get(1).(chan<- container.ContainerEvent)
 
@@ -54,6 +56,65 @@ func Test_handler_streamEvents_happy(t *testing.T) {
 	})
 
 	// This is needed so that the server is initialized for store
+	manager := docker_support.NewRetriableClientManager(nil, 3*time.Second, tls.Certificate{}, docker_support.NewDockerClientService(mockedClient, container.ContainerLabels{}))
+	multiHostService := docker_support.NewMultiHostService(manager, 3*time.Second)
+
+	server := CreateServer(multiHostService, nil, Config{Base: "/", Authorization: Authorization{Provider: NONE}})
+
+	handler := server.Handler
+	rr := httptest.NewRecorder()
+
+	handler.ServeHTTP(rr, req)
+	abide.AssertHTTPResponse(t, t.Name(), rr.Result())
+	mockedClient.AssertExpectations(t)
+}
+
+// Test_handler_streamEvents_filtered asserts that container-event for a container
+// outside the caller's label scope is not forwarded. The mocked ListContainers
+// only ever returns the in-scope container ("visible"), so the out-of-scope
+// container ("secret") is never added to the visible set and its lifecycle event
+// must be dropped. See GHSA-xcw9-qmmf-vqxj.
+func Test_handler_streamEvents_filtered(t *testing.T) {
+	context, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(context, "GET", "/api/events/stream", nil)
+	require.NoError(t, err, "NewRequest should not return an error.")
+
+	mockedClient := new(MockedClient)
+
+	mockedClient.On("ListContainers", mock.Anything, mock.Anything).Return([]container.Container{
+		{ID: "visible", Name: "visible", Image: "test", Host: "localhost"},
+	}, nil)
+	mockedClient.On("ContainerEvents", mock.Anything, mock.AnythingOfType("chan<- container.ContainerEvent")).Return(nil).Run(func(args mock.Arguments) {
+		messages := args.Get(1).(chan<- container.ContainerEvent)
+
+		time.Sleep(50 * time.Millisecond)
+		// out-of-scope container: must be dropped
+		messages <- container.ContainerEvent{
+			Name:    "start",
+			ActorID: "secret",
+			Host:    "localhost",
+		}
+		// in-scope container: must be forwarded
+		messages <- container.ContainerEvent{
+			Name:    "start",
+			ActorID: "visible",
+			Host:    "localhost",
+		}
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	})
+
+	mockedClient.On("FindContainer", mock.Anything, mock.Anything).Return(container.Container{
+		ID:    "visible",
+		Name:  "visible",
+		Image: "test",
+		Stats: utils.NewRingBuffer[container.ContainerStat](300),
+	}, nil)
+
+	mockedClient.On("Host").Return(container.Host{
+		ID: "localhost",
+	})
+
 	manager := docker_support.NewRetriableClientManager(nil, 3*time.Second, tls.Certificate{}, docker_support.NewDockerClientService(mockedClient, container.ContainerLabels{}))
 	multiHostService := docker_support.NewMultiHostService(manager, 3*time.Second)
 


### PR DESCRIPTION
## Summary

Fixes GHSA-xcw9-qmmf-vqxj. The events SSE handler (`/api/events/stream`) applied the caller's per-user label filter to the container list and `containers-changed` updates, but forwarded `container-stat` and `container-event` (plus `container-updated`/`container-health`) to every authenticated client with no filter check. A user restricted to one label scope received live telemetry (CPU/memory/network/disk) and lifecycle metadata (name, image, full label map) for every container on every host, crossing the isolation boundary the filter feature is documented to enforce.

## Fix

- Build a per-host set of visible container IDs from the already-filtered `ListAllContainers(userLabels)`.
- Refresh the set on each `containers-changed` (start/rename).
- Gate `container-stat` (by `stat.ID`, scanning all hosts since stats carry no host), `container-event` (by `ActorID`), `container-updated`, and `container-health` through it.

No behavior change for unfiltered or single-user deployments (the visible set contains everything).

## Tests

- Added `Test_handler_streamEvents_filtered`: an out-of-scope `start` event is dropped while an in-scope one is forwarded.
- Updated the happy-path test to list a realistic container.

`go build ./...` clean, `go test -race ./internal/web/` passes.

Credit 5ud0 / Tarmo Technologies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)