### PR TITLE
fix(utils): prevent panic when pushing to a zero-size ring buffer

### DIFF
--- a/internal/utils/ring_buffer.go
+++ b/internal/utils/ring_buffer.go
@@ -37,6 +37,11 @@ func RingBufferFrom[T any](size int, data []T) *RingBuffer[T] {
 func (r *RingBuffer[T]) Push(data T) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
+	if r.Size <= 0 {
+		// A zero (or negative) capacity buffer holds nothing. Bail out before
+		// indexing r.data or taking a modulo by r.Size, both of which panic.
+		return
+	}
 	if len(r.data) == r.Size {
 		r.data[r.start] = data
 		r.start = (r.start + 1) % r.Size

--- a/internal/utils/ring_buffer_test.go
+++ b/internal/utils/ring_buffer_test.go
@@ -44,6 +44,24 @@ func TestRingBuffer_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestRingBuffer_ZeroSize(t *testing.T) {
+	// A zero-capacity buffer must hold nothing rather than panic. This is
+	// reachable from the logs endpoint (?min=0), which builds NewRingBuffer(0).
+	rb := NewRingBuffer[int](0)
+
+	rb.Push(1)
+	rb.Push(2)
+
+	if rb.Len() != 0 {
+		t.Errorf("Expected len to be 0, got %d", rb.Len())
+	}
+
+	data := rb.Data()
+	if len(data) != 0 {
+		t.Errorf("Expected data to be empty, got %v", data)
+	}
+}
+
 func TestRingBuffer_Clear(t *testing.T) {
 	rb := NewRingBuffer[int](3)
 


### PR DESCRIPTION
`NewRingBuffer(0)` returns a buffer whose first `Push` panics with an index-out-of-range (and would take a modulo by zero on `r.Size`). It's reachable from the logs endpoint: `min` is validated only as `minimum < 0`, so `?min=0` passes and builds `NewRingBuffer(0)`, then the first matching log line crashes the request handler.

`Push` now returns early when capacity is non-positive, so a zero-size buffer simply holds nothing. `Data`/`Len`/`Clear` were already safe at size 0. Added `TestRingBuffer_ZeroSize`, which panics before the fix and passes after.

Verified locally: `go test ./internal/utils/` (incl. `-race`), `gofmt -l`, and `go vet ./internal/utils/` all clean.

Prepared with AI assistance (Claude) and reviewed/verified by me.
