### PR TITLE
feat(logs): show how long an alert's incident kept firing

### DIFF
--- a/assets/components/LogViewer/AlertLogItem.spec.ts
+++ b/assets/components/LogViewer/AlertLogItem.spec.ts
@@ -82,6 +82,23 @@ describe("<AlertLogItem />", () => {
     });
   });
 
+  describe("incident extent", () => {
+    test("reports how long the incident kept firing, inline on the summary", () => {
+      expect(mountAlert({ ts: ns(0), lastActivityAt: ns(40 * 60_000) }).text()).toMatch(/40/);
+    });
+
+    // Cloud's aggregation window is 15s, so a sub-minute span is an artefact of
+    // batching rather than a real incident length.
+    test("stays silent for a sub-minute span", () => {
+      expect(mountAlert({ ts: ns(0), lastActivityAt: ns(20_000) }).text()).not.toMatch(/\d+\s*(s|sec)/);
+    });
+
+    test("stays silent when there is no follow-up activity at all", () => {
+      // Only the event count on the summary — no trailing duration clause.
+      expect(mountAlert({ ts: ns(0), lastActivityAt: undefined }).text()).not.toMatch(/,\s*\d/);
+    });
+  });
+
   // alerts.level is free text and defaults to '' for anything that never went
   // through a summarizer. A neutral fallback made the common case look like an
   // ordinary log line, which is the one thing this row must not look like.

--- a/assets/components/LogViewer/AlertLogItem.vue
+++ b/assets/components/LogViewer/AlertLogItem.vue
@@ -18,7 +18,9 @@
           <!-- Only the count rides the one-line summary. Everything else —
                containers, what triage held back, the investigation — sits behind
                Details, so the row costs exactly one line until asked otherwise. -->
-          <span class="text-xs opacity-60">{{ $t("label.alert-events", alert.eventCount) }}</span>
+          <span class="text-xs opacity-60">
+            {{ $t("label.alert-events", alert.eventCount) }}<template v-if="ranFor">, {{ ranFor }}</template>
+          </span>
 
           <!-- Right-aligned so the headline starts at the same x-position on
                every alert down the stream, which is what makes a column of
@@ -62,6 +64,24 @@ const { logEntry } = defineProps<{
 
 const alert = computed(() => logEntry.alert);
 const expanded = ref(false);
+
+// Anything under a minute is one moment, not a duration — Cloud's aggregation
+// window is 15s, so sub-minute spans are an artefact of batching rather than a
+// real incident length.
+const MIN_REPORTABLE_MS = 60_000;
+
+/**
+ * How long the incident kept firing. Cloud folds follow-up batches into the
+ * original alert, so lastActivityAt is already on the row — without it a card
+ * reads as a single moment when the incident may have run for hours.
+ */
+const ranFor = computed(() => {
+  const { lastActivityAt, ts } = alert.value;
+  if (!lastActivityAt) return null;
+  const ms = (lastActivityAt - ts) / 1_000_000;
+  if (ms < MIN_REPORTABLE_MS) return null;
+  return formatDuration(Math.round(ms / 1000), locale.value === "" ? undefined : locale.value);
+});
 
 /**
  * alerts.level is free text and defaults to '' — an alert that never went


### PR DESCRIPTION
An alert row read as a single moment when the incident behind it may have run
for hours. Cloud folds follow-up batches into the original alert, so
`lastActivityAt` was already on the row and going unused.

```
ALERT  Container restarting on a failed health check  35 events, 13m 48s   [Details ›] [View in Dozzle Cloud]
```

The duration joins the one-line summary rather than getting a line of its own —
the whole point of the row treatment in #4915 is that an alert costs exactly one
line until you ask for more.

> [!NOTE]
> Stacked on #4915 → #4914 → #4913.

### This replaces the planned "show full extent" toggle

The plan called for a setting that sends `include_follow_ups` and marks later
scroll windows where the incident was still active. Building it surfaced why
that's the wrong shape: **scrollback loads incrementally**, so flipping the
toggle could only affect ranges fetched *afterwards*. The user flips it, sees
nothing change on screen, and flips it back.

Making it retroactive would mean keeping every fetched alert and re-deriving the
whole message list on toggle — a real refactor, with real bug risk, to convey
something that is one field already in hand.

`include_follow_ups` stays in the API. It's the right primitive for a client
that wants anchor-level detail, and #4917 may yet use it.

### Sub-minute spans stay silent

Cloud's aggregation window is 15s, so anything shorter is an artefact of
batching rather than an incident length worth reporting.

### Verification

`pnpm run typecheck` and `pnpm run build` pass; 15 component tests, three of
them covering the duration cases (reported inline, silent under a minute, silent
with no follow-up activity).

### Stack

- #4913 — proto + codegen
- amir20/doligence#338 — the `GetAlerts` server
- #4914 — cloud client + `/api/cloud/alerts`
- #4915 — the stream merge
- **this PR** — incident duration on the summary
- #4917 — scroll-gutter markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)