### PR TITLE
docs: complete missing translation keys across all locales

### DIFF
--- a/locales/da.yml
+++ b/locales/da.yml
@@ -39,6 +39,7 @@ label:
   running-containers: Kørende Containere
   all-containers: Alle Containere
   all-namespaces: Alle Navneområder
+  namespaces: Navneområder
   host: Vært
   hosts: Værter
   password: Kodeord
@@ -49,10 +50,13 @@ label:
   avg-cpu: Gns. CPU (%)
   avg-mem: Gns. MEM (%)
   name: Navn
+  cpu: CPU
+  mem: MEM
   pinned: Fastgjort
   per-page: Rækker per side
   host-menu: Værter og Containere
   swarm-menu: Tjenester og Stacks
+  k8s-menu: Kubernetes
   group-menu: Brugerdefinerede Grupper
   no-logs: Container har ingen logs endnu
   search-status:
@@ -112,6 +116,7 @@ title:
   login: Godkendelse Krævet
   dashboard: 1 container | {count} containere
   settings: Indstillinger
+  notifications: Notifikationer
 button:
   logout: Logout
   login: Login
@@ -130,6 +135,7 @@ settings:
   options-desc: Indstillinger for sprog, navigation og gruppering.
   cloud-desc: Stream logs til Dozzle Cloud for AI-drevne undersøgelser og søgning på tværs af installationer.
   support-title: Støt Dozzle
+  support-help: Donationer hjælper med at holde Dozzle gratis og vedligeholdt. Tak 🙏
   display: Visning
   locale: Overskriv sprog
   small-scrollbars: Brug mindre scrollbarer
@@ -213,6 +219,8 @@ notifications:
   add-destination: Tilføj destination
   alerts: Alarmer
   add-alert: Tilføj alarm
+  prefill-name: Fejlalarmer
+  prefill-expression: level == "error"
   add: Tilføj
   filter:
     all: Alle ({count})
@@ -318,6 +326,8 @@ notifications:
   empty-state:
     title: Kom i gang med notifikationer
     description: Vælg hvordan du vil modtage alarmer, når dine containere kræver opmærksomhed.
+    cloud-subtitle: AI-resuméer, fjernstyring og mere
+    webhook-subtitle: Send alarmer til ethvert endpoint
   cloud-link-success:
     title: Dozzle Cloud Linket
     message: Din instans er blevet tilsluttet. Du kan fjerne tilknytningen i indstillinger eller tjekke dit forbrug når som helst.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -39,6 +39,7 @@ label:
   running-containers: Laufende Container
   all-containers: Alle Container
   all-namespaces: Alle Namespaces
+  namespaces: Namespaces
   host: Host
   hosts: Hosts
   password: Passwort
@@ -49,10 +50,13 @@ label:
   avg-cpu: Avg. CPU (%)
   avg-mem: Avg. MEM (%)
   name: Name
+  cpu: CPU
+  mem: MEM
   pinned: Angepinnt
   per-page: Zeilen pro Seite
   host-menu: Hosts und Container
   swarm-menu: Services und Stacks
+  k8s-menu: Kubernetes
   group-menu: Benutzerdefinierte Gruppen
   no-logs: Container hat noch keine Logs
   search-status:
@@ -112,6 +116,7 @@ title:
   login: Authentifizierung erforderlich
   dashboard: 1 Container | {count} Container
   settings: Einstellungen
+  notifications: Benachrichtigungen
 button:
   logout: Ausloggen
   login: Anmeldung
@@ -130,6 +135,7 @@ settings:
   options-desc: Einstellungen für Sprache, Navigation und Gruppierung.
   cloud-desc: Streamen Sie Logs an Dozzle Cloud für KI-gestützte Analysen und Suche über Instanzen hinweg.
   support-title: Dozzle unterstützen
+  support-help: Spenden helfen, Dozzle kostenlos und gepflegt zu halten. Vielen Dank 🙏
   display: Anzeige
   locale: Sprache überschreiben
   small-scrollbars: Verwende kleinere Scrollbars
@@ -213,6 +219,8 @@ notifications:
   add-destination: Ziel hinzufügen
   alerts: Alarme
   add-alert: Alarm hinzufügen
+  prefill-name: Fehler-Alarme
+  prefill-expression: level == "error"
   add: Hinzufügen
   filter:
     all: Alle ({count})
@@ -318,6 +326,8 @@ notifications:
   empty-state:
     title: Erste Schritte mit Benachrichtigungen
     description: Wählen Sie aus, wie Sie Alarme erhalten möchten, wenn Ihre Container Aufmerksamkeit benötigen.
