### PR TITLE
fix(security): require auth for /cloud/callback (GHSA-p66q-2gfp-8v55)

### DIFF
--- a/internal/web/auth_simple_test.go
+++ b/internal/web/auth_simple_test.go
@@ -131,3 +131,33 @@ func Test_createRoutes_simple_bad_password(t *testing.T) {
 
 	assert.Equal(t, rr.Code, 401, "Response code should be 401.")
 }
+
+func Test_createRoutes_simple_cloud_callback_requires_auth(t *testing.T) {
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "index.html", []byte("index page"), 0644), "WriteFile should have no error.")
+
+	handler := createHandler(nil, afero.NewIOFS(fs), Config{Base: "/",
+		Authorization: Authorization{
+			Provider: SIMPLE,
+			Authorizer: auth.NewSimpleAuth(auth.UserDatabase{
+				Users: map[string]*auth.User{
+					"amir": {
+						Username: "amir",
+						Password: "$2a$10$4Tvzu0ms9shlv4B8pIfqI.TM9CoqsamsAznP91A1NGuwg/68SGS1m",
+					},
+				},
+			}, time.Second*100),
+		},
+	})
+
+	// The cloud callback must not be reachable without authentication. Otherwise
+	// an attacker could force-link the instance to their own cloud account.
+	for _, path := range []string{"/api/cloud/callback?token=attacker", "/api/cloud/status"} {
+		req, err := http.NewRequest("GET", path, nil)
+		require.NoError(t, err, "NewRequest should not return an error.")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, 401, rr.Code, "%s should require authentication.", path)
+	}
+}

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -216,6 +216,10 @@ func createRouter(h *handler) *chi.Mux {
 				r.Patch("/cloud/config", h.updateCloudConfig)
 				r.Delete("/cloud/config", h.deleteCloudConfig)
 				r.Post("/cloud/feedback", h.cloudFeedback)
+				// Cloud callback handles the OAuth-style code exchange. It must stay
+				// authenticated so an unauthenticated attacker cannot force-link the
+				// instance to their own cloud account via SetCloudConfig.
+				r.Get("/cloud/callback", h.cloudCallback)
 
 				// MCP (Model Context Protocol) endpoint
 				if h.config.EnableMCP {
@@ -229,9 +233,6 @@ func createRouter(h *handler) *chi.Mux {
 				r.Post("/token", h.createToken)
 				r.Delete("/token", h.deleteToken)
 			}
-
-			// Cloud callback (public, handles OAuth-style code exchange)
-			r.Get("/cloud/callback", h.cloudCallback)
 		})
 
 		r.Get("/healthcheck", h.healthcheck)


### PR DESCRIPTION
Fixes D1 from the private advisory GHSA-p66q-2gfp-8v55.

## Problem

`/cloud/callback` was registered outside the `RequireAuthentication` group in `routes.go`, so with authentication enabled it stayed reachable unauthenticated. The handler processes an attacker-supplied token and calls `SetCloudConfig`, which persists and broadcasts a cloud API key to all agents. An attacker could force-link the instance to their own cloud account and cause notification and log content to stream to it.

## Fix

Move `/cloud/callback` inside the authenticated group, alongside the other `/cloud/*` routes. The OAuth-style redirect already happens in an authenticated browser session, so no legitimate flow breaks.

## Test

Added a regression test asserting `/api/cloud/callback` and its sibling `/api/cloud/status` both return 401 when unauthenticated under the SIMPLE provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)