### PR TITLE
fix(k8s): trim owner labels, bound owner cache, refresh discovery

### DIFF
--- a/assets/stores/k8s.ts
+++ b/assets/stores/k8s.ts
@@ -53,19 +53,16 @@ export function ownerMembershipLabel(key: string) {
 }
 
 export function getK8sOwnerRefs(container: Container): K8sOwnerRef[] {
-  const count = Number(container.labels["@k8s.owner.count"] ?? container.labels["k8s.owner.count"] ?? 0);
+  const count = Number(container.labels["@k8s.owner.count"] ?? 0);
   if (count > 0) {
     const owners: K8sOwnerRef[] = [];
     for (let i = 0; i < count; i++) {
-      const syntheticPrefix = `@k8s.owner.${i}.`;
-      const legacyPrefix = `k8s.owner.${i}.`;
-      const labelValue = (key: string) =>
-        container.labels[`${syntheticPrefix}${key}`] ?? container.labels[`${legacyPrefix}${key}`];
-      const kind = labelValue("kind");
-      const name = labelValue("name");
-      const namespace = labelValue("namespace");
+      const prefix = `@k8s.owner.${i}.`;
+      const kind = container.labels[`${prefix}kind`];
+      const name = container.labels[`${prefix}name`];
+      const namespace = container.labels[`${prefix}namespace`];
       if (!kind || !name) continue;
-      const key = labelValue("key") ?? `${kind}~${namespace ?? ""}~${name}`;
+      const key = container.labels[`${prefix}key`] ?? `${kind}~${namespace ?? ""}~${name}`;
       owners.push({ key, label: ownerMembershipLabel(key), kind, name, namespace });
     }
     return owners;

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -47,6 +47,9 @@ type K8sClient struct {
 	host          container.Host
 	ownerCacheMu  sync.Mutex
 	ownerCache    map[string]ownerLookupResult
+
+	mapperMu        sync.Mutex
+	lastMapperReset time.Time
 }
 
 func NewK8sClient(namespace []string) (*K8sClient, error) {
@@ -135,6 +138,12 @@ const (
 	ownerCacheTTL = 5 * time.Minute
 	// Hard cap so a cluster with heavy ReplicaSet churn can't grow the cache unbounded.
 	ownerCacheMaxSize = 4096
+	// Evict down to this size once the cap is hit, so eviction has hysteresis and
+	// doesn't re-run on every subsequent insert.
+	ownerCacheEvictTo = ownerCacheMaxSize * 3 / 4
+	// Discovery resets are throttled to this interval so an unmappable owner kind
+	// (typo, uninstalled CRD) can't hammer the API server's discovery endpoint.
+	mapperResetInterval = time.Minute
 )
 
 func (k *K8sClient) podToContainers(ctx context.Context, pod *corev1.Pod) []container.Container {
@@ -305,16 +314,41 @@ func (k *K8sClient) lookupOwnerReferences(ctx context.Context, owner k8sOwner) (
 }
 
 // pruneOwnerCache drops expired entries and, if the cache is still at capacity,
-// clears it wholesale. Callers must hold ownerCacheMu.
+// evicts arbitrary entries down to ownerCacheEvictTo rather than clearing it
+// wholesale, so a cluster with more than ownerCacheMaxSize live owners doesn't
+// thrash by refetching everything. Callers must hold ownerCacheMu.
 func (k *K8sClient) pruneOwnerCache(now time.Time) {
 	for key, result := range k.ownerCache {
 		if !now.Before(result.expiresAt) {
 			delete(k.ownerCache, key)
 		}
 	}
-	if len(k.ownerCache) >= ownerCacheMaxSize {
-		k.ownerCache = make(map[string]ownerLookupResult)
+	// Map iteration order is randomized, so this evicts an arbitrary subset.
+	for key := range k.ownerCache {
+		if len(k.ownerCache) <= ownerCacheEvictTo {
+			break
+		}
+		delete(k.ownerCache, key)
 	}
+}
+
+// resetRESTMapper resets the cached discovery mapper so newly-registered CRDs
+// can be mapped, at most once per mapperResetInterval. Returns true if it reset.
+func (k *K8sClient) resetRESTMapper() bool {
+	resetter, ok := k.restMapper.(interface{ Reset() })
+	if !ok {
+		return false
+	}
+
+	k.mapperMu.Lock()
+	defer k.mapperMu.Unlock()
+	now := time.Now()
+	if !k.lastMapperReset.IsZero() && now.Sub(k.lastMapperReset) < mapperResetInterval {
+		return false
+	}
+	k.lastMapperReset = now
+	resetter.Reset()
+	return true
 }
 
 func (k *K8sClient) fetchOwnerReferences(ctx context.Context, owner k8sOwner) ([]metav1.OwnerReference, bool, bool) {
@@ -328,13 +362,14 @@ func (k *K8sClient) fetchOwnerReferences(ctx context.Context, owner k8sOwner) ([
 		return nil, false, false
 	}
 
-	mapping, err := k.restMapper.RESTMapping(groupVersion.WithKind(owner.Kind).GroupKind(), groupVersion.Version)
+	gk := groupVersion.WithKind(owner.Kind).GroupKind()
+	mapping, err := k.restMapper.RESTMapping(gk, groupVersion.Version)
 	if err != nil {
-		// Discovery is cached, so a CRD registered after startup won't map until
-		// the cache is reset. Reset once and retry before giving up.
-		if resetter, ok := k.restMapper.(interface{ Reset() }); ok {
-			resetter.Reset()
-			mapping, err = k.restMapper.RESTMapping(groupVersion.WithKind(owner.Kind).GroupKind(), groupVersion.Version)
+		// Discovery is cached, so a CRD registered after startup won't map until the
+		// cache is reset. Reset and retry, but throttle resets so a permanently
+		// unmappable kind can't hammer the discovery endpoint on every pod event.
+		if k.resetRESTMapper() {
+			mapping, err = k.restMapper.RESTMapping(gk, groupVersion.Version)
 		}
 		if err != nil {
 			log.Debug().Err(err).Str("owner", owner.Key).Msg("failed to map owner resource")

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -126,7 +126,16 @@ type k8sOwner struct {
 type ownerLookupResult struct {
 	ownerReferences []metav1.OwnerReference
 	found           bool
+	expiresAt       time.Time
 }
+
+const (
+	// TTL bounds owner-cache staleness so entries recover after RBAC is granted
+	// and let expired entries be swept, keeping the cache from growing forever.
+	ownerCacheTTL = 5 * time.Minute
+	// Hard cap so a cluster with heavy ReplicaSet churn can't grow the cache unbounded.
+	ownerCacheMaxSize = 4096
+)
 
 func (k *K8sClient) podToContainers(ctx context.Context, pod *corev1.Pod) []container.Container {
 	started := time.Time{}
@@ -144,27 +153,20 @@ func (k *K8sClient) podToContainers(ctx context.Context, pod *corev1.Pod) []cont
 
 	owners := k.resolveOwnerChain(ctx, pod.Namespace, pod.OwnerReferences)
 	if len(owners) > 0 {
+		// Immediate owner kept as top-level labels for backward compatibility.
 		labels["owner.kind"] = owners[0].Kind
 		labels["owner.name"] = owners[0].Name
 		labels["owner.key"] = owners[0].Key
-		labels["k8s.owner.count"] = fmt.Sprintf("%d", len(owners))
 		labels["@k8s.owner.count"] = fmt.Sprintf("%d", len(owners))
 	}
 	for i, owner := range owners {
-		prefix := fmt.Sprintf("k8s.owner.%d.", i)
-		syntheticPrefix := fmt.Sprintf("@k8s.owner.%d.", i)
+		prefix := fmt.Sprintf("@k8s.owner.%d.", i)
 		labels[prefix+"apiVersion"] = owner.APIVersion
 		labels[prefix+"kind"] = owner.Kind
 		labels[prefix+"namespace"] = owner.Namespace
 		labels[prefix+"name"] = owner.Name
 		labels[prefix+"uid"] = owner.UID
 		labels[prefix+"key"] = owner.Key
-		labels[syntheticPrefix+"apiVersion"] = owner.APIVersion
-		labels[syntheticPrefix+"kind"] = owner.Kind
-		labels[syntheticPrefix+"namespace"] = owner.Namespace
-		labels[syntheticPrefix+"name"] = owner.Name
-		labels[syntheticPrefix+"uid"] = owner.UID
-		labels[syntheticPrefix+"key"] = owner.Key
 		labels[ownerMembershipLabel(owner.Key)] = "true"
 	}
 
@@ -278,11 +280,13 @@ func isKnownK8sOwnerType(apiVersion, kind string) bool {
 
 func (k *K8sClient) lookupOwnerReferences(ctx context.Context, owner k8sOwner) ([]metav1.OwnerReference, bool) {
 	cacheKey := owner.cacheKey()
+	now := time.Now()
+
 	k.ownerCacheMu.Lock()
 	if k.ownerCache == nil {
 		k.ownerCache = make(map[string]ownerLookupResult)
 	}
-	if result, ok := k.ownerCache[cacheKey]; ok {
+	if result, ok := k.ownerCache[cacheKey]; ok && now.Before(result.expiresAt) {
 		k.ownerCacheMu.Unlock()
 		return result.ownerReferences, result.found
 	}
@@ -292,11 +296,25 @@ func (k *K8sClient) lookupOwnerReferences(ctx context.Context, owner k8sOwner) (
 
 	if cacheable {
 		k.ownerCacheMu.Lock()
-		k.ownerCache[cacheKey] = ownerLookupResult{ownerReferences: refs, found: ok}
+		k.pruneOwnerCache(now)
+		k.ownerCache[cacheKey] = ownerLookupResult{ownerReferences: refs, found: ok, expiresAt: now.Add(ownerCacheTTL)}
 		k.ownerCacheMu.Unlock()
 	}
 
 	return refs, ok
+}
+
+// pruneOwnerCache drops expired entries and, if the cache is still at capacity,
+// clears it wholesale. Callers must hold ownerCacheMu.
+func (k *K8sClient) pruneOwnerCache(now time.Time) {
+	for key, result := range k.ownerCache {
+		if !now.Before(result.expiresAt) {
+			delete(k.ownerCache, key)
+		}
+	}
+	if len(k.ownerCache) >= ownerCacheMaxSize {
+		k.ownerCache = make(map[string]ownerLookupResult)
+	}
 }
 
 func (k *K8sClient) fetchOwnerReferences(ctx context.Context, owner k8sOwner) ([]metav1.OwnerReference, bool, bool) {
@@ -312,8 +330,16 @@ func (k *K8sClient) fetchOwnerReferences(ctx context.Context, owner k8sOwner) ([
 
 	mapping, err := k.restMapper.RESTMapping(groupVersion.WithKind(owner.Kind).GroupKind(), groupVersion.Version)
 	if err != nil {
-		log.Debug().Err(err).Str("owner", owner.Key).Msg("failed to map owner resource")
-		return nil, false, false
+		// Discovery is cached, so a CRD registered after startup won't map until
+		// the cache is reset. Reset once and retry before giving up.
+		if resetter, ok := k.restMapper.(interface{ Reset() }); ok {
+			resetter.Reset()
+			mapping, err = k.restMapper.RESTMapping(groupVersion.WithKind(owner.Kind).GroupKind(), groupVersion.Version)
+		}
+		if err != nil {
+			log.Debug().Err(err).Str("owner", owner.Key).Msg("failed to map owner resource")
+			return nil, false, false
+		}
 	}
 
 	var resource dynamic.ResourceInterface
@@ -355,8 +381,7 @@ func isK8sMetadataLabel(key string) bool {
 	return key == "namespace" ||
 		key == "owner.kind" ||
 		key == "owner.name" ||
-		key == "owner.key" ||
-		strings.HasPrefix(key, "k8s.owner.")
+		key == "owner.key"
 }
 
 var (

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -313,15 +313,19 @@ func (k *K8sClient) lookupOwnerReferences(ctx context.Context, owner k8sOwner) (
 	return refs, ok
 }
 
-// pruneOwnerCache drops expired entries and, if the cache is still at capacity,
-// evicts arbitrary entries down to ownerCacheEvictTo rather than clearing it
-// wholesale, so a cluster with more than ownerCacheMaxSize live owners doesn't
-// thrash by refetching everything. Callers must hold ownerCacheMu.
+// pruneOwnerCache drops expired entries and, only once the cache grows past
+// ownerCacheMaxSize, evicts arbitrary entries down to ownerCacheEvictTo. This
+// hysteresis (grow to max, drop to evictTo) bounds growth without evicting on
+// every insert, and avoids clearing the map wholesale so a cluster with more
+// than ownerCacheMaxSize live owners doesn't thrash. Callers must hold ownerCacheMu.
 func (k *K8sClient) pruneOwnerCache(now time.Time) {
 	for key, result := range k.ownerCache {
 		if !now.Before(result.expiresAt) {
 			delete(k.ownerCache, key)
 		}
+	}
+	if len(k.ownerCache) <= ownerCacheMaxSize {
+		return
 	}
 	// Map iteration order is randomized, so this evicts an arbitrary subset.
 	for key := range k.ownerCache {

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -49,17 +49,17 @@ func TestPodToContainersAddsOwnerChainLabels(t *testing.T) {
 	assert.Equal(t, "ReplicaSet", labels["owner.kind"])
 	assert.Equal(t, "api-6f88b977f4", labels["owner.name"])
 	assert.Equal(t, "ReplicaSet~default~api-6f88b977f4", labels["owner.key"])
-	assert.Equal(t, "2", labels["k8s.owner.count"])
 	assert.Equal(t, "2", labels["@k8s.owner.count"])
 
-	assert.Equal(t, "ReplicaSet", labels["k8s.owner.0.kind"])
 	assert.Equal(t, "ReplicaSet", labels["@k8s.owner.0.kind"])
-	assert.Equal(t, "api-6f88b977f4", labels["k8s.owner.0.name"])
-	assert.Equal(t, "ReplicaSet~default~api-6f88b977f4", labels["k8s.owner.0.key"])
-	assert.Equal(t, "Deployment", labels["k8s.owner.1.kind"])
+	assert.Equal(t, "api-6f88b977f4", labels["@k8s.owner.0.name"])
+	assert.Equal(t, "ReplicaSet~default~api-6f88b977f4", labels["@k8s.owner.0.key"])
 	assert.Equal(t, "Deployment", labels["@k8s.owner.1.kind"])
-	assert.Equal(t, "api", labels["k8s.owner.1.name"])
-	assert.Equal(t, "Deployment~default~api", labels["k8s.owner.1.key"])
+	assert.Equal(t, "api", labels["@k8s.owner.1.name"])
+	assert.Equal(t, "Deployment~default~api", labels["@k8s.owner.1.key"])
+	// Legacy duplicated k8s.owner.* labels are no longer emitted.
+	assert.Empty(t, labels["k8s.owner.count"])
+	assert.Empty(t, labels["k8s.owner.0.kind"])
 	assert.Equal(t, "true", labels[ownerMembershipLabel("ReplicaSet~default~api-6f88b977f4")])
 	assert.Equal(t, "true", labels[ownerMembershipLabel("Deployment~default~api")])
 }
@@ -71,10 +71,10 @@ func TestPodToContainersStopsOwnerChainWhenOwnerCannotBeFetched(t *testing.T) {
 	require.Len(t, containers, 1)
 
 	labels := containers[0].Labels
-	assert.Equal(t, "1", labels["k8s.owner.count"])
-	assert.Equal(t, "ReplicaSet", labels["k8s.owner.0.kind"])
-	assert.Equal(t, "api-6f88b977f4", labels["k8s.owner.0.name"])
-	assert.Empty(t, labels["k8s.owner.1.kind"])
+	assert.Equal(t, "1", labels["@k8s.owner.count"])
+	assert.Equal(t, "ReplicaSet", labels["@k8s.owner.0.kind"])
+	assert.Equal(t, "api-6f88b977f4", labels["@k8s.owner.0.name"])
+	assert.Empty(t, labels["@k8s.owner.1.kind"])
 }
 
 func TestPodToContainersDoesNotAddNodeOwner(t *testing.T) {
@@ -89,7 +89,6 @@ func TestPodToContainersDoesNotAddNodeOwner(t *testing.T) {
 
 	labels := containers[0].Labels
 	assert.Empty(t, labels["owner.kind"])
-	assert.Empty(t, labels["k8s.owner.count"])
 	assert.Empty(t, labels["@k8s.owner.count"])
 }
 
@@ -112,9 +111,9 @@ func TestPodToContainersStopsBeforeNodeOwnerInChain(t *testing.T) {
 	require.Len(t, containers, 1)
 
 	labels := containers[0].Labels
-	assert.Equal(t, "1", labels["k8s.owner.count"])
-	assert.Equal(t, "ReplicaSet", labels["k8s.owner.0.kind"])
-	assert.Empty(t, labels["k8s.owner.1.kind"])
+	assert.Equal(t, "1", labels["@k8s.owner.count"])
+	assert.Equal(t, "ReplicaSet", labels["@k8s.owner.0.kind"])
+	assert.Empty(t, labels["@k8s.owner.1.kind"])
 }
 
 func TestListContainersAppliesSyntheticOwnerFiltersAfterPodList(t *testing.T) {
@@ -154,7 +153,6 @@ func TestSplitK8sFiltersKeepsInvalidSyntheticKeysOutOfPodSelector(t *testing.T) 
 		"@k8s.namespace":             {"default"},
 		"@k8s.owner.key.abc123":      {"true"},
 		"not:a:kubernetes:label:key": {"value"},
-		"k8s.owner.key.legacyabc123": {"true"},
 	})
 
 	assert.Equal(t, container.ContainerLabels{
@@ -165,7 +163,6 @@ func TestSplitK8sFiltersKeepsInvalidSyntheticKeysOutOfPodSelector(t *testing.T) 
 		"@k8s.namespace":             {"default"},
 		"@k8s.owner.key.abc123":      {"true"},
 		"not:a:kubernetes:label:key": {"value"},
-		"k8s.owner.key.legacyabc123": {"true"},
 	}, metadataLabels)
 }
 

--- a/internal/k8s/client_test.go
+++ b/internal/k8s/client_test.go
@@ -3,7 +3,9 @@ package k8s
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/amir20/dozzle/internal/container"
 	"github.com/stretchr/testify/assert"
@@ -239,6 +241,84 @@ func TestLookupOwnerReferencesCachesRealNegatives(t *testing.T) {
 			assert.Equal(t, 1, calls)
 		})
 	}
+}
+
+func TestLookupOwnerReferencesRefetchesAfterTTL(t *testing.T) {
+	client := newTestK8sClient(t,
+		&appsv1.ReplicaSet{
+			TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "ReplicaSet"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "api-6f88b977f4", UID: types.UID("rs-uid")},
+		},
+	)
+	dynamicClient := client.DynamicClient.(*dynamicfake.FakeDynamicClient)
+	calls := 0
+	dynamicClient.PrependReactor("get", "replicasets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		calls++
+		return false, nil, nil
+	})
+	owner := replicaSetOwner()
+
+	_, ok := client.lookupOwnerReferences(t.Context(), owner)
+	assert.True(t, ok)
+	client.lookupOwnerReferences(t.Context(), owner)
+	assert.Equal(t, 1, calls, "second lookup should be served from cache")
+
+	// Expire the cached entry and confirm the next lookup refetches.
+	client.ownerCacheMu.Lock()
+	entry := client.ownerCache[owner.cacheKey()]
+	entry.expiresAt = time.Now().Add(-time.Minute)
+	client.ownerCache[owner.cacheKey()] = entry
+	client.ownerCacheMu.Unlock()
+
+	client.lookupOwnerReferences(t.Context(), owner)
+	assert.Equal(t, 2, calls, "expired entry should trigger a refetch")
+}
+
+func TestPruneOwnerCacheEvictsGracefully(t *testing.T) {
+	client := newTestK8sClient(t)
+	now := time.Now()
+
+	client.ownerCacheMu.Lock()
+	for i := range 10 {
+		client.ownerCache[fmt.Sprintf("expired-%d", i)] = ownerLookupResult{expiresAt: now.Add(-time.Minute)}
+	}
+	for i := range ownerCacheMaxSize + 100 {
+		client.ownerCache[fmt.Sprintf("fresh-%d", i)] = ownerLookupResult{expiresAt: now.Add(time.Minute)}
+	}
+
+	client.pruneOwnerCache(now)
+
+	assert.LessOrEqual(t, len(client.ownerCache), ownerCacheEvictTo)
+	assert.NotEmpty(t, client.ownerCache, "should evict down, not clear wholesale")
+	for i := range 10 {
+		_, ok := client.ownerCache[fmt.Sprintf("expired-%d", i)]
+		assert.False(t, ok, "expired entries should be dropped first")
+	}
+	client.ownerCacheMu.Unlock()
+}
+
+type resettableMapper struct {
+	meta.RESTMapper
+	resets int
+}
+
+func (m *resettableMapper) Reset() { m.resets++ }
+
+func TestResetRESTMapperThrottles(t *testing.T) {
+	mapper := &resettableMapper{}
+	client := &K8sClient{restMapper: mapper}
+
+	assert.True(t, client.resetRESTMapper(), "first reset should proceed")
+	assert.False(t, client.resetRESTMapper(), "immediate second reset should be throttled")
+	assert.Equal(t, 1, mapper.resets)
+
+	// Simulate the throttle interval elapsing.
+	client.mapperMu.Lock()
+	client.lastMapperReset = time.Now().Add(-2 * mapperResetInterval)
+	client.mapperMu.Unlock()
+
+	assert.True(t, client.resetRESTMapper(), "reset should proceed after the interval")
+	assert.Equal(t, 2, mapper.resets)
 }
 
 func podWithOwner() *corev1.Pod {


### PR DESCRIPTION
Follow-up cleanup on the owner-chain grouping from #4811.

## Changes
- Drop the duplicated legacy `k8s.owner.*` indexed labels. Only `@k8s.owner.*` synthetic labels plus top-level `owner.kind/name/key` are emitted now, halving the per-container label payload that ships over SSE/gRPC. The frontend already reads the synthetic set first, so the legacy indexed fallback was dead weight.
- Add a TTL (5m) and a hard size cap to the owner lookup cache. It could previously grow unbounded under ReplicaSet churn, and Forbidden/NotFound negatives were cached forever, so owner chains never recovered after RBAC was granted without a restart. Entries now expire and get swept.
- Reset the discovery REST mapper once and retry on mapping failure, so CRDs registered after startup (Argo Rollouts, etc.) resolve instead of staying unmapped until restart.

## Notes
Owner lookups in the `ContainerEvents` watch loop are still synchronous, but the cache keys on owner UID so shared controllers (ReplicaSet/Deployment) resolve once per rollout. Leaving that on the hot path since moving it off would risk event reordering for little gain.

Tests updated and passing (`go test -race ./internal/k8s`, frontend `k8s.spec.ts`, typecheck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)