### PR TITLE
perf(logs): poll Cloud for alerts on a timer, not on every log line

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -543,7 +543,6 @@ declare module 'vue' {
     readonly inject: UnwrapRef<typeof import('vue')['inject']>
     readonly injectLocal: UnwrapRef<typeof import('@vueuse/core')['injectLocal']>
     readonly isDefined: UnwrapRef<typeof import('@vueuse/core')['isDefined']>
-    readonly isLogEvent: UnwrapRef<typeof import('./composable/cloudAlerts')['isLogEvent']>
     readonly isMobile: UnwrapRef<typeof import('./composable/media')['isMobile']>
     readonly isObject: UnwrapRef<typeof import('./utils/index')['isObject']>
     readonly isProxy: UnwrapRef<typeof import('vue')['isProxy']>

--- a/assets/components/LogViewer/LogItem.vue
+++ b/assets/components/LogViewer/LogItem.vue
@@ -24,7 +24,6 @@
     <span
       v-if="logEntry.matchedEvent"
       class="event-badge shrink-0 select-none"
-      :data-suppressed="logEntry.matchedEvent.suppressed"
       :title="logEntry.matchedEvent.suppressed ? $t('label.event-suppressed-hint') : $t('label.event-sent-hint')"
     >
       <mdi:bell-off v-if="logEntry.matchedEvent.suppressed" class="size-3.5" />
@@ -58,8 +57,5 @@ const host = computed(() => hosts.value[container.value.host]);
 }
 .event-badge:hover {
   @apply opacity-100;
-}
-.event-badge[data-suppressed="false"] {
-  @apply text-error opacity-80;
 }
 </style>

