### PR TITLE
fix(level-guesser): recognize "Information" as info level

### DIFF
--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -15,7 +15,7 @@ var SupportedLogLevels map[string]struct{}
 var logLevels = [][]string{
 	{"error", "err"},
 	{"warn", "warning", "wrn"},
-	{"info", "inf"},
+	{"info", "inf", "information"},
 	{"debug", "dbg"},
 	{"trace", "verbose", "ver", "vbs"},
 	{"fatal", "sev", "severe", "crit", "critical"},

--- a/internal/container/level_guesser_test.go
+++ b/internal/container/level_guesser_test.go
@@ -115,6 +115,20 @@ func TestGuessLogLevel(t *testing.T) {
 		{"WARN: connection error: retrying", "warn"},
 		// Symmetric: an ERROR prefix still wins over a later info word.
 		{"ERROR: handler failed, info: will retry", "error"},
+		// .NET / Serilog / Microsoft.Extensions.Logging spell out "Information".
+		{"Information: service started", "info"},
+		{"[Information] service started", "info"},
+		{"2024-12-30T17:43:16Z Information starting up", "info"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, string]{Key: "level", Value: "Information"},
+			),
+		), "info"},
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, any]{Key: "@l", Value: "Information"},
+			),
+		), "info"},
 		// Equal confidence between two different levels -> unknown (don't guess).
 		{"saw info: here and error: there", "unknown"},
 		{"[INFO] [DEBUG] both bracketed", "unknown"},


### PR DESCRIPTION
.NET, Serilog, and `Microsoft.Extensions.Logging` write the level name in full as "Information", but the info group only aliased "info" and "inf", so those logs showed up as `unknown`. "warning", "critical", and "verbose" already have full-word aliases, so this adds "information" for symmetry.

The alias flows through both the regex tiers (plain-text prefixes like `Information:` and `[Information]`) and the JSON normalizer (`level` / `@l` / `severity` keys), so every detection path now resolves it to `info`. Canonical levels are unchanged, so no frontend change is needed.

Added cases to `TestGuessLogLevel` covering the prefix, bracketed, timestamped, and JSON (`level`, `@l`) forms — they fail before this change and pass after. gofmt/vet clean.

_Prepared with AI assistance (Claude), reviewed and verified by me._
