### PR TITLE
fix: stop alpine build from overwriting the latest tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,8 @@ jobs:
           images: |
             amir20/dozzle
             ghcr.io/amir20/dozzle
+          flavor: |
+            latest=false
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}},prefix=v
@@ -132,6 +134,10 @@ jobs:
           images: |
             amir20/dozzle
             ghcr.io/amir20/dozzle
+          # Without this, latest=auto adds a bare `latest` tag on semver pushes
+          # and the alpine build (which runs second) overwrites the real latest.
+          flavor: |
+            latest=false
           tags: |
             type=raw,value=alpine
             type=semver,pattern={{version}},prefix=v,suffix=-alpine


### PR DESCRIPTION
`latest` on both Docker Hub and ghcr currently points at the alpine image instead of the scratch one:

```
latest          sha256:ece88f9b...
alpine          sha256:ece88f9b...
v10.7.0-alpine  sha256:ece88f9b...
v10.7.0         sha256:f82ae07b...
```

`metadata-action` defaults to `flavor: latest=auto`, which adds a bare `latest` tag on any semver push. The `-alpine` suffix is set per tag entry, not as global flavor, so the alpine meta step emitted a plain `latest` too. That build runs second, so it won.

Sets `latest=false` on both meta steps. The scratch step keeps its explicit `type=raw,value=latest`.

`v10`, `v10.7`, and `v10.7.0` were unaffected. The published `latest` stays wrong until the next release rebuilds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)