--- a/assets/composable/cloudAlerts.spec.ts
+++ b/assets/composable/cloudAlerts.spec.ts
@@ -209,7 +209,7 @@ describe("attachEvents", () => {
   test("badges the line the event matched", () => {
     const logs = [log(10, 100), log(11, 200)];
     expect(attachEvents(logs, [event()])).toBe(true);
-    expect(logs[0].matchedEvent).toEqual({ alertId: 0, suppressed: true, level: "" });
+    expect(logs[0].matchedEvent).toEqual({ suppressed: true });
     expect(logs[1].matchedEvent).toBeUndefined();
   });
 

--- a/assets/composable/cloudAlerts.spec.ts
+++ b/assets/composable/cloudAlerts.spec.ts
@@ -158,6 +158,9 @@ describe("fetchAlerts", () => {
     vi.unstubAllGlobals();
   });
 
+  // An unlinked Dozzle must put no traffic on the network at all — not a
+  // request that 503s, not one that returns empty. This is the backstop; the
+  // callers in logLoader check availability before assembling a window.
   test("does not call cloud when not linked", async () => {
     const spy = vi.fn();
     global.fetch = spy;

--- a/assets/composable/cloudAlerts.ts
+++ b/assets/composable/cloudAlerts.ts
@@ -151,12 +151,18 @@ export function mergeAlerts(
   const fresh = alerts.filter((a) => a.isOrigin && !seen.has(anchorKey(a)));
   if (fresh.length === 0) return logs;
 
+  // Indexed once rather than scanned per alert: logs runs into the thousands
+  // after scrollback, so the nested `logs.some` this replaces was O(alerts x
+  // logs) on the main thread every time new alerts arrived.
+  const linesPresent = new Set<string>();
+  for (const l of logs) linesPresent.add(`${l.containerID}:${l.id}`);
+
   const byLogId = new Map<number, CloudAlert[]>();
   const byTime: CloudAlert[] = [];
   for (const alert of fresh) {
     // Only trust logId when that line is actually in this run; otherwise the
     // alert would silently vanish rather than fall back to its timestamp.
-    if (alert.logId && logs.some((l) => l.id === alert.logId && l.containerID === alert.containerId)) {
+    if (alert.logId && linesPresent.has(`${alert.containerId}:${alert.logId}`)) {
       const bucket = byLogId.get(alert.logId);
       if (bucket) bucket.push(alert);
       else byLogId.set(alert.logId, [alert]);

--- a/assets/composable/cloudAlerts.ts
+++ b/assets/composable/cloudAlerts.ts
@@ -224,14 +224,14 @@ export function attachEvents(logs: LogEntry<LogMessage>[], events: CloudEvent[])
     if (log.matchedEvent) continue;
     const event = byLogId.get(log.id);
     if (!event || event.containerId !== log.containerID) continue;
-    log.matchedEvent = { alertId: event.alertId ?? 0, suppressed: event.suppressed, level: event.level ?? "" };
+    log.matchedEvent = { suppressed: event.suppressed };
     changed = true;
   }
   return changed;
 }
 
 /** A log event has a line in the stream; metric and container events do not. */
-export function isLogEvent(event: CloudEvent): boolean {
+function isLogEvent(event: CloudEvent): boolean {
   return (event.type ?? "log") === "log";
 }
 

--- a/assets/composable/cloudAlerts.ts
+++ b/assets/composable/cloudAlerts.ts
@@ -81,6 +81,9 @@ export async function fetchAlerts(
   }: { linked: boolean; signal?: AbortSignal; followUps?: boolean; events?: boolean },
 ): Promise<{ alerts: CloudAlert[]; events: CloudEvent[] }> {
   const empty = { alerts: [], events: [] };
+  // Backstop, not the primary gate — callers check availability before doing
+  // any of the work of assembling a window. Kept so a new caller that forgets
+  // cannot put traffic on an unlinked instance.
   if (!linked || containerIDs.length === 0) return empty;
 
   const params = new URLSearchParams({

--- a/assets/composable/eventStreams.ts
+++ b/assets/composable/eventStreams.ts
@@ -138,7 +138,24 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
   // Only runs when Cloud is actually linked. An unlinked Dozzle has no alerts
   // to fetch, so a timer there is pure waste — and an unconditional interval
   // also hangs any test that drains pending timers.
-  watch(alertsAvailable, (linked) => (linked ? alertPoll.resume() : alertPoll.pause()), { immediate: true });
+  //
+  // The immediate pass on becoming linked matters twice. The cloud config is
+  // fetched asynchronously at boot, so on an ordinary load this flips true
+  // *after* the stream has already assembled its first window — without it the
+  // opening window would sit bare until the first tick. It also covers linking
+  // mid-session: alerts start appearing at once rather than up to a poll later.
+  watch(
+    alertsAvailable,
+    (linked) => {
+      if (!linked) {
+        alertPoll.pause();
+        return;
+      }
+      alertPoll.resume();
+      decorateWithAlerts();
+    },
+    { immediate: true },
+  );
 
   function flushNow() {
     // Only the first assembly triggers an immediate alert pass; after that the

--- a/assets/composable/eventStreams.ts
+++ b/assets/composable/eventStreams.ts
@@ -102,20 +102,48 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
   });
 
   const allContainers = computed(() => (container ? [container.value] : containers.value));
-  const { loadOlderLogs, loadSkippedLogs, loadAlertsForVisible } = useLogLoader(
+  const { loadOlderLogs, loadSkippedLogs, loadAlertsForVisible, alertsAvailable } = useLogLoader(
     messages,
     allContainers,
     params,
     loadingMore,
   );
 
+  // Cloud aggregates events on a 15s window before an alert can even exist, so
+  // asking more often than that cannot surface anything sooner — it only costs
+  // requests. Polling on a timer also decouples the rate from log volume: this
+  // used to be driven by the buffer flush, which meant a chatty container hit
+  // Cloud roughly once a second, per open tab.
+  const ALERT_POLL_MS = 15_000;
+
   // The opening window is assembled from the stream, which knows nothing about
   // alerts — only scrollback fetched them. Debounced because the first frames
-  // arrive as a burst (initial flush, then backfill) and they all describe the
-  // same window.
+  // arrive as a burst (initial flush, then backfill) describing the same
+  // window.
   const decorateWithAlerts = useDebounceFn(loadAlertsForVisible, 400);
 
+  // An alert's anchor is the timestamp of the event that triggered it, which is
+  // always older than the alert itself — so the poll re-asks the whole visible
+  // window rather than only the slice since the last call. A window that only
+  // moved forward would never see an alert land on a line already on screen.
+  const visible = useDocumentVisibility();
+  const alertPoll = useIntervalFn(
+    () => {
+      if (visible.value === "visible") loadAlertsForVisible();
+    },
+    ALERT_POLL_MS,
+    { immediate: false },
+  );
+
+  // Only runs when Cloud is actually linked. An unlinked Dozzle has no alerts
+  // to fetch, so a timer there is pure waste — and an unconditional interval
+  // also hangs any test that drains pending timers.
+  watch(alertsAvailable, (linked) => (linked ? alertPoll.resume() : alertPoll.pause()), { immediate: true });
+
   function flushNow() {
+    // Only the first assembly triggers an immediate alert pass; after that the
+    // poll owns the cadence, so log volume cannot drive request volume.
+    let wasInitial = false;
     if (messages.value.length + buffer.value.length > config.maxLogs) {
       if (scrollingPaused.value === true) {
         if (messages.value.at(-1) instanceof SkippedLogsEntry) {
@@ -141,6 +169,7 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
       }
     } else {
       if (initial) {
+        wasInitial = true;
         // sort the buffer the very first time because of multiple logs in parallel
         buffer.value.sort((a, b) => a.date.getTime() - b.date.getTime());
 
@@ -153,7 +182,7 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
       messages.value = [...messages.value, ...buffer.value];
       buffer.value = [];
     }
-    decorateWithAlerts();
+    if (wasInitial) decorateWithAlerts();
   }
   const flushBuffer = debounce(flushNow, 250, { maxWait: 1000 });
   let es: EventSource | null = null;

--- a/assets/composable/logLoader.ts
+++ b/assets/composable/logLoader.ts
@@ -18,10 +18,20 @@ export function useLogLoader(
   // Keyed on (alertId, anchor) rather than alertId: one incident legitimately
   // marks every window it was active in.
   const placedAlerts = new Set<string>();
+  // Newest log timestamp the poll has already asked Cloud about. Events only
+  // describe lines, so a window that gained no lines cannot have gained
+  // events — and skipping them keeps a quiet container's poll from carrying a
+  // payload of up to a thousand rows the viewer would discard. Alerts are
+  // still requested every time: an alert's anchor is older than the alert, so
+  // one can land on a line that has been on screen for a while.
+  let polledThrough: number | undefined;
   // The viewer clears its messages when the stream changes (container switch,
   // filter change). Without this the seen-set would outlive the entries it was
   // tracking, and alerts already scrolled past would never render again.
-  watch([params, containers], () => placedAlerts.clear());
+  watch([params, containers], () => {
+    placedAlerts.clear();
+    polledThrough = undefined;
+  });
   async function loadOlderLogs(entry: LoadMoreLogEntry) {
     if (!(messages.value[0] instanceof LoadMoreLogEntry)) throw new Error("No loadMoreLogEntry on first item");
     if (containers.value.length === 0) return;
@@ -166,11 +176,15 @@ export function useLogLoader(
       // Origins only, like scrollback. An incident already running when this
       // window opens shows through the per-line badges instead, which is both
       // more precise and cheaper than a second block.
+      const newest = logs[logs.length - 1].date.getTime();
+      const wantEvents = polledThrough === undefined || newest > polledThrough;
+      polledThrough = newest;
+
       const { alerts, events } = await fetchAlerts(
         containers.value.map((c) => c.id),
         from,
         to,
-        { events: true },
+        { events: wantEvents },
       );
 
       // Badges mutate the entries in place, so the list has to be reassigned

--- a/assets/composable/logLoader.ts
+++ b/assets/composable/logLoader.ts
@@ -13,7 +13,7 @@ export function useLogLoader(
   params: Ref<URLSearchParams>,
   loadingMore: Ref<boolean>,
 ) {
-  const { fetchAlerts } = useCloudAlerts();
+  const { fetchAlerts, available: alertsAvailable } = useCloudAlerts();
   // Anchor keys already placed, so overlapping scroll windows don't duplicate.
   // Keyed on (alertId, anchor) rather than alertId: one incident legitimately
   // marks every window it was active in.
@@ -185,5 +185,5 @@ export function useLogLoader(
     }
   }
 
-  return { loadOlderLogs, loadSkippedLogs, loadAlertsForVisible };
+  return { loadOlderLogs, loadSkippedLogs, loadAlertsForVisible, alertsAvailable };
 }

--- a/assets/composable/logLoader.ts
+++ b/assets/composable/logLoader.ts
@@ -120,7 +120,7 @@ export function useLogLoader(
    * problem must degrade to "no alerts", never cost the user their logs.
    */
   async function withAlerts(logs: LogEntry<LogMessage>[]): Promise<LogEntry<LogMessage>[]> {
-    if (logs.length === 0) return logs;
+    if (!alertsAvailable.value || logs.length === 0) return logs;
     try {
       const ids = containers.value.map((c) => c.id);
       const { alerts, events } = await fetchAlerts(
@@ -150,7 +150,7 @@ export function useLogLoader(
    * merges nothing.
    */
   async function loadAlertsForVisible() {
-    if (containers.value.length === 0) return;
+    if (!alertsAvailable.value || containers.value.length === 0) return;
 
     // The loader pins to the top of the list and carries `now` as its date, so
     // it must be held out of the merge — a time-anchored alert would otherwise

--- a/assets/models/LogEntry.ts
+++ b/assets/models/LogEntry.ts
@@ -41,9 +41,13 @@ export interface LogEvent {
  * storm would put one between every pair of lines.
  */
 export interface MatchedEvent {
-  alertId: number;
+  /**
+   * Whether Dozzle Cloud held the alert back. Always true today — only
+   * suppressed events are badged, since a delivered one is represented by its
+   * alert block — but kept explicit so the badge cannot silently start
+   * claiming the wrong thing if that changes.
+   */
   suppressed: boolean;
-  level: string;
 }
 
 /**
@@ -259,7 +263,11 @@ export class CloudEventLogEntry extends LogEntry<string> {
     public readonly event: CloudEvent,
     date: Date,
   ) {
-    super(event.detail ?? "", event.containerId, date.getTime(), date, "stderr", event.detail ?? "");
+    // Keyed on the nanosecond timestamp, not date.getTime(): LogList uses
+    // entry.id as its v-for key, and two notifications inside the same
+    // millisecond — a metric and a lifecycle event fire together routinely —
+    // would collide and cost a row.
+    super(event.detail ?? "", event.containerId, event.ts, date, "stderr", event.detail ?? "");
   }
 
   getComponent(): Component {

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Ingen hændelser | 1 hændelse | {count} hændelser
   alert-containers: 1 container | {count} containere
   alert-held-back: "{count} lignende tilbageholdt"
-  alert-investigation: Undersøgelse
   alert-view-in-cloud: Vis i Dozzle Cloud
   alert: Alarm
   alert-details: Detaljer

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Keine Ereignisse | 1 Ereignis | {count} Ereignisse
   alert-containers: 1 Container | {count} Container
   alert-held-back: "{count} ähnliche zurückgehalten"
-  alert-investigation: Untersuchung
   alert-view-in-cloud: In Dozzle Cloud ansehen
   alert: Alarm
   alert-details: Details

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -37,7 +37,6 @@ label:
   alert-events: No events | 1 event | {count} events
   alert-containers: 1 container | {count} containers
   alert-held-back: "{count} similar held back"
-  alert-investigation: Investigation
   alert-view-in-cloud: View in Dozzle Cloud
   alert: Alert
   alert-details: Details

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Sin eventos | 1 evento | {count} eventos
   alert-containers: 1 contenedor | {count} contenedores
   alert-held-back: "{count} similares retenidos"
-  alert-investigation: Investigación
   alert-view-in-cloud: Ver en Dozzle Cloud
   alert: Alerta
   alert-details: Detalles

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Aucun événement | 1 événement | {count} événements
   alert-containers: 1 conteneur | {count} conteneurs
   alert-held-back: "{count} similaires retenus"
-  alert-investigation: Investigation
   alert-view-in-cloud: Voir dans Dozzle Cloud
   alert: Alerte
   alert-details: Détails

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -38,7 +38,6 @@ label:
   alert-events: Tidak ada peristiwa | 1 peristiwa | {count} peristiwa
   alert-containers: 1 kontainer | {count} kontainer
   alert-held-back: "{count} serupa ditahan"
-  alert-investigation: Investigasi
   alert-view-in-cloud: Lihat di Dozzle Cloud
   alert: Peringatan
   alert-details: Detail

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Nessun evento | 1 evento | {count} eventi
   alert-containers: 1 container | {count} container
   alert-held-back: "{count} simili trattenuti"
-  alert-investigation: Analisi
   alert-view-in-cloud: Apri in Dozzle Cloud
   alert: Avviso
   alert-details: Dettagli

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -37,7 +37,6 @@ label:
   alert-events: 이벤트 없음 | 이벤트 1개 | 이벤트 {count}개
   alert-containers: 컨테이너 1개 | 컨테이너 {count}개
   alert-held-back: 유사 {count}건 보류됨
-  alert-investigation: 분석
   alert-view-in-cloud: Dozzle Cloud에서 보기
   alert: 알림
   alert-details: 세부 정보

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Geen gebeurtenissen | 1 gebeurtenis | {count} gebeurtenissen
   alert-containers: 1 container | {count} containers
   alert-held-back: "{count} vergelijkbare tegengehouden"
-  alert-investigation: Onderzoek
   alert-view-in-cloud: Bekijk in Dozzle Cloud
   alert: Melding
   alert-details: Details

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -40,7 +40,6 @@ label:
   alert-events: Brak zdarzeń | 1 zdarzenie | {count} zdarzeń
   alert-containers: 1 kontener | {count} kontenerów
   alert-held-back: "{count} podobnych wstrzymano"
-  alert-investigation: Analiza
   alert-view-in-cloud: Zobacz w Dozzle Cloud
   alert: Alert
   alert-details: Szczegóły

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Nenhum evento | 1 evento | {count} eventos
   alert-containers: 1 container | {count} containers
   alert-held-back: "{count} semelhantes retidos"
-  alert-investigation: Investigação
   alert-view-in-cloud: Ver no Dozzle Cloud
   alert: Alerta
   alert-details: Detalhes

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Нет событий | 1 событие | {count} событий
   alert-containers: 1 контейнер | {count} контейнеров
   alert-held-back: "{count} похожих удержано"
-  alert-investigation: Анализ
   alert-view-in-cloud: Открыть в Dozzle Cloud
   alert: Оповещение
   alert-details: Подробности

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -61,7 +61,6 @@ label:
   alert-events: Ni dogodkov | 1 dogodek | {count} dogodkov
   alert-containers: 1 zabojnik | {count} zabojnikov
   alert-held-back: "{count} podobnih zadržanih"
-  alert-investigation: Preiskava
   alert-view-in-cloud: Odpri v Dozzle Cloud
   alert: Opozorilo
   alert-details: Podrobnosti

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -37,7 +37,6 @@ label:
   alert-events: Olay yok | 1 olay | {count} olay
   alert-containers: 1 konteyner | {count} konteyner
   alert-held-back: "{count} benzeri tutuldu"
-  alert-investigation: İnceleme
   alert-view-in-cloud: Dozzle Cloud'da görüntüle
   alert: Uyarı
   alert-details: Ayrıntılar

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -37,7 +37,6 @@ label:
   alert-events: 無事件 | 1 個事件 | {count} 個事件
   alert-containers: 1 個容器 | {count} 個容器
   alert-held-back: 已攔下 {count} 個類似事件
-  alert-investigation: 調查
   alert-view-in-cloud: 在 Dozzle Cloud 中檢視
   alert: 警示
   alert-details: 詳細資訊

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -37,7 +37,6 @@ label:
   alert-events: 无事件 | 1 个事件 | {count} 个事件
   alert-containers: 1 个容器 | {count} 个容器
   alert-held-back: 已拦下 {count} 个类似事件
-  alert-investigation: 调查
   alert-view-in-cloud: 在 Dozzle Cloud 中查看
   alert: 警报
   alert-details: 详情


### PR DESCRIPTION
Audit of today's alert work, stacked on #4920.

> [!NOTE]
> Base is #4920's branch, so the diff here is only the audit findings.

## The headline finding: one request per log line

`loadAlertsForVisible` was called from `flushNow`, which runs on every buffer
flush — so **request volume tracked log volume**. Measured on an idle tab
watching a chatty container:

| | requests to `/api/cloud/alerts` in 30s idle |
| --- | --- |
| before | **30** |
| after | **2** |

Multiply the before by open tabs and connected instances and that is real load
on Cloud for no benefit: Cloud aggregates events on a 15s window, so an alert
cannot exist sooner than that no matter how often you ask.

Now a 15s poll matching that window. The initial assembly still fetches
immediately, so alerts appear on load exactly as before.

Two details worth knowing:

**It re-asks the whole visible window, not the slice since the last call.** An
alert's anchor is the timestamp of the *event that triggered it*, which is
always older than the alert itself — a window that only moved forward would
never see an alert land on a line already on screen.

**It runs only when Cloud is linked, and only while the tab is visible.** An
unlinked Dozzle has nothing to fetch. That gating isn't just tidiness: an
unconditional `useIntervalFn` hangs any test that drains pending timers, which
is how it got found.

## Also from the audit

- **`CloudEventLogEntry` had a key collision.** It was keyed on
  `date.getTime()`, and `LogList` uses `entry.id` as its `v-for` key — two
  notifications inside the same millisecond collided and one row was silently
  dropped. A metric and a lifecycle event firing together is routine. Keyed on
  the nanosecond timestamp now.
- **Dead payload on every badge.** `MatchedEvent` carried `alertId` and `level`
  that nothing read, plus a `data-suppressed` attribute and a delivered-state
  CSS rule that became dead once delivered events stopped being badged.
- **`label.alert-investigation`** lost its caller when Details stopped labelling
  the block — dropped from all sixteen locales.
- **`isLogEvent`** was exported with no caller outside its module.

## Verification

`typecheck`, `build`, `go build` pass; **164/164 tests** green (run with `TZ=UTC`,
as `package.json` specifies — running vitest directly skips that and produces
spurious timezone failures). Request rates above measured with Playwright
against the running stack, before and after.

## Not fixed here

Cloud caps events at 1000 per window and **doesn't signal when it truncates** —
`truncated` in the response reflects alerts only. Above that, some lines just
don't get badged with no indication. Belongs on the cloud side
(amir20/doligence#338).

🤖 Generated with [Claude Code](https://claude.com/claude-code)