### PR TITLE
fix(web): strip highlight markers from copied and downloaded logs

### DIFF
--- a/internal/container/sanitize.go
+++ b/internal/container/sanitize.go
@@ -2,20 +2,46 @@ package container
 
 import "strings"
 
+// Highlight markers that Dozzle injects into log messages for HTML rendering
+// (see internal/support/web: MarkerStart/End = U+E000/U+E001 for search hits,
+// URLMarkerStart/End = U+E002/U+E003 for URLs). They live in the Unicode
+// private-use area and must never appear in copied or downloaded plain-text
+// logs, where they show up as invisible garbage characters.
+const (
+	markerSearchStart = ""
+	markerSearchEnd   = ""
+	markerURLStart    = ""
+	markerURLEnd      = ""
+)
+
+var highlightMarkerStripper = strings.NewReplacer(
+	markerSearchStart, "",
+	markerSearchEnd, "",
+	markerURLStart, "",
+	markerURLEnd, "",
+)
+
+// StripHighlightMarkers removes the internal search/URL highlight markers that
+// Dozzle injects for HTML rendering. Paths that emit raw log text (clipboard
+// copy, downloads) must call it so the markers don't leak into the output.
+func StripHighlightMarkers(s string) string {
+	return highlightMarkerStripper.Replace(s)
+}
+
 // PlainText renders a log event as plain text for clipboard copy, stripping
-// ANSI escape sequences. Grouped events carry their lines in fragments and
-// have an empty RawMessage, so they are expanded one line per fragment;
-// otherwise every grouped multi-line entry collapses to a single blank line on
-// copy.
+// ANSI escape sequences and the internal highlight markers. Grouped events
+// carry their lines in fragments and have an empty RawMessage, so they are
+// expanded one line per fragment; otherwise every grouped multi-line entry
+// collapses to a single blank line on copy.
 func (e *LogEvent) PlainText() string {
 	if e.Type == LogTypeGroup {
 		if fragments, ok := e.Message.([]LogFragment); ok {
 			lines := make([]string, len(fragments))
 			for i, fragment := range fragments {
-				lines[i] = StripANSI(fragment.Message)
+				lines[i] = StripHighlightMarkers(StripANSI(fragment.Message))
 			}
 			return strings.Join(lines, "\n")
 		}
 	}
-	return StripANSI(e.RawMessage)
+	return StripHighlightMarkers(StripANSI(e.RawMessage))
 }

--- a/internal/container/sanitize_test.go
+++ b/internal/container/sanitize_test.go
@@ -38,12 +38,51 @@ func TestLogEventPlainText(t *testing.T) {
 			},
 			expected: "red\nplain",
 		},
+		{
+			// A regex filter marks search hits with U+E000/U+E001 before the
+			// event is rendered; those internal markers must not leak into the
+			// copied text.
+			name: "grouped fragments strip search-highlight markers",
+			event: &LogEvent{
+				Type: LogTypeGroup,
+				Message: []LogFragment{
+					{Message: "  at com.\ue000example\ue001.Main(Main.java:10)"},
+					{Message: "  at com.\ue000example\ue001.Foo(Foo.java:20)"},
+				},
+			},
+			expected: "  at com.example.Main(Main.java:10)\n  at com.example.Foo(Foo.java:20)",
+		},
+		{
+			name:     "single event strips search-highlight markers",
+			event:    &LogEvent{Type: LogTypeSingle, RawMessage: "found \ue000error\ue001 here"},
+			expected: "found error here",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.event.PlainText(); got != tt.expected {
 				t.Errorf("PlainText() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripHighlightMarkers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"no markers", "plain text", "plain text"},
+		{"search markers", "a \ue000b\ue001 c", "a b c"},
+		{"url markers", "see \ue002http://example.com\ue003 now", "see http://example.com now"},
+		{"mixed search and url markers", "\ue002http://x/\ue000hit\ue001\ue003", "http://x/hit"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StripHighlightMarkers(tt.input); got != tt.expected {
+				t.Errorf("StripHighlightMarkers(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}

--- a/internal/support/web/copy_leak_test.go
+++ b/internal/support/web/copy_leak_test.go
@@ -1,0 +1,40 @@
+package support_web
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/amir20/dozzle/internal/container"
+)
+
+// A regex filter marks matches with private-use markers as a side effect of
+// Search. When a grouped (multi-line) log is then copied as plain text, those
+// markers must not leak into the output.
+func TestSearchedGroupedLogCopyHasNoMarkers(t *testing.T) {
+	event := &container.LogEvent{
+		Type: container.LogTypeGroup,
+		Message: []container.LogFragment{
+			{Message: "Exception in thread main"},
+			{Message: "  at com.example.Main(Main.java:10)"},
+			{Message: "  at com.example.Foo(Foo.java:20)"},
+		},
+	}
+
+	regex, err := ParseRegex("example")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This mirrors the copy-logs path: filter via Search (mutating), then render.
+	if !Search(regex, event) {
+		t.Fatal("expected search to match the grouped log")
+	}
+
+	out := event.PlainText()
+	if strings.ContainsAny(out, MarkerStart+MarkerEnd+URLMarkerStart+URLMarkerEnd) {
+		t.Fatalf("copied text leaked highlight markers: %q", out)
+	}
+	if !strings.Contains(out, "at com.example.Main(Main.java:10)") {
+		t.Fatalf("expected grouped lines preserved, got %q", out)
+	}
+}

--- a/internal/web/download.go
+++ b/internal/web/download.go
@@ -177,7 +177,10 @@ func (h *handler) downloadLogs(w http.ResponseWriter, r *http.Request) {
 				if event.Type == container.LogTypeGroup {
 					if fragments, ok := event.Message.([]container.LogFragment); ok {
 						for _, fragment := range fragments {
-							_, err = fmt.Fprintf(f, "%s %s\n", timestamp, fragment.Message)
+							// Strip the search-highlight markers the regex filter
+							// injected into grouped fragments; otherwise they leak
+							// into the downloaded file as invisible characters.
+							_, err = fmt.Fprintf(f, "%s %s\n", timestamp, container.StripHighlightMarkers(fragment.Message))
 							if err != nil {
 								log.Error().Err(err).Msgf("error writing log for container %s", c.id)
 								return


### PR DESCRIPTION
Copying or downloading grouped (multi-line) logs while a search filter is active puts invisible characters into the output.

`Search` marks matches by wrapping them in private-use runes (U+E000/U+E001) so the UI can render `<mark>` highlights. The copy-logs and download paths call `Search` only to test whether a line matches, but the marking is a side effect, and for grouped logs those markers end up in the fragment text that gets written straight to the clipboard or the downloaded file. Single and complex logs are fine because they emit `RawMessage`, which `Search` doesn't modify.

Steps to reproduce: open a container with multi-line logs (e.g. a stack trace), type a search term that matches inside the group, then copy or download. The result contains U+E000/U+E001 around each hit.

Fix: strip the internal highlight markers at the plain-text output boundary. `LogEvent.PlainText` now removes them alongside ANSI, and the grouped download path does the same.

Added regression tests in `sanitize_test.go`, a `StripHighlightMarkers` test, and an end-to-end test in `support_web` that runs the real `Search` then render path. All pass; they fail before the change. `go vet`, `gofmt`, and the `-race` suites are clean.

I found this while reading the copy-logs path rather than from a filed issue, so there's no issue number to reference.

Disclosure: prepared with Claude Code (see the `Co-Authored-By` trailer), verified and tested locally.
