### PR TITLE
fix(logs): show cloud alerts in the historical log view

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -93,6 +93,7 @@ declare global {
   const isReadonly: typeof import('vue').isReadonly
   const isRef: typeof import('vue').isRef
   const isShallow: typeof import('vue').isShallow
+  const isStreamLog: typeof import('./composable/alertMerger').isStreamLog
   const lightTheme: typeof import('./stores/settings').lightTheme
   const loadBetween: typeof import('./composable/loadBetween').loadBetween
   const locale: typeof import('./stores/settings').locale
@@ -196,6 +197,7 @@ declare global {
   const until: typeof import('@vueuse/core').until
   const useActiveElement: typeof import('@vueuse/core').useActiveElement
   const useAlertForm: typeof import('./composable/alertForm').useAlertForm
+  const useAlertMerger: typeof import('./composable/alertMerger').useAlertMerger
   const useAnimate: typeof import('@vueuse/core').useAnimate
   const useAnnouncements: typeof import('./stores/announcements').useAnnouncements
   const useArrayDifference: typeof import('@vueuse/core').useArrayDifference
@@ -550,6 +552,7 @@ declare module 'vue' {
     readonly isReadonly: UnwrapRef<typeof import('vue')['isReadonly']>
     readonly isRef: UnwrapRef<typeof import('vue')['isRef']>
     readonly isShallow: UnwrapRef<typeof import('vue')['isShallow']>
+    readonly isStreamLog: UnwrapRef<typeof import('./composable/alertMerger')['isStreamLog']>
     readonly lightTheme: UnwrapRef<typeof import('./stores/settings')['lightTheme']>
     readonly loadBetween: UnwrapRef<typeof import('./composable/loadBetween')['loadBetween']>
     readonly locale: UnwrapRef<typeof import('./stores/settings')['locale']>
@@ -650,6 +653,7 @@ declare module 'vue' {
     readonly until: UnwrapRef<typeof import('@vueuse/core')['until']>
     readonly useActiveElement: UnwrapRef<typeof import('@vueuse/core')['useActiveElement']>
     readonly useAlertForm: UnwrapRef<typeof import('./composable/alertForm')['useAlertForm']>
+    readonly useAlertMerger: UnwrapRef<typeof import('./composable/alertMerger')['useAlertMerger']>
     readonly useAnimate: UnwrapRef<typeof import('@vueuse/core')['useAnimate']>
     readonly useAnnouncements: UnwrapRef<typeof import('./stores/announcements')['useAnnouncements']>
     readonly useArrayDifference: UnwrapRef<typeof import('@vueuse/core')['useArrayDifference']>

--- a/assets/composable/alertMerger.spec.ts
+++ b/assets/composable/alertMerger.spec.ts
@@ -16,9 +16,16 @@ import {
 } from "@/models/LogEntry";
 import type { Container } from "@/models/Container";
 
-vi.mock("@/composable/cloudConfig", () => ({
-  useCloudConfig: () => ({ cloudConfig: { value: { linked: true } } }),
-}));
+// Reactive so tests can flip the instance between linked and unlinked, which is
+// what drives the poll and the boot-race decoration.
+type CloudLink = { linked: boolean };
+const holder = vi.hoisted(() => ({ cloudConfig: null as ReturnType<typeof import("vue").ref<CloudLink>> | null }));
+vi.mock("@/composable/cloudConfig", async () => {
+  const { ref: vueRef } = await import("vue");
+  holder.cloudConfig = vueRef<CloudLink>({ linked: true });
+  return { useCloudConfig: () => ({ cloudConfig: holder.cloudConfig }) };
+});
+const setLinked = (linked: boolean) => (holder.cloudConfig!.value = { linked });
 
 const ns = (n: number) => n * 1_000_000;
 
@@ -78,7 +85,10 @@ describe("isStreamLog", () => {
 });
 
 describe("useAlertMerger", () => {
-  beforeEach(() => vi.useFakeTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setLinked(true);
+  });
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -123,6 +133,60 @@ describe("useAlertMerger", () => {
       respondWith([alert({ logId: 1, ts: ns(100) })]);
       await vi.advanceTimersByTimeAsync(15_000);
       expect(shapeOf(messages.value)).toEqual(["log:1", "alert:a1", "log:2"]);
+    });
+  });
+
+  test("asks cloud for nothing while the instance is unlinked", async () => {
+    respondWith([alert({ logId: 1, ts: ns(100) })]);
+    setLinked(false);
+    const messages = shallowRef<LogEntry<LogMessage>[]>([log(1, 100), log(2, 200)]);
+
+    await withMerger(messages, async ({ decorateVisible }) => {
+      decorateVisible();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(shapeOf(messages.value)).toEqual(["log:1", "log:2"]);
+    });
+  });
+
+  test("decorates the open window as soon as cloud links", async () => {
+    // The boot race: cloudConfig is fetched asynchronously, so the first window
+    // is usually assembled before the instance looks linked.
+    respondWith([alert({ logId: 1, ts: ns(100) })]);
+    setLinked(false);
+    const messages = shallowRef<LogEntry<LogMessage>[]>([log(1, 100), log(2, 200)]);
+
+    await withMerger(messages, async () => {
+      await vi.advanceTimersByTimeAsync(500);
+      expect(shapeOf(messages.value)).toEqual(["log:1", "log:2"]);
+
+      setLinked(true);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(shapeOf(messages.value)).toEqual(["log:1", "alert:a1", "log:2"]);
+    });
+  });
+
+  test("drops a response whose window was replaced while it was in flight", async () => {
+    let release: (res: unknown) => void = () => {};
+    global.fetch = vi.fn().mockImplementation(() => new Promise((resolve) => (release = resolve)));
+    const messages = shallowRef<LogEntry<LogMessage>[]>([log(1, 100), log(2, 200)]);
+
+    await withMerger(messages, async ({ decorateVisible }) => {
+      decorateVisible();
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Container switch (or a live flush) lands before cloud answers.
+      const replaced = [log(3, 300)];
+      messages.value = replaced;
+      release({ ok: true, json: async () => ({ hits: [alert({ logId: 1, ts: ns(100) })] }) });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(messages.value).toBe(replaced);
+
+      // And the dropped alert is not marked as placed, so the next pass draws it.
+      respondWith([alert({ logId: 1, ts: ns(100) })]);
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(shapeOf(messages.value)).toEqual(["alert:a1", "log:3"]);
     });
   });
 

--- a/assets/composable/alertMerger.spec.ts
+++ b/assets/composable/alertMerger.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import { effectScope, shallowRef, ref } from "vue";
+import { useAlertMerger, isStreamLog } from "./alertMerger";
+import type { CloudAlert } from "./cloudAlerts";
+import {
+  AlertLogEntry,
+  CloudEventLogEntry,
+  LoadMoreLogEntry,
+  SimpleLogEntry,
+  SkippedLogsEntry,
+  type LogEntry,
+  type LogMessage,
+} from "@/models/LogEntry";
+import type { Container } from "@/models/Container";
+
+vi.mock("@/composable/cloudConfig", () => ({
+  useCloudConfig: () => ({ cloudConfig: { value: { linked: true } } }),
+}));
+
+const ns = (n: number) => n * 1_000_000;
+
+function log(id: number, at: number): LogEntry<LogMessage> {
+  return new SimpleLogEntry(`line ${id}`, "abc", id, new Date(at), "info", "stdout", `line ${id}`);
+}
+
+function alert(overrides: Partial<CloudAlert> = {}): CloudAlert {
+  return {
+    alertId: "a1",
+    containerId: "abc",
+    hostId: "h",
+    ts: ns(100),
+    headline: "Pool exhausted",
+    level: "error",
+    eventCount: 3,
+    createdAt: ns(100),
+    isOrigin: true,
+    ...overrides,
+  };
+}
+
+const shapeOf = (entries: LogEntry<LogMessage>[]) =>
+  entries.map((e) => {
+    if (e instanceof LoadMoreLogEntry) return "loader";
+    if (e instanceof AlertLogEntry) return `alert:${e.alert.alertId}`;
+    return `log:${e.id}`;
+  });
+
+function withMerger(
+  messages: ReturnType<typeof shallowRef<LogEntry<LogMessage>[]>>,
+  fn: (merger: ReturnType<typeof useAlertMerger>) => Promise<void>,
+) {
+  const scope = effectScope();
+  const containers = shallowRef<Container[]>([{ id: "abc" } as unknown as Container]);
+  const params = ref(new URLSearchParams());
+  const merger = scope.run(() => useAlertMerger(messages as any, containers, params))!;
+  return fn(merger).finally(() => scope.stop());
+}
+
+function respondWith(hits: CloudAlert[]) {
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ hits }) });
+}
+
+describe("isStreamLog", () => {
+  test("accepts log lines and rejects the synthetic rows", () => {
+    expect(isStreamLog(log(1, 100))).toBe(true);
+    expect(isStreamLog(new LoadMoreLogEntry(new Date(), async () => {}))).toBe(false);
+    expect(isStreamLog(new AlertLogEntry(alert(), new Date(100)))).toBe(false);
+    expect(isStreamLog(new CloudEventLogEntry({ ts: ns(1), containerId: "abc", suppressed: true }, new Date(1)))).toBe(
+      false,
+    );
+    expect(isStreamLog(new SkippedLogsEntry(new Date(), 1, log(1, 1) as any, log(2, 2) as any, async () => {}))).toBe(
+      false,
+    );
+  });
+});
+
+describe("useAlertMerger", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("withAlerts splices an alert after the line that triggered it", async () => {
+    respondWith([alert({ logId: 2, ts: ns(200) })]);
+    const messages = shallowRef<LogEntry<LogMessage>[]>([]);
+    await withMerger(messages, async ({ withAlerts }) => {
+      const merged = await withAlerts([log(1, 100), log(2, 200), log(3, 300)]);
+      expect(shapeOf(merged)).toEqual(["log:1", "log:2", "alert:a1", "log:3"]);
+    });
+  });
+
+  test("decorateVisible keeps load-more rows at both ends", async () => {
+    // A time-anchored alert older than every line on screen: without holding the
+    // loaders out of the merge it would sort ahead of the head one.
+    respondWith([alert({ ts: ns(50) })]);
+    const messages = shallowRef<LogEntry<LogMessage>[]>([
+      new LoadMoreLogEntry(new Date(), async () => {}),
+      log(1, 100),
+      log(2, 200),
+      new LoadMoreLogEntry(new Date(), async () => {}, false),
+    ]);
+
+    await withMerger(messages, async ({ decorateVisible }) => {
+      decorateVisible();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(shapeOf(messages.value)).toEqual(["loader", "alert:a1", "log:1", "log:2", "loader"]);
+    });
+  });
+
+  test("polls the visible window so an alert can land while the view is open", async () => {
+    respondWith([]);
+    const messages = shallowRef<LogEntry<LogMessage>[]>([log(1, 100), log(2, 200)]);
+
+    await withMerger(messages, async ({ decorateVisible }) => {
+      decorateVisible();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(shapeOf(messages.value)).toEqual(["log:1", "log:2"]);
+
+      respondWith([alert({ logId: 1, ts: ns(100) })]);
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(shapeOf(messages.value)).toEqual(["log:1", "alert:a1", "log:2"]);
+    });
+  });
+
+  test("does not place the same alert twice across overlapping windows", async () => {
+    respondWith([alert({ logId: 2, ts: ns(200) })]);
+    const messages = shallowRef<LogEntry<LogMessage>[]>([]);
+    await withMerger(messages, async ({ withAlerts }) => {
+      const first = await withAlerts([log(1, 100), log(2, 200)]);
+      expect(shapeOf(first)).toEqual(["log:1", "log:2", "alert:a1"]);
+      const second = await withAlerts([log(2, 200), log(3, 300)]);
+      expect(shapeOf(second)).toEqual(["log:2", "log:3"]);
+    });
+  });
+});