+    cloud-subtitle: KI-Zusammenfassungen, Fernsteuerung und mehr
+    webhook-subtitle: Alarme an jeden Endpunkt senden
   cloud-link-success:
     title: Dozzle Cloud verknüpft
     message: Ihre Instanz wurde erfolgreich verbunden. Sie können die Verknüpfung in den Einstellungen aufheben oder Ihre Nutzung jederzeit einsehen.

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -39,6 +39,7 @@ label:
   running-containers: Contenedores en ejecución
   all-containers: Todos los contenedores
   all-namespaces: Todos los espacios de nombres
+  namespaces: Espacios de nombres
   host: Host
   hosts: Hosts
   password: Contraseña
@@ -49,10 +50,13 @@ label:
   avg-cpu: Promedio de CPU (%)
   avg-mem: Promedio de MEM (%)
   name: Nombre
+  cpu: CPU
+  mem: MEM
   pinned: Fijado
   per-page: Filas por página
   host-menu: Hosts y Contenedores
   swarm-menu: Servicios y Stacks
+  k8s-menu: Kubernetes
   group-menu: Grupos Personalizados
   no-logs: El contenedor aún no tiene registros
   search-status:
@@ -112,6 +116,7 @@ title:
   login: Autenticación requerida
   dashboard: 1 contenedor | {count} contenedores
   settings: Configuración
+  notifications: Notificaciones
 button:
   logout: Cerrar la sesión
   login: Iniciar sesión
@@ -158,6 +163,7 @@ settings:
   options-desc: Preferencias de idioma, navegación y agrupación.
   cloud-desc: Transmite logs a Dozzle Cloud para investigaciones con IA y búsqueda entre instancias.
   support-title: Apoya a Dozzle
+  support-help: Las donaciones ayudan a mantener Dozzle gratuito y actualizado. Gracias 🙏
   display: Vista
   locale: Sobrescribir idioma
   small-scrollbars: Utilizar barras de desplazamiento más pequeñas
@@ -241,6 +247,8 @@ notifications:
   add-destination: Añadir destino
   alerts: Alertas
   add-alert: Añadir alerta
+  prefill-name: Alertas de error
+  prefill-expression: level == "error"
   add: Añadir
   filter:
     all: Todos ({count})
@@ -346,6 +354,8 @@ notifications:
   empty-state:
     title: Comenzar con las notificaciones
     description: Elija cómo desea recibir alertas cuando sus contenedores necesiten atención.
+    cloud-subtitle: Resúmenes con IA, control remoto y más
+    webhook-subtitle: Envía alertas a cualquier endpoint
   cloud-link-success:
     title: Dozzle Cloud Vinculado
     message: Su instancia se ha conectado correctamente. Puede desvincularla en la configuración o consultar su uso en cualquier momento.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -39,6 +39,7 @@ label:
   running-containers: Conteneurs en execution
   all-containers: Tous les conteneurs
   all-namespaces: Tous les espaces de noms
+  namespaces: Espaces de noms
   host: Hôte
   hosts: Hôtes
   password: Mot de passe
@@ -49,10 +50,13 @@ label:
   avg-cpu: Moyenne CPU (%)
   avg-mem: Moyenne MEM (%)
   name: Nom
+  cpu: CPU
+  mem: MEM
   pinned: Epinglé
   per-page: Colonnes par page
   host-menu: Hôtes et Conteneurs
   swarm-menu: Services et Stacks
+  k8s-menu: Kubernetes
   group-menu: Groupes Personnalisés
   no-logs: Le conteneur n'a pas encore de logs
   search-status:
@@ -112,6 +116,7 @@ title:
   login: Authentification requise
   dashboard: 1 conteneur | {count} conteneurs
   settings: Paramètres
+  notifications: Notifications
 button:
   logout: Déconnexion
   login: Connexion
@@ -130,6 +135,7 @@ settings:
   options-desc: Préférences de langue, de navigation et de regroupement.
   cloud-desc: Diffusez les logs vers Dozzle Cloud pour des analyses assistées par IA et la recherche entre instances.
   support-title: Soutenir Dozzle
+  support-help: Les dons aident à garder Dozzle gratuit et maintenu. Merci 🙏
   display: Afficher
   locale: Langue de remplacement
   small-scrollbars: Utiliser des barres de défilement plus petites
@@ -213,6 +219,8 @@ notifications:
   add-destination: Ajouter une destination
   alerts: Alertes
   add-alert: Ajouter une alerte
+  prefill-name: Alertes d'erreur
+  prefill-expression: level == "error"
   add: Ajouter
   filter:
     all: Tous ({count})
