### PR TITLE
fix(logs): guess level from more formats

### DIFF
--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -1,8 +1,10 @@
 package container
 
 import (
+	"encoding/json"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -15,32 +17,43 @@ var SupportedLogLevels map[string]struct{}
 var logLevels = [][]string{
 	{"error", "err"},
 	{"warn", "warning", "wrn"},
-	{"info", "inf", "information"},
+	{"info", "inf", "information", "notice"},
 	{"debug", "dbg"},
 	{"trace", "verbose", "ver", "vbs"},
-	{"fatal", "sev", "severe", "crit", "critical"},
+	{"fatal", "sev", "severe", "crit", "critical", "panic", "emerg", "emergency"},
+}
+
+// Aliases that are also ordinary words ("alert sent to slack") and would guess
+// wrong far too often on their own. They resolve in structured logs and in the
+// two shapes that leave no doubt, bracketed tags and level keys, and are kept
+// out of every loose text matcher.
+var ambiguousAliases = map[string]string{
+	"alert": "fatal",
 }
 
 // aliasToCanonical maps every alias to its canonical level name.
 var aliasToCanonical = map[string]string{}
 
 // levelMatcher extracts a canonical log level from a line. re must expose a
-// single capture group holding the level alias, or a single-letter code when
-// single is true (mapped via singleLetterToLevel).
+// single capture group holding the level alias, or whatever convert expects
+// when convert is set.
 type levelMatcher struct {
-	re     *regexp.Regexp
-	single bool
+	re *regexp.Regexp
+	// convert turns the capture group into a canonical level, returning ""
+	// when it does not resolve. When nil the capture is looked up as an alias.
+	convert func(string) string
 }
 
 // levelTiers groups matchers by how confidently their shape identifies the log
 // level, highest confidence first:
 //
-//  1. ^<level>     start-of-line prefix: "ERROR: ...", "INF ...", "E0806 14:55:55.980915 ..."
-//  2. [<level>]    bracketed tag / single-letter: "[ERROR]", "[E]"
-//  3. <tag>:<level> structured prefix: "Zigbee2MQTT:info "
-//  4. "<LEVEL>"    quoted upper-case value: LL="ERROR"
-//  5. <sp><level>[/|:-] separator: " error:", " info|"
-//  6. <sp><LEVEL><sp> bare upper-case token mid-line: "123 ERROR foo"
+//  1. ^<level>       start-of-line prefix: "ERROR: ...", "INF ...", "E0806 14:55:55.980915 ...", "<11>Jan  1 ..."
+//  2. level=<level>  explicit key/value: "level=info", "lvl=WARN", "severity: error"
+//  3. [<level>]      bracketed tag / single-letter: "[ERROR]", "[E]"
+//  4. <tag>:<level>  structured prefix: "Zigbee2MQTT:info "
+//  5. "<LEVEL>"      quoted upper-case value: LL="ERROR"
+//  6. <sp><level>[/|:-] separator: " error:", " info|"
+//  7. <sp><LEVEL><sp> bare upper-case token mid-line: "123 ERROR foo"
 //
 // guessFromString walks the tiers in order and stops at the first that matches,
 // so a real level prefix at the front of the line always beats a level word
@@ -62,10 +75,24 @@ var singleLetterBracket = regexp.MustCompile(`\[([EWIDFTV])\]`)
 // prose starting with a capital letter cannot match.
 var klogPrefix = regexp.MustCompile(`^([EWIDFTV])\d{4} \d{2}:\d{2}:\d{2}\.\d{6}`)
 
+// syslogPriority matches the RFC 3164 / RFC 5424 priority value that starts a
+// syslog line, e.g. "<11>Jan  1 00:00:00 host app: disk failure". systemd,
+// rsyslog and anything piped through systemd-cat emit it. The value is
+// facility*8 + severity, so the severity is the remainder of 8.
+var syslogPriority = regexp.MustCompile(`^<(\d{1,3})>`)
+
 var timestampRegex = regexp.MustCompile(`^(?:\d{4}[-/]\d{2}[-/]\d{2}(?:[T ](?:\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?|\d{2}:\d{2}(?:AM|PM)))?\s+)`)
 
-// JSON keys to check for log level (in priority order).
-var levelKeys = []string{"@l", "level", "log.level", "severity"}
+// Keys that carry a log level in structured logs, in priority order. Keys are
+// matched case-insensitively and ignoring ".", "_" and "-", so "level",
+// "Level", "log.level", "log_level" and "logLevel" all resolve to the same
+// entry. Covers Serilog (@l), Python's json logger (levelname), OpenTelemetry
+// and GCP (severity, severityText) and the logfmt loggers (lvl).
+var levelKeys = []string{"@l", "level", "levelname", "loglevel", "lvl", "severity", "severitytext"}
+
+var levelKeyRank = map[string]int{}
+
+var keyNormalizer = strings.NewReplacer(".", "", "_", "", "-", "")
 
 func init() {
 	SupportedLogLevels = make(map[string]struct{}, len(logLevels)+1)
@@ -80,19 +107,38 @@ func init() {
 	}
 	SupportedLogLevels["unknown"] = struct{}{}
 
+	for i, key := range levelKeys {
+		levelKeyRank[key] = i
+	}
+
+	unambiguous := make([]string, len(aliases))
+	copy(unambiguous, aliases)
+	for alias, canonical := range ambiguousAliases {
+		aliasToCanonical[alias] = canonical
+		aliases = append(aliases, alias)
+	}
+
 	// Longest aliases first so e.g. "warning" is preferred over "warn".
-	sort.SliceStable(aliases, func(i, j int) bool { return len(aliases[i]) > len(aliases[j]) })
-	joined := strings.Join(aliases, "|")
+	byLength := func(list []string) {
+		sort.SliceStable(list, func(i, j int) bool { return len(list[i]) > len(list[j]) })
+	}
+	byLength(aliases)
+	byLength(unambiguous)
+	joined := strings.Join(unambiguous, "|")
+	// Shapes that cannot be confused with prose also accept the ambiguous aliases.
+	joinedAll := strings.Join(aliases, "|")
 	upper := strings.ToUpper(joined)
 
 	levelTiers = [][]levelMatcher{
 		{
 			{re: regexp.MustCompile(`(?i)^(` + joined + `)[^a-z]`)},
-			{re: klogPrefix, single: true},
+			{re: klogPrefix, convert: levelFromSingleLetter},
+			{re: syslogPriority, convert: levelFromSyslogPriority},
 		},
+		{{re: regexp.MustCompile(`(?i)(?:^|[\s,{])"?(?:log[._-]?level|levelname|level|lvl|severity)"?\s*[=:]\s*"?(` + joinedAll + `)(?:[^a-z]|$)`)}},
 		{
-			{re: regexp.MustCompile(`(?i)\[ ?(` + joined + `) ?\]`)},
-			{re: singleLetterBracket, single: true},
+			{re: regexp.MustCompile(`(?i)\[ ?(` + joinedAll + `) ?\]`)},
+			{re: singleLetterBracket, convert: levelFromSingleLetter},
 		},
 		{{re: regexp.MustCompile(`(?i):(` + joined + `)\s`)}},
 		{{re: regexp.MustCompile(`"(` + upper + `)"`)}},
@@ -110,28 +156,117 @@ func guessLogLevel(logEvent *LogEvent) string {
 		if value == nil {
 			return "unknown"
 		}
-		for _, key := range levelKeys {
-			if v, ok := value.Get(key); ok {
-				if s, ok := v.(string); ok {
-					return normalizeLogLevel(s)
-				}
-			}
-		}
+		return guessFromMap(value)
 
 	case *orderedmap.OrderedMap[string, string]:
 		if value == nil {
 			return "unknown"
 		}
-		for _, key := range levelKeys {
-			if v, ok := value.Get(key); ok {
-				return normalizeLogLevel(v)
-			}
-		}
+		return guessFromMap(value)
 
 	default:
 		log.Debug().Type("type", value).Msg("unknown logEvent type")
 	}
 
+	return "unknown"
+}
+
+// guessFromMap picks the level out of a structured entry. Every level key is
+// collected in one pass and then resolved in priority order, so an unusable
+// value on a high priority key (a number where a name was expected, an object)
+// falls through to the next key instead of losing the level.
+func guessFromMap[V any](value *orderedmap.OrderedMap[string, V]) string {
+	candidates := make([]any, len(levelKeys))
+	found := false
+	for pair := value.Oldest(); pair != nil; pair = pair.Next() {
+		rank, ok := levelKeyRank[normalizeKey(pair.Key)]
+		if !ok || candidates[rank] != nil {
+			continue
+		}
+		candidates[rank] = pair.Value
+		found = true
+	}
+	if !found {
+		return "unknown"
+	}
+	for i, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		if level := resolveLevelValue(candidate, numericLevelKeys[levelKeys[i]]); level != "unknown" {
+			return level
+		}
+	}
+	return "unknown"
+}
+
+// Keys where a number means a bunyan/pino level. "severity" is left out: a
+// number there is a syslog or OpenTelemetry severity, which counts the other
+// way around.
+var numericLevelKeys = map[string]bool{"@l": true, "level": true, "loglevel": true, "lvl": true}
+
+// normalizeKey lowercases a key and drops the separators loggers sprinkle
+// through it, so "log.level", "log_level" and "logLevel" all collapse to
+// "loglevel".
+func normalizeKey(key string) string {
+	return keyNormalizer.Replace(strings.ToLower(key))
+}
+
+// resolveLevelValue turns the value of a level key into a canonical level.
+// Numbers are only read when numeric says so, because bunyan and pino, the two
+// most common Node loggers, write levels as numbers.
+func resolveLevelValue(value any, numeric bool) string {
+	number := func(n float64) string {
+		if !numeric {
+			return "unknown"
+		}
+		return levelFromNumber(n)
+	}
+	switch v := value.(type) {
+	case string:
+		if level := normalizeLogLevel(v); level != "unknown" {
+			return level
+		}
+		if n, err := strconv.ParseFloat(strings.TrimSpace(v), 64); err == nil {
+			return number(n)
+		}
+	case float64:
+		return number(v)
+	case float32:
+		return number(float64(v))
+	case int:
+		return number(float64(v))
+	case int64:
+		return number(float64(v))
+	case json.Number:
+		if n, err := v.Float64(); err == nil {
+			return number(n)
+		}
+	}
+	return "unknown"
+}
+
+// levelFromNumber maps the numeric levels used by bunyan and pino (10 trace,
+// 20 debug, 30 info, 40 warn, 50 error, 60 fatal) to canonical names. Custom
+// levels in between fall into the band below them, which is how those loggers
+// render them too. Values below 10 are left unknown on purpose: there the
+// bunyan scale collides with syslog severities (0-7, and inverted) and with
+// OpenTelemetry severity numbers, so a guess would be wrong as often as right.
+func levelFromNumber(n float64) string {
+	switch {
+	case n >= 60:
+		return "fatal"
+	case n >= 50:
+		return "error"
+	case n >= 40:
+		return "warn"
+	case n >= 30:
+		return "info"
+	case n >= 20:
+		return "debug"
+	case n >= 10:
+		return "trace"
+	}
 	return "unknown"
 }
 
@@ -145,6 +280,22 @@ var singleLetterToLevel = map[byte]string{
 	'V': "trace",
 }
 
+func levelFromSingleLetter(match string) string {
+	return singleLetterToLevel[match[0]]
+}
+
+// syslogSeverityToLevel maps the eight RFC 5424 severities, in order, onto the
+// levels Dozzle knows about.
+var syslogSeverityToLevel = [8]string{"fatal", "fatal", "fatal", "error", "warn", "info", "info", "debug"}
+
+func levelFromSyslogPriority(match string) string {
+	pri, err := strconv.Atoi(match)
+	if err != nil || pri > 191 {
+		return ""
+	}
+	return syslogSeverityToLevel[pri%8]
+}
+
 func guessFromString(value string) string {
 	value = StripANSI(value)
 	value = timestampRegex.ReplaceAllString(value, "")
@@ -153,8 +304,8 @@ func guessFromString(value string) string {
 		for _, m := range tier {
 			for _, match := range m.re.FindAllStringSubmatch(value, -1) {
 				var canonical string
-				if m.single {
-					canonical = singleLetterToLevel[match[1][0]]
+				if m.convert != nil {
+					canonical = m.convert(match[1])
 				} else {
 					canonical = aliasToCanonical[strings.ToLower(match[1])]
 				}

--- a/internal/container/level_guesser_test.go
+++ b/internal/container/level_guesser_test.go
@@ -137,6 +137,122 @@ func TestGuessLogLevel(t *testing.T) {
 				orderedmap.Pair[string, any]{Key: "@l", Value: "Information"},
 			),
 		), "info"},
+		// logfmt style key=value, used by logrus, go-kit, slog, Traefik, Grafana, containerd.
+		{`time="2024-01-01T00:00:00Z" level=error msg="failed to connect"`, "error"},
+		{`ts=2024-01-01T00:00:00.000Z caller=main.go:10 level=warn msg="disk almost full"`, "warn"},
+		{"time=2024-01-01T00:00:00Z level=INFO msg=\"server started\"", "info"},
+		{"2024-01-01 12:00:00 level=debug handling request", "debug"},
+		{`level="warning" some message`, "warn"},
+		{"lvl=trace some message", "trace"},
+		{"log_level=error something broke", "error"},
+		{"loglevel=fatal giving up", "fatal"},
+		{"severity: ERROR something broke", "error"},
+		{"levelname=INFO started", "info"},
+		// The key must hold the level, not just look like it.
+		{"level=whatever some message", "unknown"},
+		{"lowlevel=error is not a level key", "unknown"},
+		// An explicit key beats a level word in the message.
+		{`level=info msg="connection error: retrying"`, "info"},
+		// ...but a real prefix still beats the key/value pair.
+		{`ERROR: request failed level=info`, "error"},
+		// Syslog priority prefix (RFC 3164/5424), emitted by systemd and rsyslog.
+		{"<11>Jan  1 00:00:00 host app: connection refused", "error"},
+		{"<30>Jan  1 00:00:00 host app: listening on :80", "info"},
+		{"<28>Jan  1 00:00:00 host app: retrying", "warn"},
+		{"<7>Jan  1 00:00:00 host app: cache hit", "debug"},
+		{"<1>1 2024-01-01T00:00:00Z host app - - - shutting down", "fatal"},
+		{"<190>Jan  1 00:00:00 host app: local7 info message", "info"},
+		{"<999> is not a syslog priority", "unknown"},
+		{"<html> is not a syslog priority", "unknown"},
+		// Syslog level names, used by nginx, haproxy, php-fpm and postfix.
+		{"2023/01/01 12:00:00 [notice] 1#1: start worker process 30", "info"},
+		{"2023/01/01 12:00:00 [emerg] 1#1: bind() to 0.0.0.0:80 failed (98: Address in use)", "fatal"},
+		{"2023/01/01 12:00:00 [alert] 1#1: worker process 30 exited on signal 9", "fatal"},
+		{"NOTICE: fpm is running, pid 1", "info"},
+		{"panic: runtime error: invalid memory address", "fatal"},
+		{"level=alert disk is full", "fatal"},
+		// "alert" is an ordinary word, so it only counts where the shape is unambiguous.
+		{"alert sent to slack channel", "unknown"},
+		{"Alerts: 5 fired in the last hour", "unknown"},
+		{"Received notice from upstream server", "unknown"},
+		// bunyan / pino write numeric levels.
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, any]{Key: "level", Value: float64(30)},
+				orderedmap.Pair[string, any]{Key: "msg", Value: "started"},
+			),
+		), "info"},
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(orderedmap.Pair[string, any]{Key: "level", Value: float64(10)}),
+		), "trace"},
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(orderedmap.Pair[string, any]{Key: "level", Value: float64(20)}),
+		), "debug"},
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(orderedmap.Pair[string, any]{Key: "level", Value: float64(40)}),
+		), "warn"},
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(orderedmap.Pair[string, any]{Key: "level", Value: float64(50)}),
+		), "error"},
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(orderedmap.Pair[string, any]{Key: "level", Value: float64(60)}),
+		), "fatal"},
+		// Custom levels land in the band below them.
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(orderedmap.Pair[string, any]{Key: "level", Value: float64(35)}),
+		), "info"},
+		// Below 10 the numeric scales contradict each other, so don't guess.
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(orderedmap.Pair[string, any]{Key: "level", Value: float64(3)}),
+		), "unknown"},
+		// A key that cannot be resolved falls through to the next one.
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, any]{Key: "level", Value: float64(3)},
+				orderedmap.Pair[string, any]{Key: "severity", Value: "error"},
+			),
+		), "error"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "level", Value: "50"}),
+		), "error"},
+		// A number under "severity" is a syslog or OpenTelemetry severity, which
+		// counts the other way around, so it is not read as a bunyan level.
+		{orderedmap.New[string, any](
+			orderedmap.WithInitialData(orderedmap.Pair[string, any]{Key: "severity", Value: float64(17)}),
+		), "unknown"},
+		// Level keys are matched case-insensitively and ignoring separators.
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "Level", Value: "Error"}),
+		), "error"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "log.level", Value: "debug"}),
+		), "debug"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "log_level", Value: "warn"}),
+		), "warn"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "logLevel", Value: "trace"}),
+		), "trace"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "lvl", Value: "info"}),
+		), "info"},
+		// Python's json logger writes levelname; OpenTelemetry writes severityText.
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "levelname", Value: "WARNING"}),
+		), "warn"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "severityText", Value: "ERROR"}),
+		), "error"},
+		// Syslog and GCP severity names.
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "severity", Value: "NOTICE"}),
+		), "info"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "severity", Value: "EMERGENCY"}),
+		), "fatal"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(orderedmap.Pair[string, string]{Key: "severity", Value: "CRITICAL"}),
+		), "fatal"},
 		// Equal confidence between two different levels -> unknown (don't guess).
 		{"saw info: here and error: there", "unknown"},
 		{"[INFO] [DEBUG] both bracketed", "unknown"},


### PR DESCRIPTION
Adds level detection for shapes that were coming back as unknown:

- logfmt style key/value pairs (level=info, lvl=WARN, severity: error) as
  emitted by slog, logrus, go-kit, Traefik, Grafana and containerd
- syslog priority prefixes (<11>Jan  1 ...) from systemd and rsyslog
- syslog severity names: notice, emerg, emergency, alert, panic
- numeric bunyan/pino levels in structured logs (10 trace through 60 fatal)
- more level keys (levelname, loglevel, lvl, severityText), matched
  case-insensitively and ignoring . _ - so Level, log.level, log_level and
  logLevel all resolve

Level keys are now collected in one pass and resolved in priority order, so
an unusable value on a high priority key falls through to the next key
instead of losing the level. Numbers only count on level style keys since a
number under severity is a syslog or OpenTelemetry severity, which counts
the other way around. "alert" doubles as an ordinary word, so it only
resolves in structured logs, bracketed tags and level keys.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018CRXbfAnaxKu7eh1UGd9gH