### PR TITLE
chore: type-check on tsgo via typescript-native-bridge

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  typescript: npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
+
 importers:
 
   .:
@@ -61,7 +64,7 @@ importers:
         version: 1.2.2
       '@intlify/unplugin-vue-i18n':
         specifier: ^11.2.4
-        version: 11.2.4(@vue/compiler-dom@3.5.39)(eslint@9.19.0(jiti@2.7.0)(supports-color@10.2.2))(rollup@4.60.3)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-i18n@11.4.7(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        version: 11.2.4(@vue/compiler-dom@3.5.39)(eslint@9.19.0(jiti@2.7.0)(supports-color@10.2.2))(rollup@4.60.3)(supports-color@10.2.2)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
@@ -73,16 +76,16 @@ importers:
         version: 4.3.3(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))
       '@vueuse/components':
         specifier: ^14.3.0
-        version: 14.3.0(vue@3.5.40(typescript@6.0.3))
+        version: 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vueuse/core':
         specifier: ^14.3.0
-        version: 14.3.0(vue@3.5.40(typescript@6.0.3))
+        version: 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vueuse/integrations':
         specifier: ^14.3.0
-        version: 14.3.0(focus-trap@7.8.0)(fuse.js@7.5.0)(sortablejs@1.15.7)(vue@3.5.40(typescript@6.0.3))
+        version: 14.3.0(focus-trap@7.8.0)(fuse.js@7.5.0)(sortablejs@1.15.7)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vueuse/router':
         specifier: 14.3.0
-        version: 14.3.0(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        version: 14.3.0(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -112,13 +115,13 @@ importers:
         version: 4.0.8
       pinia:
         specifier: ^4.0.2
-        version: 4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))
+        version: 4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       sortablejs:
         specifier: ^1.15.7
         version: 1.15.7
       splitpanes:
         specifier: ^4.1.2
-        version: 4.1.2(vue@3.5.40(typescript@6.0.3))
+        version: 4.1.2(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       strip-ansi:
         specifier: ^7.2.0
         version: 7.2.0
@@ -127,37 +130,37 @@ importers:
         version: 4.3.3
       unplugin-auto-import:
         specifier: ^21.0.0
-        version: 21.0.0(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3)))
+        version: 21.0.0(@vueuse/core@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))
       unplugin-icons:
         specifier: ^23.0.1
         version: 23.0.1(@vue/compiler-sfc@3.5.40)
       unplugin-vue-components:
         specifier: ^32.1.0
-        version: 32.1.0(vue@3.5.40(typescript@6.0.3))
+        version: 32.1.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin-vue-macros:
         specifier: ^2.14.5
-        version: 2.14.5(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))
+        version: 2.14.5(@vueuse/core@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       vite:
         specifier: 8.1.5
         version: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)
       vite-plugin-vue-layouts:
         specifier: ^0.11.0