@@ -318,6 +326,8 @@ notifications:
   empty-state:
     title: Commencer avec les notifications
     description: Choisissez comment vous souhaitez recevoir des alertes lorsque vos conteneurs nécessitent une attention.
+    cloud-subtitle: Résumés IA, contrôle à distance et plus
+    webhook-subtitle: Envoyez des alertes vers n'importe quel endpoint
   cloud-link-success:
     title: Dozzle Cloud Lié
     message: Votre instance a été connectée avec succès. Vous pouvez la délier dans les paramètres ou consulter votre utilisation à tout moment.

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -40,6 +40,7 @@ label:
   running-containers: Kontainer Berjalan
   all-containers: Semua Kontainer
   all-namespaces: Semua Namespace
+  namespaces: Namespace
   host: Host
   hosts: Host
   password: Kata sandi
@@ -50,10 +51,13 @@ label:
   avg-cpu: Rata-rata CPU (%)
   avg-mem: Rata-rata MEM (%)
   name: Nama
+  cpu: CPU
+  mem: MEM
   pinned: Disematkan
   per-page: Baris per halaman
   host-menu: Host dan Kontainer
   swarm-menu: Layanan dan Stack
+  k8s-menu: Kubernetes
   group-menu: Grup Kustom
   no-logs: Kontainer belum memiliki log
   search-status:
@@ -117,6 +121,7 @@ title:
   login: Autentikasi Diperlukan
   dashboard: 1 kontainer | {count} kontainer
   settings: Pengaturan
+  notifications: Notifikasi
 
 button:
   logout: Keluar
@@ -138,6 +143,7 @@ settings:
   options-desc: Preferensi bahasa, navigasi, dan pengelompokan.
   cloud-desc: Streaming log ke Dozzle Cloud untuk investigasi bertenaga AI dan pencarian lintas instans.
   support-title: Dukung Dozzle
+  support-help: Donasi membantu menjaga Dozzle tetap gratis dan terawat. Terima kasih 🙏
   display: Tampilan
   locale: Ganti bahasa
   small-scrollbars: Gunakan scrollbar kecil
@@ -225,6 +231,8 @@ notifications:
   add-destination: Tambah tujuan
   alerts: Peringatan
   add-alert: Tambah peringatan
+  prefill-name: Peringatan kesalahan
+  prefill-expression: level == "error"
   add: Tambah
   filter:
     all: Semua ({count})
@@ -330,6 +338,8 @@ notifications:
   empty-state:
     title: Mulai dengan notifikasi
     description: Pilih cara Anda ingin menerima peringatan saat kontainer Anda membutuhkan perhatian.
+    cloud-subtitle: Ringkasan AI, kendali jarak jauh & lainnya
+    webhook-subtitle: Kirim peringatan ke endpoint mana pun
   cloud-link-success:
     title: Dozzle Cloud Tertaut
     message: Instans Anda telah berhasil terhubung. Anda dapat melepaskan tautan di pengaturan atau memeriksa penggunaan Anda kapan saja.

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -39,6 +39,7 @@ label:
   running-containers: Container in esecuzione
   all-containers: Tutti i Container
   all-namespaces: Tutti i Namespace
+  namespaces: Namespace
   host: Host
   hosts: Hosts
   password: Password
@@ -49,10 +50,13 @@ label:
   avg-cpu: CPU (%)
   avg-mem: MEM (%)
   name: Nome
+  cpu: CPU
+  mem: MEM
   pinned: Fissato
   per-page: Righe per pagina
   host-menu: Host e Container
   swarm-menu: Servizi e Stack
+  k8s-menu: Kubernetes
   group-menu: Gruppi Personalizzati
   no-logs: Il container non ha ancora log
   search-status:
@@ -112,6 +116,7 @@ title:
   login: Autenticazione richiesta
   dashboard: 1 container | {count} container
   settings: Impostazioni
+  notifications: Notifiche
 button:
   logout: Logout
   login: Login
@@ -130,6 +135,7 @@ settings:
   options-desc: Preferenze di lingua, navigazione e raggruppamento.
   cloud-desc: Trasmetti i log a Dozzle Cloud per analisi basate su IA e ricerca tra le istanze.
   support-title: Sostieni Dozzle
+  support-help: Le donazioni aiutano a mantenere Dozzle gratuito e curato. Grazie 🙏
   display: Visualizza
   locale: Sovrascrivi Lingua
   small-scrollbars: Usa una scrollbars più piccola
@@ -213,6 +219,8 @@ notifications:
   add-destination: Aggiungi destinazione
   alerts: Avvisi
   add-alert: Aggiungi avviso
