### PR TITLE
fix: disambiguate containers with duplicate names across groups

### DIFF
--- a/assets/components/ContainerTable.vue
+++ b/assets/components/ContainerTable.vue
@@ -94,6 +94,9 @@
               <router-link :to="{ name: '/container/[id]', params: { id: container.id } }" :title="container.name">
                 {{ container.name }}
               </router-link>
+              <div v-if="container.customGroup" class="text-base-content/50 truncate text-xs">
+                {{ container.customGroup }}
+              </div>
             </td>
             <td v-if="isVisible('host')">{{ container.hostLabel }}</td>
             <td v-if="isVisible('state')">{{ container.state }}</td>
@@ -151,7 +154,8 @@ const fields: Record<
   name: {
     label: "label.container-name",
     mobileLabel: "label.name",
-    sortFunc: (a: Container, b: Container) => a.name.localeCompare(b.name) * direction.value,
+    sortFunc: (a: Container, b: Container) =>
+      (a.name.localeCompare(b.name) || (a.customGroup ?? "").localeCompare(b.customGroup ?? "")) * direction.value,
     mobileVisible: true,
   },
   host: {

--- a/assets/components/ContainerViewer/ContainerTitle.vue
+++ b/assets/components/ContainerViewer/ContainerTitle.vue
@@ -32,6 +32,9 @@
                       ></div>
                       <div v-if="other.isSwarm">{{ other.swarmId }}</div>
                       <div v-else>{{ other.name }}</div>
+                      <div v-if="other.hostLabel !== container.hostLabel" class="text-base-content/50 text-xs">
+                        {{ other.hostLabel }}
+                      </div>
                       <div v-if="other.state === 'running'">running</div>
                       <div v-else-if="other.state === 'paused'">paused</div>
                       <RelativeTime :date="other.finishedAt" class="text-base-content/70 text-xs" v-else />
@@ -98,7 +101,7 @@ const { containers: allContainers } = storeToRefs(store);
 
 const otherContainers = computed(() =>
   allContainers.value
-    .filter((c) => c.name === container.name && c.id !== container.id)
+    .filter((c) => c.name === container.name && c.id !== container.id && c.customGroup === container.customGroup)
     .sort((a, b) => +b.created - +a.created),
 );
 </script>


### PR DESCRIPTION
When two groups (dev.dozzle.group) contain containers with the same name, the main container table and the container title dropdown show them as identical, indistinguishable rows.
  
- ContainerTable.vue: show the group name under the container name, and use it as a secondary sort key
- ContainerTitle.vue: scope the "switch to" dropdown to containers within the same group instead of matching by name alone across all groups; show the host label when switching between instances on different hosts