-        version: 0.11.0(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+        version: 0.11.0(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       vite-svg-loader:
         specifier: ^5.1.1
-        version: 5.1.1(supports-color@10.2.2)(vue@3.5.40(typescript@6.0.3))
+        version: 5.1.1(supports-color@10.2.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       vitepress:
         specifier: 1.6.4
-        version: 1.6.4(@algolia/client-search@5.52.1)(@types/node@25.9.5)(fuse.js@7.5.0)(lightningcss@1.32.0)(postcss@8.5.20)(search-insights@2.17.3)(sortablejs@1.15.7)(typescript@6.0.3)
+        version: 1.6.4(@algolia/client-search@5.52.1)(@types/node@25.9.5)(fuse.js@7.5.0)(lightningcss@1.32.0)(postcss@8.5.20)(search-insights@2.17.3)(sortablejs@1.15.7)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       vue:
         specifier: ^3.5.40
-        version: 3.5.40(typescript@6.0.3)
+        version: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       vue-i18n:
         specifier: ^11.4.7
-        version: 11.4.7(vue@3.5.40(typescript@6.0.3))
+        version: 11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       vue-router:
         specifier: ^5.2.0
-        version: 5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+        version: 5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
     devDependencies:
       '@apache-arrow/esnext-esm':
         specifier: ^21.2.0
@@ -179,10 +182,10 @@ importers:
         version: 1.2.4
       '@iconify/vue':
         specifier: ^5.0.1
-        version: 5.0.1(vue@3.5.40(typescript@6.0.3))
+        version: 5.0.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@pinia/testing':
         specifier: ^2.0.1
-        version: 2.0.1(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))
+        version: 2.0.1(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -194,13 +197,13 @@ importers:
         version: 25.9.5
       '@vitejs/plugin-vue':
         specifier: 6.0.8
-        version: 6.0.8(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+        version: 6.0.8(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-sfc':
         specifier: ^3.5.40
         version: 3.5.40
       '@vue/test-utils':
         specifier: ^2.4.11
-        version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript@6.0.3))
+        version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       bumpp:
         specifier: ^12.0.0
         version: 12.0.0
@@ -230,10 +233,10 @@ importers:
         version: 2.13.1
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.9.5)(typescript@6.0.3)
+        version: 10.9.2(@types/node@25.9.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
+        version: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.5)(jsdom@29.1.1)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))
@@ -242,7 +245,7 @@ importers:
         version: 3.3.8
       vue-tsc:
         specifier: 3.3.8