+  prefill-name: Avvisi di errore
+  prefill-expression: level == "error"
   add: Aggiungi
   filter:
     all: Tutti ({count})
@@ -318,6 +326,8 @@ notifications:
   empty-state:
     title: Inizia con le notifiche
     description: Scegli come vuoi ricevere avvisi quando i tuoi container richiedono attenzione.
+    cloud-subtitle: Riepiloghi AI, controllo remoto e altro
+    webhook-subtitle: Invia avvisi a qualsiasi endpoint
   cloud-link-success:
     title: Dozzle Cloud Collegato
     message: La tua istanza è stata connessa con successo. Puoi scollegarla nelle impostazioni o controllare il tuo utilizzo in qualsiasi momento.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -39,6 +39,7 @@ label:
   running-containers: Actieve containers
   all-containers: Alle containers
   all-namespaces: Alle Namespaces
+  namespaces: Namespaces
   host: Host
   hosts: Hosts
   password: Wachtwoord
@@ -49,10 +50,13 @@ label:
   avg-cpu: Gem. CPU (%)
   avg-mem: Gem. geheugen (%)
   name: Naam
+  cpu: CPU
+  mem: MEM
   pinned: Vastgezet
   per-page: Rijen per pagina
   host-menu: Hosts en Containers
   swarm-menu: Services en Stacks
+  k8s-menu: Kubernetes
   group-menu: Aangepaste groepen
   no-logs: Container heeft nog geen logbestanden
   search-status:
@@ -113,6 +117,7 @@ title:
   login: Aanmelding vereist
   dashboard: 1 container | {count} containers
   settings: Instellingen
+  notifications: Meldingen
 button:
   logout: Afmelden
   login: Aanmelden
@@ -131,6 +136,7 @@ settings:
   options-desc: Voorkeuren voor taal, navigatie en groepering.
   cloud-desc: Stream logs naar Dozzle Cloud voor AI-gestuurde analyses en zoeken over instanties heen.
   support-title: Steun Dozzle
+  support-help: Donaties houden Dozzle gratis en onderhouden. Bedankt 🙏
   display: Weergave
   locale: Taal aanpassen
   small-scrollbars: Kleinere scrollbalk gebruiken
@@ -214,6 +220,8 @@ notifications:
   add-destination: Bestemming toevoegen
   alerts: Waarschuwingen
   add-alert: Waarschuwing toevoegen
+  prefill-name: Foutwaarschuwingen
+  prefill-expression: level == "error"
   add: Toevoegen
   filter:
     all: Alle ({count})
@@ -319,6 +327,8 @@ notifications:
   empty-state:
     title: Aan de slag met meldingen
     description: Kies hoe je waarschuwingen wilt ontvangen wanneer je containers aandacht nodig hebben.
+    cloud-subtitle: AI-samenvattingen, bediening op afstand en meer
+    webhook-subtitle: Stuur waarschuwingen naar elk eindpunt
   cloud-link-success:
     title: Dozzle Cloud gekoppeld
     message: Je instantie is succesvol verbonden. Je kunt de koppeling ongedaan maken in de instellingen of je gebruik op elk moment bekijken.

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -32,17 +32,14 @@ action:
   create-alert: Utwórz alert
 label:
   service: Brak usług | 1 usługa | {count} usług
+  services: Usługi
   host-count: Brak Hostów | 1 Host | {count} Hostów
-  total-containers: Całkowita liczba kontenerów
-  running: Uruchomione
-  total-cpu-usage: Całkowite użycie CPU
-  total-mem-usage: Całkowite użycie pamięci
-  dozzle-version: Wersja Dozzle
   containers: Kontenery
   container: Brak kontenerów | 1 kontener | {count} kontenerów
   running-containers: Działające kontenery
   all-containers: Wszystkie kontenery
   all-namespaces: Wszystkie przestrzenie nazw
+  namespaces: Przestrzenie nazw
   host: Host
   hosts: Hosty
   password: Hasło
@@ -53,10 +50,13 @@ label:
   avg-cpu: Średnie zużycie CPU (%)
   avg-mem: Średnie zużycie pamięci (%)
   name: Nazwa
+  cpu: CPU
+  mem: MEM
   pinned: Przypięte
   per-page: Wierszy na strone
   host-menu: Hosty i Kontenery
   swarm-menu: Usługi i Stosy
+  k8s-menu: Kubernetes
   group-menu: Grupy Niestandardowe
   no-logs: Kontener nie ma jeszcze logów
   search-status:
@@ -118,6 +118,7 @@ title:
   login: Wymagane uwierzytelnienie
   dashboard: 1 kontener | {count} kontenerów
   settings: Ustawienia
