### PR TITLE
fix(container): keep custom name label on docker rename

### DIFF
--- a/internal/container/container_store.go
+++ b/internal/container/container_store.go
@@ -448,14 +448,21 @@ func (s *ContainerStore) init() {
 
 			case "rename":
 				s.containers.Compute(event.ActorID, func(c *Container, loaded bool) (*Container, xsync.ComputeOp) {
-					if loaded {
-						log.Debug().Str("id", event.ActorID).Str("name", event.ActorAttributes["name"]).Msg("container renamed")
-						copy := *c
-						copy.Name = event.ActorAttributes["name"]
-						return &copy, xsync.UpdateOp
-					} else {
+					if !loaded {
 						return c, xsync.CancelOp
 					}
+					// A dev.dozzle.name or coolify.serviceName label pins a custom
+					// display name (see newContainer). That name must survive a
+					// docker-level rename, so only follow the rename when the name
+					// actually comes from Docker.
+					if c.Labels["dev.dozzle.name"] != "" || c.Labels["coolify.serviceName"] != "" {
+						log.Debug().Str("id", event.ActorID).Msg("ignoring rename: container has a custom name label")
+						return c, xsync.CancelOp
+					}
+					log.Debug().Str("id", event.ActorID).Str("name", event.ActorAttributes["name"]).Msg("container renamed")
+					copy := *c
+					copy.Name = event.ActorAttributes["name"]
+					return &copy, xsync.UpdateOp
 				})
 			}
 			s.subscribers.Range(func(c context.Context, events chan<- ContainerEvent) bool {

--- a/internal/container/container_store_test.go
+++ b/internal/container/container_store_test.go
@@ -119,6 +119,80 @@ func TestContainerStore_die(t *testing.T) {
 	assert.Equal(t, containers[0].State, "exited")
 }
 
+func TestContainerStore_rename(t *testing.T) {
+	run := func(t *testing.T, initial Container, attributes map[string]string) Container {
+		client := new(mockedClient)
+		client.On("ListContainers", mock.Anything, mock.Anything).Return([]Container{initial}, nil)
+		client.On("FindContainer", mock.Anything, initial.ID).Return(initial, nil)
+		client.On("Host").Return(Host{ID: "localhost"})
+
+		ready := make(chan struct{})
+		client.On("ContainerEvents", mock.Anything, mock.AnythingOfType("chan<- container.ContainerEvent")).Return(nil).
+			Run(func(args mock.Arguments) {
+				ctx := args.Get(0).(context.Context)
+				events := args.Get(1).(chan<- ContainerEvent)
+				<-ready
+				events <- ContainerEvent{
+					Name:            "rename",
+					ActorID:         initial.ID,
+					Host:            "localhost",
+					ActorAttributes: attributes,
+				}
+				<-ctx.Done()
+			})
+
+		store := NewContainerStore(t.Context(), client, &fakeStatsCollector{}, ContainerLabels{})
+
+		events := make(chan ContainerEvent)
+		store.SubscribeEvents(t.Context(), events)
+		close(ready)
+		<-events
+
+		containers, err := store.ListContainers(ContainerLabels{})
+		assert.NoError(t, err)
+		assert.Len(t, containers, 1)
+		return containers[0]
+	}
+
+	t.Run("keeps custom name from dev.dozzle.name label", func(t *testing.T) {
+		initial := Container{
+			ID:          "1234",
+			Name:        "custom-name",
+			State:       "running",
+			FullyLoaded: true,
+			Labels:      map[string]string{"dev.dozzle.name": "custom-name"},
+			Stats:       utils.NewRingBuffer[ContainerStat](300),
+		}
+		result := run(t, initial, map[string]string{"name": "new-docker-name"})
+		assert.Equal(t, "custom-name", result.Name)
+	})
+
+	t.Run("keeps custom name from coolify.serviceName label", func(t *testing.T) {
+		initial := Container{
+			ID:          "1234",
+			Name:        "coolify-name",
+			State:       "running",
+			FullyLoaded: true,
+			Labels:      map[string]string{"coolify.serviceName": "coolify-name"},
+			Stats:       utils.NewRingBuffer[ContainerStat](300),
+		}
+		result := run(t, initial, map[string]string{"name": "new-docker-name"})
+		assert.Equal(t, "coolify-name", result.Name)
+	})
+
+	t.Run("follows rename when name comes from docker", func(t *testing.T) {
+		initial := Container{
+			ID:          "1234",
+			Name:        "old-docker-name",
+			State:       "running",
+			FullyLoaded: true,
+			Stats:       utils.NewRingBuffer[ContainerStat](300),
+		}
+		result := run(t, initial, map[string]string{"name": "new-docker-name"})
+		assert.Equal(t, "new-docker-name", result.Name)
+	})
+}
+
 type fakeStatsCollector struct{}
 
 func (f *fakeStatsCollector) Subscribe(_ context.Context, _ chan<- ContainerStat) {}


### PR DESCRIPTION
Renaming a container at the docker level wiped out its custom display name. If a container has a `dev.dozzle.name` (or `coolify.serviceName`) label, `docker rename` replaced the shown name with the docker name for every connected client — and in downloaded log ZIP filenames — until the next full refresh.

### Cause

The `"rename"` handler in `container_store.go` set `Container.Name` straight from the raw event attribute (`event.ActorAttributes["name"]`), ignoring the name precedence that `newContainer` uses (`dev.dozzle.name` > `coolify.serviceName` > docker name, per `docs/guide/container-names.md`). The store is the source of truth that `ListContainersForHost` feeds into the `containers-changed` SSE event, so the wrong name propagated to every client.

### Fix

Skip the rename-driven name update when a name-override label is present. Containers whose name comes from Docker still follow the rename. This keeps the name in the store (which preserves the `Stats` ring buffer) rather than rebuilding the container, so stats history survives the rename too.

### Tests

Added `TestContainerStore_rename` covering all three cases (label kept for `dev.dozzle.name` and `coolify.serviceName`, docker-named container still renames). Fails before the change, passes after. `gofmt`/`go vet` clean; `go test ./internal/container/ -race` green.

Disclosure: AI-assisted (Claude). I reviewed the change and ran the fail-before / pass-after tests locally.