-        version: 3.3.8(typescript@6.0.3)
+        version: 3.3.8(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
   docs:
     dependencies:
@@ -1621,6 +1624,41 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.2':
     resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-native-bridge/darwin-arm64@6.0.3-bridge.1.tsgo.7.0.2':
+    resolution: {integrity: sha512-odo538uhOuD6PZT4gY8955l/r1xTLfVoyeU1RQ8O7QxISRbS90sYeQBNCts4VUyvcVa/1yBClgjgEbBYXZbDyg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript-native-bridge/darwin-x64@6.0.3-bridge.1.tsgo.7.0.2':
+    resolution: {integrity: sha512-LMJSZZXLNh7otRZoMH2+algHWupo3EcYnEXdxwH6+AAZJL7FZAiRA2h+nGNc0j3f0lRrw5qeFLcE2Rhtzk6Kpw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript-native-bridge/linux-arm64@6.0.3-bridge.1.tsgo.7.0.2':
+    resolution: {integrity: sha512-uPSbphc1Z7VMSVTs9wVuaqxK1jpkGwkMwcg7UvXwUUBdVrIv/zdFq349RkbG4IB0G0i78EWDDFDSkGs/aL/WEg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript-native-bridge/linux-arm@6.0.3-bridge.1.tsgo.7.0.2':
+    resolution: {integrity: sha512-28OCjw/dpf5NV8glXnVsdMbCSImhInCe49jVIH3ICKYf9Re8QFnqz5fLVI8+3SUVproaFT7PQfuAKGt0sUuePQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript-native-bridge/linux-x64@6.0.3-bridge.1.tsgo.7.0.2':
+    resolution: {integrity: sha512-kVJXTkXx3GWSGKJXZak6IhSiiR+HuKX4F6H74Dr96kqKS4Jopx0dqBbZ1+05xizCShJsw6gFP1tmWtYwt/V63A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript-native-bridge/win32-arm64@6.0.3-bridge.1.tsgo.7.0.2':
+    resolution: {integrity: sha512-xvNNBTKogTyvd1rFogt/dreCsx1kvbqLidBeoTuGDOjOCXjLRGuz1ym6woVXUwiVi3KdtwsaXqYE9CoURxNyCA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript-native-bridge/win32-x64@6.0.3-bridge.1.tsgo.7.0.2':
+    resolution: {integrity: sha512-5HegdRz7LXB61YdtJ0/F6tgTv4A4WfT0Uz0BQma6fPVhwK6UHdYOWosFW05ZEZOAZMQ9MgFsryvd8nNZNvUjVg==}
+    cpu: [x64]
+    os: [win32]
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -3558,9 +3596,9 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2:
+    resolution: {integrity: sha512-vBtvhFVhjwUBIo4xZE6CNr3C1J1VSAvV7kLBRAPqs29HuL5bvxsOTRq+KxXODSEyp/TCWn/TeE0Bzd0D7k1UWg==}
+    engines: {node: '>=20.19'}
     hasBin: true
 
   typical@4.0.0:
@@ -4642,12 +4680,12 @@ snapshots:
       '@iconify/types': 2.0.0
       import-meta-resolve: 4.2.0
 
-  '@iconify/vue@5.0.1(vue@3.5.40(typescript@6.0.3))':
+  '@iconify/vue@5.0.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@iconify/types': 2.0.0
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@intlify/bundle-utils@11.2.4(vue-i18n@11.4.7(vue@3.5.40(typescript@6.0.3)))':
+  '@intlify/bundle-utils@11.2.4(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))':
     dependencies:
       '@intlify/message-compiler': 11.4.6
       '@intlify/shared': 11.4.6
@@ -4659,7 +4697,7 @@ snapshots:
       source-map-js: 1.2.1
       yaml-eslint-parser: 1.3.2
     optionalDependencies:
-      vue-i18n: 11.4.7(vue@3.5.40(typescript@6.0.3))
+      vue-i18n: 11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
 
   '@intlify/core-base@11.4.7':
     dependencies:
@@ -4686,24 +4724,24 @@ snapshots:
 
   '@intlify/shared@11.4.7': {}
 
-  '@intlify/unplugin-vue-i18n@11.2.4(@vue/compiler-dom@3.5.39)(eslint@9.19.0(jiti@2.7.0)(supports-color@10.2.2))(rollup@4.60.3)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-i18n@11.4.7(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@intlify/unplugin-vue-i18n@11.2.4(@vue/compiler-dom@3.5.39)(eslint@9.19.0(jiti@2.7.0)(supports-color@10.2.2))(rollup@4.60.3)(supports-color@10.2.2)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.19.0(jiti@2.7.0)(supports-color@10.2.2))
-      '@intlify/bundle-utils': 11.2.4(vue-i18n@11.4.7(vue@3.5.40(typescript@6.0.3)))
+      '@intlify/bundle-utils': 11.2.4(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))
       '@intlify/shared': 11.4.6
-      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.4.6)(@vue/compiler-dom@3.5.39)(vue-i18n@11.4.7(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.4.6)(@vue/compiler-dom@3.5.39)(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
       '@typescript-eslint/scope-manager': 8.59.2
-      '@typescript-eslint/typescript-estree': 8.59.2(supports-color@10.2.2)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(supports-color@10.2.2)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       debug: 4.4.3(supports-color@10.2.2)
       fast-glob: 3.3.3
       pathe: 2.0.3
       picocolors: 1.1.1
       unplugin: 2.3.11
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     optionalDependencies:
       vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)
-      vue-i18n: 11.4.7(vue@3.5.40(typescript@6.0.3))
+      vue-i18n: 11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
     transitivePeerDependencies:
       - '@vue/compiler-dom'
       - eslint
@@ -4711,14 +4749,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.4.6)(@vue/compiler-dom@3.5.39)(vue-i18n@11.4.7(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.4.6)(@vue/compiler-dom@3.5.39)(vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@babel/parser': 7.29.7
     optionalDependencies:
       '@intlify/shared': 11.4.6
       '@vue/compiler-dom': 3.5.39
-      vue: 3.5.40(typescript@6.0.3)
-      vue-i18n: 11.4.7(vue@3.5.40(typescript@6.0.3))
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      vue-i18n: 11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -4844,10 +4882,10 @@ snapshots:
   '@oxc-resolver/binding-win32-x64-msvc@4.2.0':
     optional: true
 
-  '@pinia/testing@2.0.1(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))':
+  '@pinia/testing@2.0.1(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))':
     dependencies:
       nostics: 1.1.4
-      pinia: 4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))
+      pinia: 4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5184,12 +5222,12 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
-  '@typescript-eslint/project-service@8.59.2(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.59.2(supports-color@10.2.2)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       '@typescript-eslint/types': 8.59.2
       debug: 4.4.3(supports-color@10.2.2)
-      typescript: 6.0.3
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5198,24 +5236,24 @@ snapshots:
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
 
-  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
 
   '@typescript-eslint/types@8.59.2': {}
 
-  '@typescript-eslint/typescript-estree@8.59.2(supports-color@10.2.2)(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.59.2(supports-color@10.2.2)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.59.2(supports-color@10.2.2)(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.59.2(supports-color@10.2.2)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       '@typescript-eslint/types': 8.59.2
       '@typescript-eslint/visitor-keys': 8.59.2
       debug: 4.4.3(supports-color@10.2.2)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5224,18 +5262,39 @@ snapshots:
       '@typescript-eslint/types': 8.59.2
       eslint-visitor-keys: 5.0.1
 
+  '@typescript-native-bridge/darwin-arm64@6.0.3-bridge.1.tsgo.7.0.2':
+    optional: true
+
+  '@typescript-native-bridge/darwin-x64@6.0.3-bridge.1.tsgo.7.0.2':
+    optional: true
+
+  '@typescript-native-bridge/linux-arm64@6.0.3-bridge.1.tsgo.7.0.2':
+    optional: true
+
+  '@typescript-native-bridge/linux-arm@6.0.3-bridge.1.tsgo.7.0.2':
+    optional: true
+
+  '@typescript-native-bridge/linux-x64@6.0.3-bridge.1.tsgo.7.0.2':
+    optional: true
+
+  '@typescript-native-bridge/win32-arm64@6.0.3-bridge.1.tsgo.7.0.2':
+    optional: true
+
+  '@typescript-native-bridge/win32-x64@6.0.3-bridge.1.tsgo.7.0.2':
+    optional: true
+
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.9.5)(lightningcss@1.32.0))(vue@3.5.40(typescript@6.0.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.9.5)(lightningcss@1.32.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       vite: 5.4.21(@types/node@25.9.5)(lightningcss@1.32.0)
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vitejs/plugin-vue@6.0.8(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))':
+  '@vitejs/plugin-vue@6.0.8(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -5290,36 +5349,36 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  '@vue-macros/api@0.13.4(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/api@0.13.4(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       oxc-resolver: 4.2.0
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/better-define@1.11.4(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/better-define@1.11.4(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/api': 0.13.4(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/api': 0.13.4(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/boolean-prop@0.5.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/boolean-prop@0.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-core': 3.5.39
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/chain-call@0.4.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/chain-call@0.4.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/common@1.16.1(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/common@1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@vue/compiler-sfc': 3.5.40
       ast-kit: 1.4.3
@@ -5328,9 +5387,9 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
     optionalDependencies:
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/common@3.1.3(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/common@3.1.3(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@vue/compiler-sfc': 3.5.40
       ast-kit: 2.2.0
@@ -5338,195 +5397,195 @@ snapshots:
       magic-string-ast: 1.0.3
       unplugin-utils: 0.3.1
     optionalDependencies:
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/config@0.6.1(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/config@0.6.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       make-synchronized: 0.2.10
       unconfig: 7.5.0
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/define-emit@0.5.4(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/define-emit@0.5.4(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/define-models@1.3.5(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/define-models@1.3.5(@vueuse/core@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       ast-walker-scope: 0.6.2
       unplugin: 1.16.1
     optionalDependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/define-prop@0.6.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/define-prop@0.6.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/api': 0.13.4(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/api': 0.13.4(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/define-props-refs@1.3.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/define-props-refs@1.3.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/define-props@4.0.6(@vue-macros/reactivity-transform@1.1.6(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/define-props@4.0.6(@vue-macros/reactivity-transform@1.1.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/reactivity-transform': 1.1.6(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/reactivity-transform': 1.1.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/define-render@1.6.6(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/define-render@1.6.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/define-slots@1.2.6(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/define-slots@1.2.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/define-stylex@0.2.3(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/define-stylex@0.2.3(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-dom': 3.5.39
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/devtools@0.4.1(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vue-macros/devtools@0.4.1(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       sirv: 3.0.2
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     optionalDependencies:
       vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - typescript
 
-  '@vue-macros/export-expose@0.3.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/export-expose@0.3.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-sfc': 3.5.40
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/export-props@0.6.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/export-props@0.6.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/export-render@0.3.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/export-render@0.3.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/hoist-static@1.7.0(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/hoist-static@1.7.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/jsx-directive@0.10.6(typescript@6.0.3)':
+  '@vue-macros/jsx-directive@0.10.6(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-sfc': 3.5.40
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vue-macros/named-template@0.5.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/named-template@0.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-dom': 3.5.39
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/reactivity-transform@1.1.6(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/reactivity-transform@1.1.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@babel/parser': 7.29.7
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-core': 3.5.39
       '@vue/shared': 3.5.39
       magic-string: 0.30.21
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/script-lang@0.2.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/script-lang@0.2.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vue-macros/setup-block@0.4.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/setup-block@0.4.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-dom': 3.5.39
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/setup-component@0.18.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/setup-component@0.18.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/setup-sfc@0.18.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/setup-sfc@0.18.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/short-bind@1.1.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/short-bind@1.1.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-core': 3.5.39
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/short-emits@1.6.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/short-emits@1.6.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/short-vmodel@1.5.5(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/short-vmodel@1.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/compiler-core': 3.5.39
     transitivePeerDependencies:
       - vue
 
-  '@vue-macros/volar@0.30.15(typescript@6.0.3)(vue-tsc@3.3.8(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))':
+  '@vue-macros/volar@0.30.15(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue-tsc@3.3.8(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vue-macros/boolean-prop': 0.5.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/config': 0.6.1(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/short-bind': 1.1.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/short-vmodel': 1.5.5(vue@3.5.40(typescript@6.0.3))
-      '@vue/language-core': 2.1.10(typescript@6.0.3)
+      '@vue-macros/boolean-prop': 0.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/config': 0.6.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/short-bind': 1.1.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/short-vmodel': 1.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue/language-core': 2.1.10(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       muggle-string: 0.4.1
       ts-macro: 0.1.35
     optionalDependencies:
-      vue-tsc: 3.3.8(typescript@6.0.3)
+      vue-tsc: 3.3.8(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     transitivePeerDependencies:
       - typescript
       - vue
@@ -5612,7 +5671,7 @@ snapshots:
 
   '@vue/devtools-shared@8.1.5': {}
 
-  '@vue/language-core@2.1.10(typescript@6.0.3)':
+  '@vue/language-core@2.1.10(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.39
@@ -5623,7 +5682,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
 
   '@vue/language-core@3.3.8':
     dependencies:
@@ -5661,42 +5720,42 @@ snapshots:
 
   '@vue/shared@3.5.40': {}
 
-  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript@6.0.3))':
+  '@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.40)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@vue/compiler-dom': 3.5.39
       js-beautify: 1.15.4
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       vue-component-type-helpers: 3.3.8
     optionalDependencies:
       '@vue/server-renderer': 3.5.40
 
-  '@vueuse/components@14.3.0(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/components@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vueuse/core@12.8.2(typescript@6.0.3)':
+  '@vueuse/core@12.8.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@6.0.3)
-      vue: 3.5.40(typescript@6.0.3)
+      '@vueuse/shared': 12.8.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/core@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.3.0
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(fuse.js@7.5.0)(sortablejs@1.15.7)(typescript@6.0.3)':
+  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(fuse.js@7.5.0)(sortablejs@1.15.7)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@6.0.3)
-      '@vueuse/shared': 12.8.2(typescript@6.0.3)
-      vue: 3.5.40(typescript@6.0.3)
+      '@vueuse/core': 12.8.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      '@vueuse/shared': 12.8.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     optionalDependencies:
       focus-trap: 7.8.0
       fuse.js: 7.5.0
@@ -5704,11 +5763,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@14.3.0(focus-trap@7.8.0)(fuse.js@7.5.0)(sortablejs@1.15.7)(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/integrations@14.3.0(focus-trap@7.8.0)(fuse.js@7.5.0)(sortablejs@1.15.7)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     optionalDependencies:
       focus-trap: 7.8.0
       fuse.js: 7.5.0
@@ -5718,21 +5777,21 @@ snapshots:
 
   '@vueuse/metadata@14.3.0': {}
 
-  '@vueuse/router@14.3.0(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/router@14.3.0(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
 
-  '@vueuse/shared@12.8.2(typescript@6.0.3)':
+  '@vueuse/shared@12.8.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)':
     dependencies:
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/shared@14.3.0(vue@3.5.40(typescript@6.0.3))':
+  '@vueuse/shared@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))':
     dependencies:
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
   '@xterm/addon-fit@0.11.0': {}
 
@@ -6861,13 +6920,13 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)):
+  pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
       '@vue/devtools-api': 8.1.5
       nostics: 1.1.4
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
 
   pkg-types@1.3.1:
     dependencies:
@@ -7094,9 +7153,9 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
-  splitpanes@4.1.2(vue@3.5.40(typescript@6.0.3)):
+  splitpanes@4.1.2(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
   stackback@0.0.2: {}
 
@@ -7217,15 +7276,15 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
+  ts-api-utils@2.5.0(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
 
   ts-macro@0.1.35:
     dependencies:
       muggle-string: 0.4.1
 
-  ts-node@10.9.2(@types/node@25.9.5)(typescript@6.0.3):
+  ts-node@10.9.2(@types/node@25.9.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -7239,7 +7298,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 6.0.3
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -7249,7 +7308,15 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript@6.0.3: {}
+  typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2:
+    optionalDependencies:
+      '@typescript-native-bridge/darwin-arm64': 6.0.3-bridge.1.tsgo.7.0.2
+      '@typescript-native-bridge/darwin-x64': 6.0.3-bridge.1.tsgo.7.0.2
+      '@typescript-native-bridge/linux-arm': 6.0.3-bridge.1.tsgo.7.0.2
+      '@typescript-native-bridge/linux-arm64': 6.0.3-bridge.1.tsgo.7.0.2
+      '@typescript-native-bridge/linux-x64': 6.0.3-bridge.1.tsgo.7.0.2
+      '@typescript-native-bridge/win32-arm64': 6.0.3-bridge.1.tsgo.7.0.2
+      '@typescript-native-bridge/win32-x64': 6.0.3-bridge.1.tsgo.7.0.2
 
   typical@4.0.0: {}
 
@@ -7316,7 +7383,7 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  unplugin-auto-import@21.0.0(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3))):
+  unplugin-auto-import@21.0.0(@vueuse/core@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))):
     dependencies:
       local-pkg: 1.2.0
       magic-string: 0.30.21
@@ -7325,7 +7392,7 @@ snapshots:
       unplugin: 2.3.11
       unplugin-utils: 0.3.1
     optionalDependencies:
-      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@6.0.3))
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
 
   unplugin-combine@1.2.1(rolldown@1.1.5)(rollup@4.60.3)(unplugin@1.16.1)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)):
     optionalDependencies:
@@ -7354,7 +7421,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.5
 
-  unplugin-vue-components@32.1.0(vue@3.5.40(typescript@6.0.3)):
+  unplugin-vue-components@32.1.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
       chokidar: 5.0.0
       local-pkg: 1.2.0
@@ -7365,51 +7432,51 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin: 3.0.0
       unplugin-utils: 0.3.1
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  unplugin-vue-define-options@1.5.5(vue@3.5.40(typescript@6.0.3)):
+  unplugin-vue-define-options@1.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       ast-walker-scope: 0.6.2
       unplugin: 1.16.1
     transitivePeerDependencies:
       - vue
 
-  unplugin-vue-macros@2.14.5(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3)):
+  unplugin-vue-macros@2.14.5(@vueuse/core@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
-      '@vue-macros/better-define': 1.11.4(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/boolean-prop': 0.5.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/chain-call': 0.4.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/config': 0.6.1(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/define-emit': 0.5.4(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/define-models': 1.3.5(@vueuse/core@14.3.0(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/define-prop': 0.6.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/define-props': 4.0.6(@vue-macros/reactivity-transform@1.1.6(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/define-props-refs': 1.3.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/define-render': 1.6.6(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/define-slots': 1.2.6(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/define-stylex': 0.2.3(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/devtools': 0.4.1(typescript@6.0.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))
-      '@vue-macros/export-expose': 0.3.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/export-props': 0.6.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/export-render': 0.3.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/hoist-static': 1.7.0(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/jsx-directive': 0.10.6(typescript@6.0.3)
-      '@vue-macros/named-template': 0.5.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/reactivity-transform': 1.1.6(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/script-lang': 0.2.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/setup-block': 0.4.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/setup-component': 0.18.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/setup-sfc': 0.18.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/short-bind': 1.1.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/short-emits': 1.6.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/short-vmodel': 1.5.5(vue@3.5.40(typescript@6.0.3))
-      '@vue-macros/volar': 0.30.15(typescript@6.0.3)(vue-tsc@3.3.8(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/better-define': 1.11.4(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/boolean-prop': 0.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/chain-call': 0.4.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/common': 1.16.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/config': 0.6.1(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/define-emit': 0.5.4(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/define-models': 1.3.5(@vueuse/core@14.3.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/define-prop': 0.6.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/define-props': 4.0.6(@vue-macros/reactivity-transform@1.1.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/define-props-refs': 1.3.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/define-render': 1.6.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/define-slots': 1.2.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/define-stylex': 0.2.3(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/devtools': 0.4.1(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))
+      '@vue-macros/export-expose': 0.3.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/export-props': 0.6.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/export-render': 0.3.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/hoist-static': 1.7.0(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/jsx-directive': 0.10.6(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      '@vue-macros/named-template': 0.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/reactivity-transform': 1.1.6(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/script-lang': 0.2.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/setup-block': 0.4.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/setup-component': 0.18.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/setup-sfc': 0.18.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/short-bind': 1.1.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/short-emits': 1.6.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/short-vmodel': 1.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      '@vue-macros/volar': 0.30.15(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue-tsc@3.3.8(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       unplugin: 1.16.1
       unplugin-combine: 1.2.1(rolldown@1.1.5)(rollup@4.60.3)(unplugin@1.16.1)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))
-      unplugin-vue-define-options: 1.5.5(vue@3.5.40(typescript@6.0.3))
-      vue: 3.5.40(typescript@6.0.3)
+      unplugin-vue-define-options: 1.5.5(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vueuse/core'
@@ -7475,21 +7542,21 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-vue-layouts@0.11.0(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)))(vue@3.5.40(typescript@6.0.3)):
+  vite-plugin-vue-layouts@0.11.0(supports-color@10.2.2)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       fast-glob: 3.3.3
       vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)
-      vue: 3.5.40(typescript@6.0.3)
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
     transitivePeerDependencies:
       - supports-color
 
-  vite-svg-loader@5.1.1(supports-color@10.2.2)(vue@3.5.40(typescript@6.0.3)):
+  vite-svg-loader@5.1.1(supports-color@10.2.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
       svgo: 3.3.3
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -7516,7 +7583,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitepress@1.6.4(@algolia/client-search@5.52.1)(@types/node@25.9.5)(fuse.js@7.5.0)(lightningcss@1.32.0)(postcss@8.5.20)(search-insights@2.17.3)(sortablejs@1.15.7)(typescript@6.0.3):
+  vitepress@1.6.4(@algolia/client-search@5.52.1)(@types/node@25.9.5)(fuse.js@7.5.0)(lightningcss@1.32.0)(postcss@8.5.20)(search-insights@2.17.3)(sortablejs@1.15.7)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.52.1)(search-insights@2.17.3)
@@ -7525,17 +7592,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.9.5)(lightningcss@1.32.0))(vue@3.5.40(typescript@6.0.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.21(@types/node@25.9.5)(lightningcss@1.32.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/devtools-api': 7.7.9
       '@vue/shared': 3.5.39
-      '@vueuse/core': 12.8.2(typescript@6.0.3)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)(fuse.js@7.5.0)(sortablejs@1.15.7)(typescript@6.0.3)
+      '@vueuse/core': 12.8.2(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
+      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)(fuse.js@7.5.0)(sortablejs@1.15.7)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
       vite: 5.4.21(@types/node@25.9.5)(lightningcss@1.32.0)
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
     optionalDependencies:
       postcss: 8.5.20
     transitivePeerDependencies:
@@ -7597,18 +7664,18 @@ snapshots:
 
   vue-component-type-helpers@3.3.8: {}
 
-  vue-i18n@11.4.7(vue@3.5.40(typescript@6.0.3)):
+  vue-i18n@11.4.7(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
       '@intlify/core-base': 11.4.7
       '@intlify/devtools-types': 11.4.7
       '@intlify/shared': 11.4.7
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
 
-  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3)):
+  vue-router@5.2.0(@vue/compiler-sfc@3.5.40)(pinia@4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)))(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)):
     dependencies:
       '@babel/generator': 8.0.0
-      '@vue-macros/common': 3.1.3(vue@3.5.40(typescript@6.0.3))
+      '@vue-macros/common': 3.1.3(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       '@vue/devtools-api': 8.1.5
       ast-walker-scope: 0.9.0
       chokidar: 5.0.0
@@ -7624,11 +7691,11 @@ snapshots:
       tinyglobby: 0.2.17
       unplugin: 3.3.0(rolldown@1.1.5)(rollup@4.60.3)(vite@8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      vue: 3.5.40(typescript@6.0.3)
+      vue: 3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)
       yaml: 2.9.0
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.40
-      pinia: 4.0.2(@vue/devtools-api@8.1.5)(typescript@6.0.3)(vue@3.5.40(typescript@6.0.3))
+      pinia: 4.0.2(@vue/devtools-api@8.1.5)(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2)(vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2))
       vite: 8.1.5(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -7640,13 +7707,13 @@ snapshots:
       - unloader
       - webpack
 
-  vue-tsc@3.3.8(typescript@6.0.3):
+  vue-tsc@3.3.8(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2):
     dependencies:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 3.3.8
-      typescript: 6.0.3
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
 
-  vue@3.5.40(typescript@6.0.3):
+  vue@3.5.40(typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2):
     dependencies:
       '@vue/compiler-dom': 3.5.40
       '@vue/compiler-sfc': 3.5.40
@@ -7654,7 +7721,7 @@ snapshots:
       '@vue/server-renderer': 3.5.40
       '@vue/shared': 3.5.40
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
 
   w3c-keyname@2.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 packages:
   - docs
+overrides:
+  typescript: npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2
 allowBuilds:
   esbuild: true
   simple-git-hooks: true


### PR DESCRIPTION
Runs frontend type checking on the Go-based TypeScript engine (TypeScript 7 / tsgo 7.0.2) via [typescript-native-bridge](https://github.com/johnsoncodehk/typescript-native-bridge).

## What

- `pnpm-workspace.yaml`: override `typescript` -> `npm:typescript-native-bridge@6.0.3-bridge.1.tsgo.7.0.2`

The bridge is a drop-in for the classic `typescript` package (same 6.0.3 API surface) but runs the checker on tsgo underneath. `vue-tsc`, ESLint, and editor tooling keep using the classic API, so no `tsconfig.json` or code changes.

## Verify

`pnpm typecheck` prints `✅ TNB ACTIVE` and passes clean.

## Notes

- Pinned to `bridge.1`. Newer `bridge.6` exists but is blocked by the repo's `minimumReleaseAge: 1440` (24h) policy. Bump once it ages.
- For VS Code to use the native engine too, add `"typescript.tsdk": "node_modules/typescript/lib"` and select "Use Workspace Version".

🤖 Generated with [Claude Code](https://claude.com/claude-code)