+  notifications: Powiadomienia
 button:
   logout: Wyloguj się
   login: Zaloguj się
@@ -136,6 +137,7 @@ settings:
   options-desc: Preferencje języka, nawigacji i grupowania.
   cloud-desc: Przesyłaj logi do Dozzle Cloud w celu analiz wspomaganych przez AI i wyszukiwania między instancjami.
   support-title: Wesprzyj Dozzle
+  support-help: Darowizny pomagają utrzymać Dozzle darmowym i rozwijanym. Dziękujemy 🙏
   display: Wyświetlanie
   locale: Nadpisz język
   small-scrollbars: Użyj mniejszych suwaków
@@ -220,6 +222,8 @@ notifications:
   add-destination: Dodaj miejsce docelowe
   alerts: Alerty
   add-alert: Dodaj alert
+  prefill-name: Alerty o błędach
+  prefill-expression: level == "error"
   add: Dodaj
   filter:
     all: Wszystkie ({count})
@@ -325,6 +329,8 @@ notifications:
   empty-state:
     title: Zacznij korzystać z powiadomień
     description: Wybierz, jak chcesz otrzymywać alerty, gdy Twoje kontenery wymagają uwagi.
+    cloud-subtitle: Podsumowania AI, zdalne sterowanie i więcej
+    webhook-subtitle: Wysyłaj alerty do dowolnego endpointu
   cloud-link-success:
     title: Dozzle Cloud Połączony
     message: Twoja instancja została pomyślnie połączona. Możesz rozłączyć ją w ustawieniach lub sprawdzić swoje użycie w dowolnym momencie.

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -38,6 +38,8 @@ label:
   services: Serviços
   running-containers: Containers em Execução
   all-containers: Todos os Containers
+  all-namespaces: Todos
+  namespaces: Namespaces
   host: Host
   hosts: Hosts
   password: Senha
@@ -48,10 +50,13 @@ label:
   avg-cpu: Média CPU (%)
   avg-mem: Média MEM (%)
   name: Nome
+  cpu: CPU
+  mem: MEM
   pinned: Fixado
   per-page: Linhas por página
   host-menu: Hosts e Containers
   swarm-menu: Serviços e Stacks
+  k8s-menu: Kubernetes
   group-menu: Grupos Personalizados
   no-logs: O container ainda não tem logs
   search-status:
@@ -111,6 +116,7 @@ title:
   login: Autenticação Requerida
   dashboard: 1 container | {count} containers
   settings: Configurações
+  notifications: Notificações
 button:
   logout: Sair
   login: Entrar
@@ -129,6 +135,7 @@ settings:
   options-desc: Preferências de idioma, navegação e agrupamento.
   cloud-desc: Transmita logs para o Dozzle Cloud para investigações com IA e busca entre instâncias.
   support-title: Apoiar o Dozzle
+  support-help: As doações ajudam a manter o Dozzle gratuito e com manutenção contínua. Obrigado 🙏
   display: Exibição
   locale: Sobrescrever idioma
   small-scrollbars: Usar barras de rolagem menores
@@ -212,6 +219,8 @@ notifications:
   add-destination: Adicionar destino
   alerts: Alertas
   add-alert: Adicionar alerta
+  prefill-name: Alertas de erro
+  prefill-expression: level == "error"
   add: Adicionar
   filter:
     all: Todos ({count})
@@ -317,6 +326,8 @@ notifications:
   empty-state:
     title: Comece com as notificações
     description: Escolha como você deseja receber alertas quando seus containers precisarem de atenção.
+    cloud-subtitle: Resumos com IA, controle remoto e mais
+    webhook-subtitle: Envie alertas para qualquer endpoint
   cloud-link-success:
     title: Dozzle Cloud Vinculado
     message: Sua instância foi conectada com sucesso. Você pode desvincular nas configurações ou verificar seu uso a qualquer momento.

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -39,6 +39,7 @@ label:
   running-containers: Запущенные контейнеры
   all-containers: Все контейнеры
   all-namespaces: Все пространства имён
+  namespaces: Пространства имён
   host: Хост
   hosts: Хосты
   password: Пароль
@@ -49,10 +50,13 @@ label:
   avg-cpu: средний процессор (%)
   avg-mem: средняя память (%)
   name: Имя
+  cpu: CPU
+  mem: MEM
   pinned: Закреплено
   per-page: Строк на странице
   host-menu: Хосты и Контейнеры
   swarm-menu: Сервисы и Стеки
+  k8s-menu: Kubernetes
   group-menu: Пользовательские Группы
   no-logs: У контейнера еще нет логов
   search-status:
