### PR TITLE
ci: group and automerge github action digest updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "schedule:weekly", "group:allNonMajor", ":automergeMinor"],
+  "extends": [
+    "config:recommended",
+    "schedule:weekly",
+    "group:allNonMajor",
+    ":automergeMinor",
+    "helpers:pinGitHubActionDigests"
+  ],
   "rangeStrategy": "bump",
   "minimumReleaseAge": "24 hours",
   "ignoreDeps": [],
@@ -8,6 +14,12 @@
     {
       "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
       "groupName": "playwright"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "pin"],
+      "groupName": "github actions",
+      "automerge": true
     }
   ]
 }


### PR DESCRIPTION
Follow up to #4898.

Once actions are pinned to SHAs, Renovate classifies every bump as a `digest` update. Both presets in `.github/renovate.json` match only `["minor", "patch"]`:

- `group:allNonMajor`
- `:automergeMinor`

So digest updates fall through both, meaning one manual PR per pinned action per week instead of the single grouped automerge we get today. This adds a packageRule that puts `digest` and `pin` updates for `github-actions` into their own group with automerge on.

Also extends `helpers:pinGitHubActionDigests` so any action added later gets pinned to a SHA automatically and the pinning does not drift back to floating tags.

Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)