### PR TITLE
test(e2e): assert static assets resolve under a custom base path

### DIFF
--- a/e2e/custom.spec.ts
+++ b/e2e/custom.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from "@playwright/test";
 
+const origin = "http://custom_base:8080";
+const base = "/foobarbase";
+
 test.beforeEach(async ({ page }) => {
-  await page.goto("http://custom_base:8080/foobarbase");
+  await page.goto(origin + base);
 });
 
 test("has right title", async ({ page }) => {
@@ -10,4 +13,36 @@ test("has right title", async ({ page }) => {
 
 test("url should have custom base", async ({ page }) => {
   await expect(page).toHaveURL(/foobarbase/);
+});
+
+test("static assets resolve under the custom base", async ({ page }) => {
+  const requested: string[] = [];
+  const broken: string[] = [];
+
+  const isAsset = (url: string) => new URL(url).pathname.includes("/assets/");
+
+  page.on("request", (request) => {
+    if (isAsset(request.url())) requested.push(new URL(request.url()).pathname);
+  });
+  page.on("response", (response) => {
+    if (isAsset(response.url()) && response.status() >= 400) {
+      broken.push(`${response.status()} ${response.url()}`);
+    }
+  });
+
+  await page.reload();
+  await expect(page).toHaveTitle(/.* - Dozzle/);
+  // fonts are only fetched when a glyph needs them, so force the @font-face src to resolve.
+  // swallow the rejection on a bad url so the assertions below report which path was wrong
+  await page.evaluate(() =>
+    document.fonts.load('400 1rem "JetBrains Mono"').then(
+      () => {},
+      () => {},
+    ),
+  );
+
+  // the css lives at <base>/assets/, so a relative url() in it must resolve back under <base>
+  expect(requested.some((path) => path.endsWith(".woff2"))).toBe(true);
+  expect(requested.filter((path) => !path.startsWith(`${base}/assets/`))).toEqual([]);
+  expect(broken).toEqual([]);
 });


### PR DESCRIPTION
Regression test for #4878. Depends on #4879, will be red until that merges.

The `custom_base` service already runs with `DOZZLE_BASE=/foobarbase`, so this just adds a third test to `e2e/custom.spec.ts` that watches every `/assets/` request and asserts the path stays under the base.

Why it's shaped this way:

* filters on `/assets/` so the pre-existing `/api/cloud/config` 404s don't leak in
* `document.fonts.load()` forces the lazy `@font-face` fetch, otherwise the woff2 is only requested when a mono glyph happens to render
* can't use `networkidle`, the SSE stream never settles
* the font promise rejection is swallowed so a bad url fails as a readable path diff instead of `NetworkError`

Verified both directions locally against a real `dozzle-custom_base` image:

* current master (no fix): fails with `["/assets/jetbrains-mono-latin-400-normal-V6pRDFza.woff2", ...]`
* with #4879 applied: 3 passed

Unrelated thing I noticed while digging: the service worker cache regex in `internal/web/sw.go:31` is `/\/assets\/.*\.[a-f0-9]{8}\./`, which never matches. Vite hashes are base64url (`main-BVSE7uv-.css`) and there's no dot before the hash, so asset caching in the SW has never run. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)