@@ -112,6 +116,7 @@ title:
   login: Требуется авторизация
   dashboard: 1 контейнер | {count} контейнеров
   settings: Настройки
+  notifications: Уведомления
 button:
   logout: Выйти
   login: Войти
@@ -130,6 +135,7 @@ settings:
   options-desc: Настройки языка, навигации и группировки.
   cloud-desc: Передавайте логи в Dozzle Cloud для аналитики с использованием ИИ и поиска по экземплярам.
   support-title: Поддержать Dozzle
+  support-help: Пожертвования помогают сохранять Dozzle бесплатным и поддерживаемым. Спасибо 🙏
   display: Вид
   locale: Язык
   small-scrollbars: Уменьшенная полоса прокрутки
@@ -213,6 +219,8 @@ notifications:
   add-destination: Добавить назначение
   alerts: Оповещения
   add-alert: Добавить оповещение
+  prefill-name: Оповещения об ошибках
+  prefill-expression: level == "error"
   add: Добавить
   filter:
     all: Все ({count})
@@ -318,6 +326,8 @@ notifications:
   empty-state:
     title: Начните с уведомлений
     description: Выберите, как вы хотите получать оповещения, когда ваши контейнеры требуют внимания.
+    cloud-subtitle: Сводки на основе ИИ, удалённое управление и многое другое
+    webhook-subtitle: Отправляйте оповещения на любую конечную точку
   cloud-link-success:
     title: Dozzle Cloud Связан
     message: Ваш экземпляр успешно подключён. Вы можете отвязать его в настройках или проверить использование в любое время.

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -36,6 +36,8 @@ label:
   service: Ni storitev | 1 storitev | {count} storitev
   running-containers: Delujoči zabojniki
   all-containers: Vsi zabojniki
+  all-namespaces: Vsi
+  namespaces: Imenski prostori
   host: Gostitelj
   hosts: Gostitelji
   password: Geslo
@@ -47,6 +49,7 @@ label:
   per-page: Vrstic na stran
   host-menu: Gostitelji in zabojniki
   swarm-menu: Storitve in skladi
+  k8s-menu: Kubernetes
   group-menu: Skupine po meri
   show-all-containers: Prikaži vse zabojnike
   collapse-all: Strni vse
@@ -57,6 +60,8 @@ label:
   services: Storitve
   avg-mem: Povprečje spomina (%)
   name: Ime
+  cpu: CPU
+  mem: MEM
   no-logs: Zabojnik še nima dnevnika
   search-status:
     searching: Iskanje po starejših dnevnikih…
@@ -113,6 +118,7 @@ title:
   login: Zahtevana overitev
   dashboard: 1 zabojnik| {count} zabojnikov
   settings: Nastavitve
+  notifications: Obvestila
 button:
   logout: Odjava
   cancel: Prekliči
@@ -129,6 +135,7 @@ settings:
   options-desc: Nastavitve jezika, navigacije in združevanja.
   cloud-desc: Pretakajte dnevnike v Dozzle Cloud za preiskave z umetno inteligenco in iskanje med instancami.
   support-title: Podprite Dozzle
+  support-help: Donacije pomagajo, da Dozzle ostane brezplačen in vzdrževan. Hvala 🙏
   display: Prikaz
   locale: Preglasi jezik
   small-scrollbars: Uporabite manjše drsne trakove
@@ -218,6 +225,8 @@ notifications:
   add-destination: Dodaj cilj
   alerts: Opozorila
   add-alert: Dodaj opozorilo
+  prefill-name: Opozorila o napakah
+  prefill-expression: level == "error"
   add: Dodaj
   filter:
     all: Vsi ({count})
@@ -323,6 +332,8 @@ notifications:
   empty-state:
     title: Začnite z obvestili
     description: Izberite, kako želite prejemati opozorila, ko vaši zabojniki potrebujejo pozornost.
+    cloud-subtitle: Povzetki UI, upravljanje na daljavo in več
+    webhook-subtitle: Pošiljajte opozorila na katero koli končno točko
   cloud-link-success:
     title: Dozzle Cloud Povezan
     message: Vaša instanca je bila uspešno povezana. Povezavo lahko prekinete v nastavitvah ali kadar koli preverite svojo uporabo.

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -38,12 +38,8 @@ label:
   services: Servisler
   running-containers: Çalışan Konteynerlar
   all-containers: Tüm Konteynerlar
