### PR TITLE
fix(logs): keep event badges through the viewer's re-clone

### DIFF
--- a/assets/composable/alertMerger.spec.ts
+++ b/assets/composable/alertMerger.spec.ts
@@ -190,6 +190,19 @@ describe("useAlertMerger", () => {
     });
   });
 
+  test("covers the whole time range when the newest line is not the last one", async () => {
+    // The historical view builds its opening window from two overlapping range
+    // queries, so the list can end on a line older than one in the middle.
+    respondWith([]);
+    const messages = shallowRef<LogEntry<LogMessage>[]>([]);
+    await withMerger(messages, async ({ withAlerts }) => {
+      await withAlerts([log(1, 100), log(2, 900), log(3, 300)]);
+      const url = new URL((global.fetch as any).mock.calls[0][0], "http://localhost");
+      expect(url.searchParams.get("from")).toBe(String(ns(100)));
+      expect(url.searchParams.get("to")).toBe(String(ns(901)));
+    });
+  });
+
   test("does not place the same alert twice across overlapping windows", async () => {
     respondWith([alert({ logId: 2, ts: ns(200) })]);
     const messages = shallowRef<LogEntry<LogMessage>[]>([]);

--- a/assets/composable/alertMerger.ts
+++ b/assets/composable/alertMerger.ts
@@ -86,12 +86,20 @@ export function useAlertMerger(
     if (!alertsAvailable.value || logs.length === 0) return logs;
     try {
       const ids = containers.value.map((c) => c.id);
-      const { alerts, events } = await fetchAlerts(
-        ids,
-        logs[0].date,
-        new Date(logs[logs.length - 1].date.getTime() + 1),
-        { events: true },
-      );
+      // Scanned rather than read off the ends: the historical view assembles
+      // its opening window from two overlapping range queries, so the newest
+      // line is not reliably the last one. Taking logs[last] there could close
+      // the window early and drop every alert anchored past it.
+      let earliest = logs[0].date.getTime();
+      let latest = earliest;
+      for (const l of logs) {
+        const t = l.date.getTime();
+        if (t < earliest) earliest = t;
+        if (t > latest) latest = t;
+      }
+      const { alerts, events } = await fetchAlerts(ids, new Date(earliest), new Date(latest + 1), {
+        events: true,
+      });
       attachEvents(logs, events);
       return mergeAlerts(mergeCloudEvents(logs, events, placedAlerts), alerts, placedAlerts);
     } catch (err) {
@@ -130,12 +138,20 @@ export function useAlertMerger(
     if (logs.length === 0) return;
 
     try {
-      const from = logs[0].date;
-      const to = new Date(logs[logs.length - 1].date.getTime() + 1);
+      // Same scan as withAlerts, for the same reason: the ends of the list are
+      // not reliably the ends of its time range.
+      let earliest = logs[0].date.getTime();
+      let newest = earliest;
+      for (const l of logs) {
+        const t = l.date.getTime();
+        if (t < earliest) earliest = t;
+        if (t > newest) newest = t;
+      }
+      const from = new Date(earliest);
+      const to = new Date(newest + 1);
       // Origins only, like scrollback. An incident already running when this
       // window opens shows through the per-line badges instead, which is both
       // more precise and cheaper than a second block.
-      const newest = logs[logs.length - 1].date.getTime();
       const wantEvents = polledThrough === undefined || newest > polledThrough;
       const startedAt = generation;
 

--- a/assets/models/LogEntry.spec.ts
+++ b/assets/models/LogEntry.spec.ts
@@ -116,3 +116,23 @@ describe("SkippedLogsEntry", () => {
     expect(entry.lastSkippedLog).toBe(newLast);
   });
 });
+
+describe("matchedEvent", () => {
+  const complex = () => new ComplexLogEntry({ msg: "hi" }, "abc", 1, new Date(1), "info", "stdout", '{"msg":"hi"}');
+
+  test("survives the re-clone the viewer does on every render", () => {
+    const entry = complex();
+    entry.matchedEvent = { suppressed: true };
+
+    const rendered = ComplexLogEntry.fromLogEvent(entry, ref(new Map()));
+    expect(rendered.matchedEvent).toEqual({ suppressed: true });
+  });
+
+  test("reaches a clone that was made before the alert loader marked the entry", () => {
+    const entry = complex();
+    const rendered = ComplexLogEntry.fromLogEvent(entry, ref(new Map()));
+
+    entry.matchedEvent = { suppressed: true };
+    expect(rendered.matchedEvent).toEqual({ suppressed: true });
+  });
+});

--- a/assets/models/LogEntry.ts
+++ b/assets/models/LogEntry.ts
@@ -178,7 +178,7 @@ export class ComplexLogEntry extends LogEntry<JSONObject> {
   }
 
   static fromLogEvent(event: ComplexLogEntry, visibleKeys: Ref<Map<string[], boolean>>): ComplexLogEntry {
-    return new ComplexLogEntry(
+    const clone = new ComplexLogEntry(
       event._message,
       event.containerID,
       event.id,
@@ -188,6 +188,14 @@ export class ComplexLogEntry extends LogEntry<JSONObject> {
       event.rawMessage,
       visibleKeys,
     );
+    // The viewer re-clones every complex entry on each render, so the clone is
+    // what actually reaches the row component. Matched events live in a WeakMap
+    // keyed on the instance, so without carrying the ref across, a JSON log
+    // could never show its badge — the entry the alert loader marked was thrown
+    // away before it was drawn. Sharing the ref rather than copying the value
+    // also keeps a badge that arrives after this clone was made.
+    matchedEvents.set(clone, matchedEventRef(event));
+    return clone;
   }
 }
 


### PR DESCRIPTION
Follow-up to #4925. Alerts render in the historical view now, but events still don't show on JSON logs.

## The badge bug (confirmed)

`LogViewer` runs every entry through `useVisibleFilter.filteredPayload`, which rebuilds each `ComplexLogEntry` via `ComplexLogEntry.fromLogEvent` on **every render**. Matched events live in a `WeakMap` keyed on the entry instance, so the clone that actually reaches `LogItem` has no `matchedEvent` — the instance the alert loader marked was thrown away before it was drawn.

Net effect: the bell badge never appears on structured/JSON logs, in the live view as well as the historical one. Plain text logs were unaffected, which is why this hid behind the alert cards.

The clone now shares the source entry's ref rather than getting a fresh one, so a badge that arrives *after* the clone was made also propagates.

## Window hardening

`withAlerts`/`decorateVisibleNow` took the fetch window from `logs[0]` and `logs[last]`. The historical view assembles its opening window from two overlapping range queries (`before` covering `date-5m → date+1s`, `after` covering `date → now` capped at 50), so on a busy container the list can end on a line older than one in its middle. That closed the window early and dropped every alert anchored past it. Both now scan for min/max.

## Tests

- `LogEntry.spec.ts`: badge survives the re-clone, and reaches a clone made before the loader marked the entry.
- `alertMerger.spec.ts`: fetch window covers the full range when the newest line isn't last.

174 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)