### PR TITLE
fix(logs): guess level from klog/glog prefix

### DIFF
--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -35,7 +35,7 @@ type levelMatcher struct {
 // levelTiers groups matchers by how confidently their shape identifies the log
 // level, highest confidence first:
 //
-//  1. ^<level>     start-of-line prefix: "ERROR: ...", "INF ..."
+//  1. ^<level>     start-of-line prefix: "ERROR: ...", "INF ...", "E0806 14:55:55.980915 ..."
 //  2. [<level>]    bracketed tag / single-letter: "[ERROR]", "[E]"
 //  3. <tag>:<level> structured prefix: "Zigbee2MQTT:info "
 //  4. "<LEVEL>"    quoted upper-case value: LL="ERROR"
@@ -51,6 +51,16 @@ var levelTiers [][]levelMatcher
 
 // singleLetterBracket matches single-letter levels in brackets, e.g. [I], [E], [W]
 var singleLetterBracket = regexp.MustCompile(`\[([EWIDFTV])\]`)
+
+// klogPrefix matches the Kubernetes klog/glog header, where the single-letter
+// level is glued straight onto the timestamp with no separator, e.g.
+//
+//	E0806 14:55:55.980915       1 fsHandler.go:121] failed to collect ...
+//
+// Used by the whole Kubernetes toolchain (kubelet, kube-*, cAdvisor, etcd
+// tooling). The full "Lmmdd hh:mm:ss.uuuuuu" shape is required so ordinary
+// prose starting with a capital letter cannot match.
+var klogPrefix = regexp.MustCompile(`^([EWIDFTV])\d{4} \d{2}:\d{2}:\d{2}\.\d{6}`)
 
 var timestampRegex = regexp.MustCompile(`^(?:\d{4}[-/]\d{2}[-/]\d{2}(?:[T ](?:\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?|\d{2}:\d{2}(?:AM|PM)))?\s+)`)
 
@@ -76,7 +86,10 @@ func init() {
 	upper := strings.ToUpper(joined)
 
 	levelTiers = [][]levelMatcher{
-		{{re: regexp.MustCompile(`(?i)^(` + joined + `)[^a-z]`)}},
+		{
+			{re: regexp.MustCompile(`(?i)^(` + joined + `)[^a-z]`)},
+			{re: klogPrefix, single: true},
+		},
 		{
 			{re: regexp.MustCompile(`(?i)\[ ?(` + joined + `) ?\]`)},
 			{re: singleLetterBracket, single: true},

--- a/internal/container/level_guesser_test.go
+++ b/internal/container/level_guesser_test.go
@@ -41,6 +41,14 @@ func TestGuessLogLevel(t *testing.T) {
 		{"inf Something went wrong", "info"},
 		{"crit: Something went wrong", "fatal"},
 		{"[21:01:45] [WRN] this is a test", "warn"},
+		// klog / glog format used across the Kubernetes toolchain
+		{"E0806 14:55:55.980915       1 fsHandler.go:121] failed to collect filesystem stats", "error"},
+		{"W0806 14:54:52.068675       1 info.go:52] Couldn't collect info from any of the files", "warn"},
+		{"I0808 13:37:10.853121       1 cadvisor.go:182] Starting cAdvisor version: v0.60.5", "info"},
+		{"F0806 14:55:55.980915       1 main.go:10] exiting", "fatal"},
+		// the level letter must be glued to a full klog timestamp, not just any capital
+		{"E0806 is not a klog line", "unknown"},
+		{"Warning0806 14:55:55.980915 not klog either", "warn"},
 		{"2026-01-05 12:13:24,566 - retry.api                        (7fd8ad34eb30) :  WARNING (api:40) - HTTPSConnectionPool(host='podnapisi.net', port=443): Max retries exceeded", "warn"},
 		{"2026-01-05 08:21:16,511 - root                             (7fd8bf822b30) :  INFO (get_providers:408) - Throttling podnapisi for 10 minutes", "info"},
 		{orderedmap.New[string, string](


### PR DESCRIPTION
klog lines fall back to "unknown" today, so cAdvisor, kubelet and the rest of the Kubernetes toolchain are invisible to the error/warning filter. klog puts the level letter straight onto the timestamp, no separator and no brackets:

```
E0806 14:55:55.980915       1 fsHandler.go:121] failed to collect filesystem stats
W0806 14:54:52.068675       1 info.go:52] Couldn't collect info from any of the files
```

`level_guesser.go` only matches single letter levels inside brackets (`\[([EWIDFTV])\]`), so none of these match.

This adds one matcher to tier 0:

```go
var klogPrefix = regexp.MustCompile(`^([EWIDFTV])\d{4} \d{2}:\d{2}:\d{2}\.\d{6}`)
```

It reuses the existing `levelMatcher{single: true}` path and the `singleLetterToLevel` table, both already there. Tier 0 is right for it because the pattern is anchored at the start of the line and needs a complete klog timestamp, so ordinary prose beginning with a capital letter cannot trigger it. Two negative cases in the test cover that (`E0806 is not a klog line` stays unknown, `Warning0806 ...` still resolves to warn through the alias matcher).

No new level is introduced, only new input for the existing ones, so `logContext.ts` needs no change.

`go test ./internal/container/...` and `go vet` pass on go 1.27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)