### PR TITLE
fix(logs): guess levels for "::INFO::" and signale style lines

### DIFF
--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -37,10 +37,11 @@ type levelMatcher struct {
 //
 //  1. ^<level>     start-of-line prefix: "ERROR: ...", "INF ...", "E0806 14:55:55.980915 ..."
 //  2. [<level>]    bracketed tag / single-letter: "[ERROR]", "[E]"
-//  3. <tag>:<level> structured prefix: "Zigbee2MQTT:info "
-//  4. "<LEVEL>"    quoted upper-case value: LL="ERROR"
-//  5. <sp><level>[/|:-] separator: " error:", " info|"
-//  6. <sp><LEVEL><sp> bare upper-case token mid-line: "123 ERROR foo"
+//  3. > <level>    signale/consola marker: "› ℹ  info      started"
+//  4. <tag>:<level> structured prefix: "Zigbee2MQTT:info ", "::INFO::"
+//  5. "<LEVEL>"    quoted upper-case value: LL="ERROR"
+//  6. <sp><level>[/|:-] separator: " error:", " info|"
+//  7. <sp><LEVEL><sp> bare upper-case token mid-line: "123 ERROR foo"
 //
 // guessFromString walks the tiers in order and stops at the first that matches,
 // so a real level prefix at the front of the line always beats a level word
@@ -62,7 +63,7 @@ var singleLetterBracket = regexp.MustCompile(`\[([EWIDFTV])\]`)
 // prose starting with a capital letter cannot match.
 var klogPrefix = regexp.MustCompile(`^([EWIDFTV])\d{4} \d{2}:\d{2}:\d{2}\.\d{6}`)
 
-var timestampRegex = regexp.MustCompile(`^(?:\d{4}[-/]\d{2}[-/]\d{2}(?:[T ](?:\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?|\d{2}:\d{2}(?:AM|PM)))?\s+)`)
+var timestampRegex = regexp.MustCompile(`^(?:\d{4}[-/]\d{2}[-/]\d{2}(?:[T ](?:\d{2}:\d{2}:\d{2}(?:[.,]\d+)?Z?|\d{2}:\d{2}(?:AM|PM)))?\s+)`)
 
 // JSON keys to check for log level (in priority order).
 var levelKeys = []string{"@l", "level", "log.level", "severity"}
@@ -94,7 +95,10 @@ func init() {
 			{re: regexp.MustCompile(`(?i)\[ ?(` + joined + `) ?\]`)},
 			{re: singleLetterBracket, single: true},
 		},
-		{{re: regexp.MustCompile(`(?i):(` + joined + `)\s`)}},
+		// Signale/consola: the level is the first word after the "›" marker. [^a-z]
+		// cannot cross a letter, so only that first word is considered.
+		{{re: regexp.MustCompile(`(?i)\x{203a}[^a-z]*(` + joined + `)(?:[^a-z]|$)`)}},
+		{{re: regexp.MustCompile(`(?i):(` + joined + `)(?:[^a-z]|$)`)}},
 		{{re: regexp.MustCompile(`"(` + upper + `)"`)}},
 		{{re: regexp.MustCompile(`(?i) (` + joined + `)[/|:-]`)}},
 		{{re: regexp.MustCompile(`\s(` + upper + `)\s`)}},

--- a/internal/container/level_guesser_test.go
+++ b/internal/container/level_guesser_test.go
@@ -102,6 +102,16 @@ func TestGuessLogLevel(t *testing.T) {
 		{"Zigbee2MQTT:info  2025-12-22 12:00:00: started", "info"},
 		{"Zigbee2MQTT:warn  2025-12-22 12:00:00: queue full", "warn"},
 		{"Zigbee2MQTT:error  2025-12-22 12:00:00: failure", "error"},
+		// SABnzbd-style: "::" delimited level after a comma-millis timestamp.
+		{"2026-08-22 21:29:25,119::INFO::[newswrapper:229] Connecting 1@news.newshosting.com finished", "info"},
+		{"2026-08-22 21:29:25,119::ERROR::[newswrapper:229] Connecting 1@news.newshosting.com failed", "error"},
+		{"2026-08-22 21:29:25,119::WARNING::[newswrapper:229] Connecting slowly", "warn"},
+		{"2026-08-22 21:29:25,119::DEBUG::[newswrapper:229] Connecting", "debug"},
+		// Nginx Proxy Manager / signale: "[tag] \u203a <symbol>  <level>  message".
+		{"[8/21/2026] [9:58:28 PM] [SSL      ] \u203a \u2139  info      Renewing SSL certs expiring within 30 days ...", "info"},
+		{"[8/22/2026] [12:58:28 AM] [Nginx    ] \u203a \u26a0  warning   Reloading Nginx", "warn"},
+		{"[8/22/2026] [12:58:28 AM] [SSL      ] \u203a \u2716  error     Renew failed", "error"},
+		{"[8/22/2026] [12:58:28 AM] [SSL      ] \u203a \u2139  info      Fetch failed with error: timeout", "info"},
 		// Pipe-delimited
 		{"2024-01-01 12:00:00 | ERROR | something went wrong", "error"},
 		{"2024-01-01 12:00:00 | INFO | starting up", "info"},


### PR DESCRIPTION
Two log formats were falling through to `unknown`.

**SABnzbd / python logging**

```
2026-08-22 21:29:25,119::INFO::[newswrapper:229] Connecting 1@news.newshosting.com finished
```

The `<tag>:<level>` tier required whitespace right after the level, so `::INFO::` never matched. It now accepts any non-letter delimiter.

**signale (Nginx Proxy Manager)**

```
[8/21/2026] [9:58:28 PM] [SSL      ] › ℹ  info      Renewing SSL certs expiring within 30 days ...
```

New tier that takes the first word after the `›` marker. The pattern can't cross a letter, so a level word later in the message can't be picked up by mistake.

Also lets the timestamp stripper handle comma milliseconds (`21:29:25,119`).

Tests added for both formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)