### PR TITLE
chore: use import.meta.dirname in vite configs

### DIFF
--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [
     tailwindcss(),
     Components({
-      dirs: [path.resolve(__dirname, ".vitepress/theme/components")],
+      dirs: [path.resolve(import.meta.dirname, ".vitepress/theme/components")],
       extensions: ["vue", "md"],
       include: [/\.vue$/, /\.vue\?vue/, /\.md$/],
       dts: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig(() => ({
   },
   resolve: {
     alias: {
-      "@/": `${path.resolve(__dirname, "assets")}/`,
+      "@/": `${path.resolve(import.meta.dirname, "assets")}/`,
     },
   },
   build: {
@@ -83,7 +83,7 @@ export default defineConfig(() => ({
     VueI18nPlugin({
       runtimeOnly: true,
       strictMessage: false,
-      include: [path.resolve(__dirname, "locales/**")],
+      include: [path.resolve(import.meta.dirname, "locales/**")],
     }),
     svgLoader({}),
     tailwindcss(),


### PR DESCRIPTION
Vite warns that `__dirname` is unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version. Swapped both vite configs over to `import.meta.dirname`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)