--- a/assets/composable/alertMerger.ts
+++ b/assets/composable/alertMerger.ts
@@ -1,0 +1,200 @@
+import { ShallowRef, type Ref } from "vue";
+import {
+  type LogMessage,
+  LogEntry,
+  LoadMoreLogEntry,
+  AlertLogEntry,
+  CloudEventLogEntry,
+  SkippedLogsEntry,
+} from "@/models/LogEntry";
+import { Container } from "@/models/Container";
+import { useCloudAlerts, mergeAlerts, attachEvents, mergeCloudEvents } from "@/composable/cloudAlerts";
+
+// Cloud aggregates events on a 15s window before an alert can even exist, so
+// asking more often than that cannot surface anything sooner — it only costs
+// requests. Polling on a timer also decouples the rate from log volume: this
+// used to be driven by the buffer flush, which meant a chatty container hit
+// Cloud roughly once a second, per open tab.
+const ALERT_POLL_MS = 15_000;
+
+/**
+ * True for rows that came out of the log store, false for the ones the viewer
+ * synthesises around them.
+ *
+ * Callers that need to anchor a range request on the edge of the list have to
+ * skip the synthetic rows: an alert's id is its anchor timestamp in
+ * nanoseconds, not a line hash, so handing it to the backend as `lastSeenId`
+ * matches nothing and its date sits a millisecond off the line it followed.
+ */
+export function isStreamLog(entry: LogEntry<LogMessage>): boolean {
+  return !(
+    entry instanceof LoadMoreLogEntry ||
+    entry instanceof AlertLogEntry ||
+    entry instanceof CloudEventLogEntry ||
+    entry instanceof SkippedLogsEntry
+  );
+}
+
+/**
+ * useAlertMerger owns the Dozzle Cloud alert layer for one log view: the dedupe
+ * state, the decoration of freshly loaded windows, and the poll that catches
+ * alerts firing while the view is open.
+ *
+ * Shared between the live stream and the historical (jump-to-date) view. Both
+ * assemble their windows differently but need identical alert behaviour, and
+ * keeping this in one place is what stopped the historical view from silently
+ * having none.
+ */
+export function useAlertMerger(
+  messages: ShallowRef<LogEntry<LogMessage>[]>,
+  containers: Ref<Container[]>,
+  params: Ref<URLSearchParams>,
+) {
+  const { fetchAlerts, available: alertsAvailable } = useCloudAlerts();
+  // Anchor keys already placed, so overlapping scroll windows don't duplicate.
+  // Keyed on (alert, anchor) rather than the alert alone: one incident legitimately
+  // marks every window it was active in.
+  const placedAlerts = new Set<string>();
+  // Newest log timestamp the poll has already asked Cloud about. Events only
+  // describe lines, so a window that gained no lines cannot have gained
+  // events — and skipping them keeps a quiet container's poll from carrying a
+  // payload of up to a thousand rows the viewer would discard. Alerts are
+  // still requested every time: an alert's anchor is older than the alert, so
+  // one can land on a line that has been on screen for a while.
+  let polledThrough: number | undefined;
+  // The viewer clears its messages when the stream changes (container switch,
+  // filter change). Without this the seen-set would outlive the entries it was
+  // tracking, and alerts already scrolled past would never render again.
+  watch([params, containers], () => {
+    placedAlerts.clear();
+    polledThrough = undefined;
+  });
+
+  /**
+   * Decorates a freshly loaded, time-sorted run of logs with any Dozzle Cloud
+   * alerts that fired inside it.
+   *
+   * fetchAlerts never rejects, but the guard is kept regardless: this runs on
+   * the scroll path, where the log lines have already been fetched. A cloud
+   * problem must degrade to "no alerts", never cost the user their logs.
+   */
+  async function withAlerts(logs: LogEntry<LogMessage>[]): Promise<LogEntry<LogMessage>[]> {
+    if (!alertsAvailable.value || logs.length === 0) return logs;
+    try {
+      const ids = containers.value.map((c) => c.id);
+      const { alerts, events } = await fetchAlerts(
+        ids,
+        logs[0].date,
+        new Date(logs[logs.length - 1].date.getTime() + 1),
+        { events: true },
+      );
+      attachEvents(logs, events);
+      return mergeAlerts(mergeCloudEvents(logs, events, placedAlerts), alerts, placedAlerts);
+    } catch (err) {
+      console.error(err);
+      return logs;
+    }
+  }
+
+  /**
+   * Decorates the logs already on screen with any alerts that fired inside
+   * them.
+   *
+   * Scrollback loads only run when the user scrolls, so without this an alert
+   * that fired inside the window the viewer *opens* on never appeared — the
+   * most common case there is, since "something just happened" is usually why
+   * the container got opened at all.
+   *
+   * Safe to call repeatedly: placedAlerts dedupes, and an unchanged window
+   * merges nothing.
+   */
+  async function decorateVisibleNow() {
+    if (!alertsAvailable.value || containers.value.length === 0) return;
+
+    // Load-more rows pin to the ends of the list and carry `now` as their date,
+    // so they have to be held out of the merge — a time-anchored alert would
+    // otherwise sort ahead of the head one and push it off the top, or past the
+    // tail one in the historical view and strand it mid-list.
+    const current = messages.value;
+    let start = 0;
+    let end = current.length;
+    if (current[start] instanceof LoadMoreLogEntry) start++;
+    if (end > start && current[end - 1] instanceof LoadMoreLogEntry) end--;
+    const head = current.slice(0, start);
+    const tail = current.slice(end);
+    const logs = current.slice(start, end);
+    if (logs.length === 0) return;
+
+    try {
+      const from = logs[0].date;
+      const to = new Date(logs[logs.length - 1].date.getTime() + 1);
+      // Origins only, like scrollback. An incident already running when this
+      // window opens shows through the per-line badges instead, which is both
+      // more precise and cheaper than a second block.
+      const newest = logs[logs.length - 1].date.getTime();
+      const wantEvents = polledThrough === undefined || newest > polledThrough;
+      polledThrough = newest;
+
+      const { alerts, events } = await fetchAlerts(
+        containers.value.map((c) => c.id),
+        from,
+        to,
+        { events: wantEvents },
+      );
+
+      // Badges mutate the entries in place, so the list has to be reassigned
+      // for Vue to see it — messages is a shallowRef.
+      const badged = attachEvents(logs, events);
+      const withEvents = mergeCloudEvents(logs, events, placedAlerts);
+      const merged = mergeAlerts(withEvents, alerts, placedAlerts);
+      if (!badged && merged === logs) return;
+      messages.value = [...head, ...merged, ...tail];
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  // The opening window is assembled without alerts — only scrollback fetches
+  // them — and the frames that assemble it arrive as a burst describing the
+  // same window, so callers get a debounced entry point rather than the raw one.
+  const decorateVisible = useDebounceFn(decorateVisibleNow, 400);
+
+  // An alert's anchor is the timestamp of the event that triggered it, which is
+  // always older than the alert itself — so the poll re-asks the whole visible
+  // window rather than only the slice since the last call. A window that only
+  // moved forward would never see an alert land on a line already on screen.
+  // This matters in the historical view too, where the window never moves at
+  // all: triage can attach an alert to a line that scrolled past days ago.
+  const visible = useDocumentVisibility();
+  const alertPoll = useIntervalFn(
+    () => {
+      if (visible.value === "visible") decorateVisibleNow();
+    },
+    ALERT_POLL_MS,
+    { immediate: false },
+  );
+
+  // Only runs when Cloud is actually linked. An unlinked Dozzle has no alerts
+  // to fetch, so a timer there is pure waste — and an unconditional interval
+  // also hangs any test that drains pending timers.
+  //
+  // The immediate pass on becoming linked matters twice. The cloud config is
+  // fetched asynchronously at boot, so on an ordinary load this flips true
+  // *after* the view has already assembled its first window — without it the
+  // opening window would sit bare until the first tick. It also covers linking
+  // mid-session: alerts start appearing at once rather than up to a poll later.
+  watch(
+    alertsAvailable,
+    (linked) => {
+      if (!linked) {
+        alertPoll.pause();
+        return;
+      }
+      alertPoll.resume();
+      decorateVisible();
+    },
+    { immediate: true },
+  );
+
+  return { withAlerts, decorateVisible, alertsAvailable };
+}

--- a/assets/composable/alertMerger.ts
+++ b/assets/composable/alertMerger.ts
@@ -62,12 +62,16 @@ export function useAlertMerger(
   // still requested every time: an alert's anchor is older than the alert, so
   // one can land on a line that has been on screen for a while.
   let polledThrough: number | undefined;
+  // Bumped on every stream change so a response that was already in flight
+  // cannot merge into the window that replaced it.
+  let generation = 0;
   // The viewer clears its messages when the stream changes (container switch,
   // filter change). Without this the seen-set would outlive the entries it was
   // tracking, and alerts already scrolled past would never render again.
   watch([params, containers], () => {
     placedAlerts.clear();
     polledThrough = undefined;
+    generation++;
   });
 
   /**
@@ -133,7 +137,7 @@ export function useAlertMerger(
       // more precise and cheaper than a second block.
       const newest = logs[logs.length - 1].date.getTime();
       const wantEvents = polledThrough === undefined || newest > polledThrough;
-      polledThrough = newest;
+      const startedAt = generation;
 
       const { alerts, events } = await fetchAlerts(
         containers.value.map((c) => c.id),
@@ -141,6 +145,15 @@ export function useAlertMerger(
         to,
         { events: wantEvents },
       );
+
+      // The window can be replaced while the request is out — a container
+      // switch, or a live flush appending lines. Writing the old merge back
+      // would clobber it, so drop the response instead and let the next pass
+      // ask for the window that is actually on screen. Checked before merging:
+      // mergeAlerts records what it places in placedAlerts, so bailing after it
+      // would mark these alerts as drawn when they never were.
+      if (startedAt !== generation || messages.value !== current) return;
+      polledThrough = newest;
 
       // Badges mutate the entries in place, so the list has to be reassigned
       // for Vue to see it — messages is a shallowRef.

--- a/assets/composable/eventStreams.ts
+++ b/assets/composable/eventStreams.ts
@@ -102,59 +102,14 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
   });
 
   const allContainers = computed(() => (container ? [container.value] : containers.value));
-  const { loadOlderLogs, loadSkippedLogs, loadAlertsForVisible, alertsAvailable } = useLogLoader(
+  // The alert layer — dedupe state, the 15s poll, and the merge itself — lives
+  // in useAlertMerger, shared with the historical view. All the stream has to
+  // do is say when it has assembled a new window.
+  const { loadOlderLogs, loadSkippedLogs, decorateWithAlerts } = useLogLoader(
     messages,
     allContainers,
     params,
     loadingMore,
-  );
-
-  // Cloud aggregates events on a 15s window before an alert can even exist, so
-  // asking more often than that cannot surface anything sooner — it only costs
-  // requests. Polling on a timer also decouples the rate from log volume: this
-  // used to be driven by the buffer flush, which meant a chatty container hit
-  // Cloud roughly once a second, per open tab.
-  const ALERT_POLL_MS = 15_000;
-
-  // The opening window is assembled from the stream, which knows nothing about
-  // alerts — only scrollback fetched them. Debounced because the first frames
-  // arrive as a burst (initial flush, then backfill) describing the same
-  // window.
-  const decorateWithAlerts = useDebounceFn(loadAlertsForVisible, 400);
-
-  // An alert's anchor is the timestamp of the event that triggered it, which is
-  // always older than the alert itself — so the poll re-asks the whole visible
-  // window rather than only the slice since the last call. A window that only
-  // moved forward would never see an alert land on a line already on screen.
-  const visible = useDocumentVisibility();
-  const alertPoll = useIntervalFn(
-    () => {
-      if (visible.value === "visible") loadAlertsForVisible();
-    },
-    ALERT_POLL_MS,
-    { immediate: false },
-  );
-
-  // Only runs when Cloud is actually linked. An unlinked Dozzle has no alerts
-  // to fetch, so a timer there is pure waste — and an unconditional interval
-  // also hangs any test that drains pending timers.
-  //
-  // The immediate pass on becoming linked matters twice. The cloud config is
-  // fetched asynchronously at boot, so on an ordinary load this flips true
-  // *after* the stream has already assembled its first window — without it the
-  // opening window would sit bare until the first tick. It also covers linking
-  // mid-session: alerts start appearing at once rather than up to a poll later.
-  watch(
-    alertsAvailable,
-    (linked) => {
-      if (!linked) {
-        alertPoll.pause();
-        return;
-      }
-      alertPoll.resume();
-      decorateWithAlerts();
-    },
-    { immediate: true },
   );
 
   function flushNow() {

--- a/assets/composable/historicalLogs.ts
+++ b/assets/composable/historicalLogs.ts
@@ -2,6 +2,7 @@ import { HistoricalContainer } from "@/models/Container";
 import { LogMessage, LoadMoreLogEntry, LogEntry } from "@/models/LogEntry";
 import { ShallowRef } from "vue";
 import { loadBetween } from "@/composable/loadBetween";
+import { useAlertMerger, isStreamLog } from "@/composable/alertMerger";
 
 export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalContainer>): LogStreamSource {
   const messages: ShallowRef<LogEntry<LogMessage>[]> = shallowRef([]);
@@ -29,6 +30,11 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
     return params;
   });
 
+  // Same alert layer the live stream uses: without it a deep link to an alert
+  // landed on the one view that could not draw it.
+  const containers = computed(() => [container.value]);
+  const { withAlerts, decorateVisible } = useAlertMerger(messages, containers, params);
+
   const route = useRoute();
   async function loadLogs() {
     loadingMore.value = true;
@@ -51,9 +57,12 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
       ]);
       const loaderOlder = new LoadMoreLogEntry(new Date(), loadOlderLogs);
       const loadNewer = new LoadMoreLogEntry(new Date(), loadNewerLogs, false);
-      messages.value = [loaderOlder, ...before, ...after, loadNewer];
+      messages.value = [loaderOlder, ...(await withAlerts([...before, ...after])), loadNewer];
       loading.value = false;
       opened.value = true;
+      // Covers the boot race: the cloud config arrives asynchronously, so
+      // withAlerts above may have run while the instance still looked unlinked.
+      decorateVisible();
     } catch (error) {
       console.error(error);
     } finally {
@@ -66,7 +75,11 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
   async function loadOlderLogs(entry: LoadMoreLogEntry) {
     loadingMore.value = true;
     try {
-      const item = messages.value[1];
+      // First real line, not messages[1]: alert and event rows sit between the
+      // loader and the logs, and their id is an anchor timestamp rather than a
+      // line hash, so using one as lastSeenId would match nothing.
+      const item = messages.value.find(isStreamLog);
+      if (!item) return;
       const { logs, signal } = await loadBetween(
         container,
         params,
@@ -87,7 +100,7 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
       }
 
       const [loader, ...rest] = messages.value;
-      messages.value = [loader, ...logs, ...rest];
+      messages.value = [loader, ...(await withAlerts(logs)), ...rest];
     } catch (error) {
       console.error(error);
     } finally {
@@ -98,7 +111,10 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
   async function loadNewerLogs(entry: LoadMoreLogEntry) {
     loadingMore.value = true;
     try {
-      const item = messages.value.at(-2)!;
+      // Last real line, for the same reason loadOlderLogs skips back past the
+      // synthetic rows.
+      const item = messages.value.findLast(isStreamLog);
+      if (!item) return;
       const { logs, signal } = await loadBetween(container, params, item.date, new Date(), {
         maxStart: 100,
         startId: item.id,
@@ -114,7 +130,7 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
 
       const loader = messages.value.at(-1)!;
       const rest = messages.value.slice(0, -1);
-      messages.value = [...rest, ...logs, loader];
+      messages.value = [...rest, ...(await withAlerts(logs)), loader];
     } catch (error) {
       console.error(error);
     } finally {

--- a/assets/composable/historicalLogs.ts
+++ b/assets/composable/historicalLogs.ts
@@ -33,7 +33,7 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
   // Same alert layer the live stream uses: without it a deep link to an alert
   // landed on the one view that could not draw it.
   const containers = computed(() => [container.value]);
-  const { withAlerts, decorateVisible } = useAlertMerger(messages, containers, params);
+  const { withAlerts, decorateVisible, alertsAvailable } = useAlertMerger(messages, containers, params);
 
   const route = useRoute();
   async function loadLogs() {
@@ -57,12 +57,15 @@ export function useHistoricalContainerLog(historicalContainer: Ref<HistoricalCon
       ]);
       const loaderOlder = new LoadMoreLogEntry(new Date(), loadOlderLogs);
       const loadNewer = new LoadMoreLogEntry(new Date(), loadNewerLogs, false);
+      const wasLinked = alertsAvailable.value;
       messages.value = [loaderOlder, ...(await withAlerts([...before, ...after])), loadNewer];
       loading.value = false;
       opened.value = true;
-      // Covers the boot race: the cloud config arrives asynchronously, so
+      // Only for the boot race: the cloud config arrives asynchronously, so
       // withAlerts above may have run while the instance still looked unlinked.
-      decorateVisible();
+      // When it was already linked the window is decorated, and asking again
+      // would just spend a request on a window that cannot have changed.
+      if (!wasLinked && alertsAvailable.value) decorateVisible();
     } catch (error) {
       console.error(error);
     } finally {

--- a/assets/composable/logLoader.ts
+++ b/assets/composable/logLoader.ts
@@ -2,7 +2,7 @@ import { ShallowRef, type Ref } from "vue";
 import { type LogMessage, LogEntry, LoadMoreLogEntry, SkippedLogsEntry } from "@/models/LogEntry";
 import { Container } from "@/models/Container";
 import { loadBetween } from "@/composable/loadBetween";
-import { useCloudAlerts, mergeAlerts, attachEvents, mergeCloudEvents } from "@/composable/cloudAlerts";
+import { useAlertMerger } from "@/composable/alertMerger";
 
 // Matches the rolling window size used for stats history
 const LOG_WINDOW_FOR_DELTA = 300;
@@ -13,25 +13,8 @@ export function useLogLoader(
   params: Ref<URLSearchParams>,
   loadingMore: Ref<boolean>,
 ) {
-  const { fetchAlerts, available: alertsAvailable } = useCloudAlerts();
-  // Anchor keys already placed, so overlapping scroll windows don't duplicate.
-  // Keyed on (alert, anchor) rather than the alert alone: one incident legitimately
-  // marks every window it was active in.
-  const placedAlerts = new Set<string>();
-  // Newest log timestamp the poll has already asked Cloud about. Events only
-  // describe lines, so a window that gained no lines cannot have gained
-  // events — and skipping them keeps a quiet container's poll from carrying a
-  // payload of up to a thousand rows the viewer would discard. Alerts are
-  // still requested every time: an alert's anchor is older than the alert, so
-  // one can land on a line that has been on screen for a while.
-  let polledThrough: number | undefined;
-  // The viewer clears its messages when the stream changes (container switch,
-  // filter change). Without this the seen-set would outlive the entries it was
-  // tracking, and alerts already scrolled past would never render again.
-  watch([params, containers], () => {
-    placedAlerts.clear();
-    polledThrough = undefined;
-  });
+  const { withAlerts, decorateVisible } = useAlertMerger(messages, containers, params);
+
   async function loadOlderLogs(entry: LoadMoreLogEntry) {
     if (!(messages.value[0] instanceof LoadMoreLogEntry)) throw new Error("No loadMoreLogEntry on first item");
     if (containers.value.length === 0) return;
@@ -121,83 +104,5 @@ export function useLogLoader(
     }
   }
 
-  /**
-   * Decorates a freshly loaded, time-sorted run of logs with any Dozzle Cloud
-   * alerts that fired inside it.
-   *
-   * fetchAlerts never rejects, but the guard is kept regardless: this runs on
-   * the scroll path, where the log lines have already been fetched. A cloud
-   * problem must degrade to "no alerts", never cost the user their logs.
-   */
-  async function withAlerts(logs: LogEntry<LogMessage>[]): Promise<LogEntry<LogMessage>[]> {
-    if (!alertsAvailable.value || logs.length === 0) return logs;
-    try {
-      const ids = containers.value.map((c) => c.id);
-      const { alerts, events } = await fetchAlerts(
-        ids,
-        logs[0].date,
-        new Date(logs[logs.length - 1].date.getTime() + 1),
-        { events: true },
-      );
-      attachEvents(logs, events);
-      return mergeAlerts(mergeCloudEvents(logs, events, placedAlerts), alerts, placedAlerts);
-    } catch (err) {
-      console.error(err);
-      return logs;
-    }
-  }
-
-  /**
-   * Decorates the logs already on screen with any alerts that fired inside
-   * them.
-   *
-   * loadOlderLogs only runs when the user scrolls back, so without this an
-   * alert that fired inside the window the viewer *opens* on never appeared —
-   * the most common case there is, since "something just happened" is usually
-   * why the container got opened at all.
-   *
-   * Safe to call repeatedly: placedAlerts dedupes, and an unchanged window
-   * merges nothing.
-   */
-  async function loadAlertsForVisible() {
-    if (!alertsAvailable.value || containers.value.length === 0) return;
-
-    // The loader pins to the top of the list and carries `now` as its date, so
-    // it must be held out of the merge — a time-anchored alert would otherwise
-    // sort ahead of it and push it off the top.
-    const [head, ...rest] = messages.value;
-    const loader = head instanceof LoadMoreLogEntry ? head : undefined;
-    const logs = loader ? rest : messages.value;
-    if (logs.length === 0) return;
-
-    try {
-      const from = logs[0].date;
-      const to = new Date(logs[logs.length - 1].date.getTime() + 1);
-      // Origins only, like scrollback. An incident already running when this
-      // window opens shows through the per-line badges instead, which is both
-      // more precise and cheaper than a second block.
-      const newest = logs[logs.length - 1].date.getTime();
-      const wantEvents = polledThrough === undefined || newest > polledThrough;
-      polledThrough = newest;
-
-      const { alerts, events } = await fetchAlerts(
-        containers.value.map((c) => c.id),
-        from,
-        to,
-        { events: wantEvents },
-      );
-
-      // Badges mutate the entries in place, so the list has to be reassigned
-      // for Vue to see it — messages is a shallowRef.
-      const badged = attachEvents(logs, events);
-      const withEvents = mergeCloudEvents(logs, events, placedAlerts);
-      const merged = mergeAlerts(withEvents, alerts, placedAlerts);
-      if (!badged && merged === logs) return;
-      messages.value = loader ? [loader, ...merged] : merged;
-    } catch (err) {
-      console.error(err);
-    }
-  }
-
-  return { loadOlderLogs, loadSkippedLogs, loadAlertsForVisible, alertsAvailable };
+  return { loadOlderLogs, loadSkippedLogs, decorateWithAlerts: decorateVisible };
 }


### PR DESCRIPTION
Alerts never appeared in the jump-to-date view (`/container/{id}/time/{date}?logId=...`), only in live tailing.

The alert layer lived inside `useLogLoader`, which only `eventStreams.ts` uses. `historicalLogs.ts` is a separate `LogStreamSource` that calls `loadBetween` directly, so it never fetched alerts, never polled for them, and never badged lines with matched events. Following an alert deep link landed on the one view that couldn't draw the alert.

## What changed

New `assets/composable/alertMerger.ts` owns the whole layer:

- the `placedAlerts` dedupe set and its reset on stream change
- `withAlerts()` for decorating a freshly loaded run
- the visible-window pass, debounced
- the 15s poll, gated on document visibility and cloud-linked state

`logLoader.ts` and `historicalLogs.ts` both use it. `eventStreams.ts` loses its copy of the poll wiring and just calls `decorateWithAlerts()` when it assembles a new window.

Two things the historical view needed on top:

- it keeps a load-more row at **both** ends of the list, so the merger holds out the tail one as well as the head. A time-anchored alert would otherwise sort past it and strand it mid-list.
- its scrollback loaders anchored on `messages[1]` / `at(-2)`. Alert and event rows sit at exactly those positions once merged, and their id is an anchor timestamp rather than a line hash, so `lastSeenId` would have matched nothing. They now scan for the nearest real log line via `isStreamLog`.

No backend change: alerts were always a client-side merge over `/api/cloud/alerts`.

## Tests

`assets/composable/alertMerger.spec.ts` covers the splice, the both-ends loader case, the poll picking up an alert while the window is static, and dedupe across overlapping windows. Full suite and typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)