### PR TITLE
fix: don't log an error when docker events listener exits cleanly

### DIFF
--- a/internal/container/container_store.go
+++ b/internal/container/container_store.go
@@ -101,7 +101,7 @@ func (s *ContainerStore) checkConnectivity() error {
 		go func() {
 			log.Debug().Str("host", s.client.Host().Name).Msg("docker store subscribing docker events")
 			err := s.client.ContainerEvents(s.ctx, s.events)
-			if !errors.Is(err, context.Canceled) {
+			if err != nil && !errors.Is(err, context.Canceled) {
 				log.Error().Err(err).Str("host", s.client.Host().Name).Msg("docker store unexpectedly disconnected from docker events")
 			}
 			s.connected.Store(false)

--- a/internal/docker/stats_collector.go
+++ b/internal/docker/stats_collector.go
@@ -118,7 +118,7 @@ func (sc *DockerStatsCollector) Start(parentCtx context.Context) bool {
 		defer close(events)
 		log.Debug().Str("host", sc.client.Host().Name).Msg("starting to listen to docker events")
 		err := sc.client.ContainerEvents(ctx, events)
-		if !errors.Is(err, context.Canceled) {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			log.Error().Str("host", sc.client.Host().Name).Err(err).Msg("unexpected error while listening to docker events")
 		}
 		sc.forceStop()


### PR DESCRIPTION
`ContainerEvents` returns `nil` on a normal `ctx.Done()`, but callers only guarded with `errors.Is(err, context.Canceled)`. `errors.Is(nil, context.Canceled)` is false, so a clean shutdown logged an error with no `error=` field.

Fixed in both call sites:
- `internal/docker/stats_collector.go:121` (idle stats collector stop, the one in the issue)
- `internal/container/container_store.go:104` (same pattern)

Fixes #4906

🤖 Generated with [Claude Code](https://claude.com/claude-code)