### PR TITLE
fix(logs): stop logging client disconnects as stream errors

### DIFF
--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -499,7 +499,11 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 					Host:    c.Host,
 					Time:    finishedAt,
 				}
-			} else if !errors.Is(err, context.Canceled) {
+			} else if errors.Is(err, context.Canceled) || r.Context().Err() != nil {
+				// the client went away; a read already in flight comes back as
+				// "use of closed network connection" instead of a cancellation
+				log.Debug().Err(err).Str("container", c.ID).Msg("streaming stopped after client disconnected")
+			} else {
 				log.Error().Err(err).Str("container", c.ID).Msg("unknown error while streaming logs")
 			}
 		}


### PR DESCRIPTION
Closing a log view logged one `unknown error while streaming logs` per container in that view, all at the same timestamp:

```
level=error error=read unix @->/run/docker.sock: use of closed network connection
container=f2ba6184d0e8 message=unknown error while streaming logs
```

When the SSE request context is cancelled the Docker client closes the socket, so a read already in flight returns `net.ErrClosed` rather than `context.Canceled`. The filter in `streamLogs` only knew about `io.EOF` and `context.Canceled`, so normal teardown fell through to the error branch.

Now a stream error is logged at debug when the request context is already done. A socket that breaks mid-stream, with the context still live, still logs at error.

Fixes #4927

🤖 Generated with [Claude Code](https://claude.com/claude-code)