-  total-containers: Toplam Konteyner
-  running: Çalışıyor
-  total-cpu-usage: Toplam CPU Kullanımı
-  total-mem-usage: Toplam Bellek Kullanımı
-  dozzle-version: Dozzle Sürümü
-  all: Tümü
+  all-namespaces: Tümü
+  namespaces: Ad Alanları
   host: Sunucu
   hosts: Sunucular
   password: Şifre
@@ -54,10 +50,13 @@ label:
   avg-cpu: Ort. CPU (%)
   avg-mem: Ort. Bellek (%)
   name: Ad
+  cpu: CPU
+  mem: MEM
   pinned: Sabitlenmiş
   per-page: Sayfa başına satır
   host-menu: Sunucular ve Konteynerler
   swarm-menu: Servisler ve Yığınlar
+  k8s-menu: Kubernetes
   group-menu: Özel Gruplar
   no-logs: Konteyner henüz log içermiyor
   search-status:
@@ -120,6 +119,7 @@ title:
   login: Kimlik Doğrulama Gerekli
   dashboard: 1 konteyner | {count} konteyner
   settings: Ayarlar
+  notifications: Bildirimler
 button:
   logout: Çıkış Yap
   login: Giriş Yap
@@ -138,6 +138,7 @@ settings:
   options-desc: Dil, gezinme ve gruplama tercihleri.
   cloud-desc: AI destekli incelemeler ve örnekler arasında arama için logları Dozzle Cloud'a aktarın.
   support-title: Dozzle'ı Destekle
+  support-help: Bağışlar Dozzle'ın ücretsiz kalmasına ve bakımının sürmesine yardımcı olur. Teşekkürler 🙏
   display: Görünüm
   locale: Dili geçersiz kıl
   small-scrollbars: Daha küçük kaydırma çubukları kullan
@@ -178,6 +179,15 @@ settings:
     auto: Otomatik
     12: "12"
     24: "24"
+  log:
+    preview: Bu, logların bir önizlemesidir
+    warning: Bir uyarı logu böyle görünür
+    complex: Bu, json formatında karmaşık bir log girişidir
+    simple: Bu, varsayılan olarak kaydırılacak çok çok uzun bir mesajdır. Yumuşak kaydırmayı devre dışı bırakmak bunu devre dışı bırakır. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    multi-line-error:
+      start-line: Bu, çok satırlı bir hata mesajıdır
+      middle-line: ikinci bir satırla
+      end-line: ve son olarak üçüncü satır.
 releases:
   features: bir yeni özellik | {count} özellik
   bugFixes: bir hata düzeltmesi | {count} düzeltme
@@ -213,6 +223,8 @@ notifications:
   add-destination: Hedef ekle
   alerts: Uyarılar
   add-alert: Uyarı ekle
+  prefill-name: Hata uyarıları
+  prefill-expression: level == "error"
   add: Ekle
   filter:
     all: Tümü ({count})
@@ -318,6 +330,8 @@ notifications:
   empty-state:
     title: Bildirimlerle başlayın
     description: Konteynerleriniz dikkat gerektirdiğinde nasıl uyarı almak istediğinizi seçin.
+    cloud-subtitle: AI özetleri, uzaktan kontrol ve daha fazlası
+    webhook-subtitle: Uyarıları herhangi bir uç noktaya gönder
   cloud-link-success:
     title: Dozzle Cloud Bağlandı
     message: Örneğiniz başarıyla bağlandı. Ayarlardan bağlantıyı kaldırabilir veya kullanımınızı istediğiniz zaman kontrol edebilirsiniz.

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -39,6 +39,7 @@ label:
   running-containers: 運作中的容器
   all-containers: 所有容器
   all-namespaces: 所有命名空間
+  namespaces: 命名空間
   no-logs: 容器尚無日誌
   search-status:
     searching: 正在搜尋較舊的日誌…
@@ -60,10 +61,13 @@ label:
   avg-cpu: 平均 CPU 使用率 (%)
   avg-mem: 平均記憶體使用率 (%)
   name: 名稱
+  cpu: CPU
+  mem: MEM
   pinned: 已釘選
   per-page: 每頁列數
   host-menu: 主機和容器
   swarm-menu: 服務和堆疊
+  k8s-menu: Kubernetes
   group-menu: 自訂群組
 tooltip:
   search: 搜尋容器 (⌘ + k, ⌃k)
@@ -114,6 +118,7 @@ title:
   login: 需要身份驗證
   dashboard: 1 個容器 | {count} 個容器
   settings: 設定
+  notifications: 通知
 button:
   logout: 登出
   login: 登入
@@ -132,6 +137,7 @@ settings:
   options-desc: 語言、導覽和群組偏好設定。
   cloud-desc: 將日誌串流至 Dozzle Cloud，進行 AI 驅動的調查和跨實例搜尋。
   support-title: 支持 Dozzle
