### PR TITLE
fix(coolify): include PR id in preview container display names

### DIFF
--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -507,12 +507,28 @@ func (d *DockerClient) ContainerExec(ctx context.Context, id string, cmd []strin
 	}, nil
 }
 
+// coolifyName returns the Coolify service name for display, prefixed with the
+// pull-request id for PR-preview deployments. Coolify sets an identical
+// coolify.serviceName label on an application and every one of its PR previews,
+// so without the PR id all previews of the same app are indistinguishable in
+// the UI. Returns "" when the container is not Coolify-managed.
+func coolifyName(labels map[string]string) string {
+	name := labels["coolify.serviceName"]
+	if name == "" {
+		return ""
+	}
+	if pr := labels["coolify.pullRequestId"]; pr != "" && pr != "0" {
+		return "PR " + pr + " · " + name
+	}
+	return name
+}
+
 func newContainer(c docker.Summary, host string) container.Container {
 	name := "no name"
 	if c.Labels["dev.dozzle.name"] != "" {
 		name = c.Labels["dev.dozzle.name"]
-	} else if c.Labels["coolify.serviceName"] != "" {
-		name = c.Labels["coolify.serviceName"]
+	} else if n := coolifyName(c.Labels); n != "" {
+		name = n
 	} else if len(c.Names) > 0 {
 		name = strings.TrimPrefix(c.Names[0], "/")
 	}
@@ -541,8 +557,8 @@ func newContainerFromJSON(c docker.InspectResponse, host string) container.Conta
 	name := "no name"
 	if c.Config.Labels["dev.dozzle.name"] != "" {
 		name = c.Config.Labels["dev.dozzle.name"]
-	} else if c.Config.Labels["coolify.serviceName"] != "" {
-		name = c.Config.Labels["coolify.serviceName"]
+	} else if n := coolifyName(c.Config.Labels); n != "" {
+		name = n
 	} else if len(c.Name) > 0 {
 		name = strings.TrimPrefix(c.Name, "/")
 	}

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -285,6 +285,20 @@ func Test_newContainer_labelPriority(t *testing.T) {
 			expectedName:  "coolify-name",
 			expectedGroup: "dozzle-group",
 		},
+		{
+			name:          "coolify preview includes PR id",
+			labels:        map[string]string{"coolify.serviceName": "coolify-name", "coolify.pullRequestId": "1241", "coolify.projectName": "coolify-project"},
+			containerName: "/docker-name",
+			expectedName:  "PR 1241 · coolify-name",
+			expectedGroup: "coolify-project",
+		},
+		{
+			name:          "coolify pullRequestId 0 is not a preview",
+			labels:        map[string]string{"coolify.serviceName": "coolify-name", "coolify.pullRequestId": "0", "coolify.projectName": "coolify-project"},
+			containerName: "/docker-name",
+			expectedName:  "coolify-name",
+			expectedGroup: "coolify-project",
+		},
 	}
 
 	for _, tt := range tests {
@@ -329,6 +343,20 @@ func Test_newContainerFromJSON_labelPriority(t *testing.T) {
 			containerName: "/docker-name",
 			expectedName:  "docker-name",
 			expectedGroup: "",
+		},
+		{
+			name:          "coolify preview includes PR id",
+			labels:        map[string]string{"coolify.serviceName": "coolify-name", "coolify.pullRequestId": "1241", "coolify.projectName": "coolify-project"},
+			containerName: "/docker-name",
+			expectedName:  "PR 1241 · coolify-name",
+			expectedGroup: "coolify-project",
+		},
+		{
+			name:          "coolify pullRequestId 0 is not a preview",
+			labels:        map[string]string{"coolify.serviceName": "coolify-name", "coolify.pullRequestId": "0", "coolify.projectName": "coolify-project"},
+			containerName: "/docker-name",
+			expectedName:  "coolify-name",
+			expectedGroup: "coolify-project",
 		},
 	}
 


### PR DESCRIPTION
## Problem

When Dozzle monitors a Coolify host, every PR-preview container of an application shows the **same** name in the sidebar, so they can't be told apart.

Coolify sets an identical `coolify.serviceName` label on an application **and all of its PR previews** — only the container name and the `coolify.pullRequestId` label differ between them. Dozzle's name resolution prefers `coolify.serviceName` over the container name:

```
dev.dozzle.name  >  coolify.serviceName  >  container name
```

so all previews of one app collapse to a single indistinguishable entry (e.g. seven previews all showing `myapp-myapp-develop-<uuid>`), and the only unique part — the container name `...-pr-<N>` — is shadowed.

## Fix

Coolify already stamps `coolify.pullRequestId` on every managed container (`0` for the base app, the PR number for previews). When falling back to `coolify.serviceName`, fold that id into the display name for preview deployments, so previews show as `PR 1241 · myapp-…` with the PR number at the front (where it stays visible even in a narrow sidebar).

- Non-preview containers (`coolify.pullRequestId` absent or `0`) are unchanged.
- An explicit `dev.dozzle.name` still wins — user override is untouched.
- Applies to both the list view (`newContainer`) and the detail view (`newContainerFromJSON`) via a small shared helper.

Added table cases to `Test_newContainer_labelPriority` and `Test_newContainerFromJSON_labelPriority` covering the preview (PR id prefixed) and `pullRequestId=0` (unchanged) paths.

The separator/format (`PR <id> · `) is trivial to tweak if you'd prefer another style.

> Note: I don't have a Go toolchain on the machine I authored this on, so I couldn't run `go test ./internal/docker/...` locally — relying on CI here. The change is mechanical (map lookups + string concat) and `gofmt`-clean.
