### PR TITLE
fix: respect custom base paths for built assets

### DIFF
--- a/assets/build.spec.ts
+++ b/assets/build.spec.ts
@@ -1,0 +1,24 @@
+import { build } from "vite";
+import { describe, expect, it } from "vitest";
+
+describe("production build", () => {
+  it("emits font URLs relative to the generated stylesheet", async () => {
+    const result = await build({
+      configFile: "vite.config.ts",
+      logLevel: "silent",
+      build: { write: false },
+    });
+    const outputs = Array.isArray(result) ? result : [result];
+    const stylesheet = outputs
+      .flatMap((output) => ("output" in output ? output.output : []))
+      .find((item) => item.type === "asset" && item.fileName.endsWith(".css"));
+
+    expect(stylesheet).toBeDefined();
+    if (!stylesheet || stylesheet.type !== "asset") {
+      throw new Error("Production build did not emit a stylesheet");
+    }
+    const css = String(stylesheet.source);
+    expect(css).toMatch(/url\(\.\/jetbrains-mono/);
+    expect(css).not.toMatch(/url\(\/assets\/jetbrains-mono/);
+  }, 15_000);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,7 @@ import svgLoader from "vite-svg-loader";
 import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig(() => ({
+  base: "./",
   define: {
     __CLOUD_URL__: JSON.stringify(process.env.CLOUD_URL || "https://cloud.dozzle.dev"),
   },


### PR DESCRIPTION
Closes #4878

## Summary
- configure Vite to emit asset references relative to their generated files
- keep font requests under the configured Dozzle base path
- add an artifact-level regression test for generated font URLs

With a stylesheet served from /dozzle/assets/, font URLs now resolve to /dozzle/assets/... instead of /assets/.... Root deployments continue to resolve them under /assets/.

## Verification
- pnpm test --run (121 passed)
- pnpm typecheck
- pnpm build
- go test ./internal/web (46 passed)
- Prettier check for changed files
- independent review: no findings

The repository-wide Go suite additionally requires generated shared_cert.pem and has an unrelated internal/agent initializer failure in this local checkout; the affected web package passes.