+  support-help: 捐款有助於維持 Dozzle 免費並持續維護。謝謝 🙏
   display: 顯示
   locale: 變更語言
   small-scrollbars: 使用較小的捲軸
@@ -216,6 +222,8 @@ notifications:
   add-destination: 新增目標
   alerts: 警報
   add-alert: 新增警報
+  prefill-name: 錯誤警報
+  prefill-expression: level == "error"
   add: 新增
   filter:
     all: 全部 ({count})
@@ -321,6 +329,8 @@ notifications:
   empty-state:
     title: 開始使用通知
     description: 選擇當您的容器需要關注時，您希望如何接收警報。
+    cloud-subtitle: AI 摘要、遠端控制等功能
+    webhook-subtitle: 將警報傳送至任何端點
   cloud-link-success:
     title: Dozzle Cloud 已連結
     message: 您的實例已成功連線。您可以在設定中取消連結，或隨時查看使用量。

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -39,6 +39,7 @@ label:
   running-containers: 运行中的容器
   all-containers: 所有容器
   all-namespaces: 所有命名空间
+  namespaces: 命名空间
   no-logs: 容器尚无日志
   search-status:
     searching: 正在搜索较旧的日志…
@@ -60,10 +61,13 @@ label:
   avg-cpu: 平均CPU (%)
   avg-mem: 平均MEM (%)
   name: 名称
+  cpu: CPU
+  mem: MEM
   pinned: 固定
   per-page: 每页行数
   host-menu: 主机和容器
   swarm-menu: 服务和堆栈
+  k8s-menu: Kubernetes
   group-menu: 自定义组
 tooltip:
   search: 搜索 (⌘ + k, ⌃k)
@@ -112,6 +116,7 @@ title:
   login: 需要身份验证
   dashboard: 1 容器 | {count} 容器
   settings: 设置
+  notifications: 通知
 button:
   logout: 退出
   login: 登录
@@ -130,6 +135,7 @@ settings:
   options-desc: 语言、导航和分组首选项。
   cloud-desc: 将日志流式传输到 Dozzle Cloud，进行 AI 驱动的调查和跨实例搜索。
   support-title: 支持 Dozzle
+  support-help: 捐赠有助于保持 Dozzle 免费并持续维护。谢谢 🙏
   display: 显示
   locale: 显示语言
   small-scrollbars: 使用较小的滚动条
@@ -213,6 +219,8 @@ notifications:
   add-destination: 添加目标
   alerts: 警报
   add-alert: 添加警报
+  prefill-name: 错误警报
+  prefill-expression: level == "error"
   add: 添加
   filter:
     all: 全部 ({count})
@@ -318,6 +326,8 @@ notifications:
   empty-state:
     title: 开始使用通知
     description: 选择当您的容器需要关注时，您希望如何接收警报。
+    cloud-subtitle: AI 摘要、远程控制及更多功能
+    webhook-subtitle: 将警报发送到任意端点
   cloud-link-success:
     title: Dozzle Cloud 已关联
     message: 您的实例已成功连接。您可以在设置中取消关联，或随时查看使用情况。


### PR DESCRIPTION
All 16 locales now match `en.yml` exactly (365 keys, 0 missing, 0 extra). Only `en` and `ko` were complete before this; every other locale was missing the same set of recently added keys for k8s, notifications, and cloud.

## Added
- 10 core keys to da, de, es, fr, id, it, nl, ru, zh, zh-tw: `label.namespaces`, `label.cpu`, `label.mem`, `label.k8s-menu`, `title.notifications`, `settings.support-help`, `notifications.prefill-name`, `notifications.prefill-expression`, `notifications.empty-state.cloud-subtitle`, `notifications.empty-state.webhook-subtitle`
- `label.all-namespaces` to pt, sl, tr
- `label.services` to pl
- the full `settings.log` block (preview/warning/complex/simple + multi-line-error) to tr

## Removed (stale, unused in code)
- pl and tr: `label.total-containers`, `label.running`, `label.total-cpu-usage`, `label.total-mem-usage`, `label.dozzle-version`
- tr also: `label.all` (its value was reused for `all-namespaces`)

## Notes
- `notifications.prefill-expression` kept as the literal `level == "error"` in every locale (it's a filter expression, not prose)
- CPU / MEM / Kubernetes labels kept untranslated
- Verified: valid YAML, no duplicate keys, additions-only diffs (plus the intended removals)
- `namespaces` was localized in some files and kept as a loanword in others, matching each file's existing convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)