### PR TITLE
fix: derive jwt signing key from users in a stable order

### DIFF
--- a/internal/auth/simple.go
+++ b/internal/auth/simple.go
@@ -3,7 +3,9 @@ package auth
 import (
 	"crypto/sha256"
 	"errors"
+	"maps"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/go-chi/jwtauth/v5"
@@ -18,8 +20,13 @@ type simpleAuthContext struct {
 var ErrInvalidCredentials = errors.New("invalid credentials")
 
 func NewSimpleAuth(userDatabase UserDatabase, ttl time.Duration) *simpleAuthContext {
+	// Hash the users in a stable order. Ranging over the map directly makes the
+	// digest depend on Go's randomized map iteration order, so any users.yml with
+	// more than one user derives a different signing key on every start and
+	// silently invalidates every session on restart.
 	h := sha256.New()
-	for _, user := range userDatabase.Users {
+	for _, username := range slices.Sorted(maps.Keys(userDatabase.Users)) {
+		user := userDatabase.Users[username]
 		h.Write([]byte(user.Password))
 		h.Write([]byte(user.RolesConfigured))
 	}

--- a/internal/auth/simple_test.go
+++ b/internal/auth/simple_test.go
@@ -1,0 +1,50 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The JWT signing key is derived from the users in users.yml so that a token
+// stays valid across restarts and is only invalidated when a password or role
+// actually changes. Deriving it by ranging over the user map made the digest
+// depend on Go's randomized map iteration order, so every restart of a
+// multi-user setup rolled the key and logged everyone out.
+func TestSimpleAuthSigningKeyIsStableAcrossRestarts(t *testing.T) {
+	users := UserDatabase{
+		Users: map[string]*User{
+			"alice": {Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all"},
+			"bob":   {Username: "bob", Password: "$2a$11$bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", RolesConfigured: "shell"},
+			"carol": {Username: "carol", Password: "$2a$11$cccccccccccccccccccccccccccccccccccccccccccccccccccccc", RolesConfigured: "actions"},
+			"dave":  {Username: "dave", Password: "$2a$11$dddddddddddddddddddddddddddddddddddddddddddddddddddddd", RolesConfigured: "download"},
+		},
+	}
+
+	_, token, err := NewSimpleAuth(users, 0).tokenAuth.Encode(map[string]any{"username": "alice"})
+	require.NoError(t, err)
+
+	// Each iteration stands in for a Dozzle restart against an unchanged users.yml.
+	for i := range 50 {
+		if _, err := NewSimpleAuth(users, 0).tokenAuth.Decode(token); err != nil {
+			t.Fatalf("token issued before restart %d was rejected: %v", i+1, err)
+		}
+	}
+}
+
+// Changing a password or a role must still roll the key so old tokens stop working.
+func TestSimpleAuthSigningKeyChangesWhenCredentialsChange(t *testing.T) {
+	users := UserDatabase{
+		Users: map[string]*User{
+			"alice": {Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all"},
+			"bob":   {Username: "bob", Password: "$2a$11$bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", RolesConfigured: "shell"},
+		},
+	}
+
+	_, token, err := NewSimpleAuth(users, 0).tokenAuth.Encode(map[string]any{"username": "alice"})
+	require.NoError(t, err)
+
+	users.Users["bob"].RolesConfigured = "shell,actions"
+	_, err = NewSimpleAuth(users, 0).tokenAuth.Decode(token)
+	require.Error(t, err)
+}


### PR DESCRIPTION
In #4858 the answer was that the signing key is deterministic and a JWT survives a restart unless something in `users.yml` changes. That holds for a single user, but not for more than one.

`NewSimpleAuth` builds the sha256 by ranging over `userDatabase.Users`, which is a map, and Go randomizes map iteration order. With two or more users the digest comes out different on most starts, so the key rolls and every session cookie and API/MCP token dies on restart. Feeding the same 4-user map through the current loop 200 times produced 3 distinct keys.

Sorting by username keeps the exact same hash inputs and makes the result reproducible. A single-user `users.yml` derives the same key it did before, so those installs see no change; multi-user installs get logged out once on upgrade and then stay logged in.

Tests cover both directions: a token issued before a restart still verifies afterwards, and changing a role still invalidates it.

Prepared with AI assistance (Claude); fail-before/pass-after and `go test -race` verified before opening.
