### PR TITLE
fix(ui): make copy logs work outside secure contexts

### DIFF
--- a/assets/components/ContainerViewer/ContainerActionsToolbar.vue
+++ b/assets/components/ContainerViewer/ContainerActionsToolbar.vue
@@ -266,37 +266,46 @@ async function copyLogs() {
     { once: true },
   );
 
-  const blobPromise = fetch(url, { headers: { Accept: "text/plain" } })
-    .then((response) => {
-      if (!response.ok) throw new Error(response.statusText);
-      return response.blob();
-    })
-    .then((blob) => {
-      removeToast(toastId);
-      showToast(
-        {
-          title: t("toasts.copied.title"),
-          message: t("toasts.copied.message"),
-          type: "info",
-        },
-        { expire: 2000 },
-      );
-      return blob;
-    })
-    .catch((err) => {
-      removeToast(toastId);
-      showToast(
-        {
-          title: "Error",
-          message: err.message,
-          type: "error",
-        },
-        { expire: 5000 },
-      );
-      throw err;
-    });
+  const fetchLogs = async () => {
+    const response = await fetch(url, { headers: { Accept: "text/plain" } });
+    if (!response.ok) throw new Error(response.statusText);
+    return await response.text();
+  };
 
-  await navigator.clipboard.write([new ClipboardItem({ "text/plain": blobPromise })]);
+  // navigator.clipboard is unavailable on insecure origins, which is how most people run Dozzle
+  const asyncClipboard = window.isSecureContext && typeof ClipboardItem !== "undefined" && !!navigator.clipboard?.write;
+
+  try {
+    if (asyncClipboard) {
+      // safari drops the user gesture if we await the fetch first, so hand write() a promise instead
+      // the response is "text/plain; charset=UTF-8" which some browsers reject as a clipboard type
+      const blob = fetchLogs().then((text) => new Blob([text], { type: "text/plain" }));
+      await navigator.clipboard.write([new ClipboardItem({ "text/plain": blob })]);
+    } else {
+      await copy(await fetchLogs());
+      if (!copied.value) throw new Error(t("error.copy-not-supported-hint"));
+    }
+
+    removeToast(toastId);
+    showToast(
+      {
+        title: t("toasts.copied.title"),
+        message: t("toasts.copied.message"),
+        type: "info",
+      },
+      { expire: 2000 },
+    );
+  } catch (err) {
+    removeToast(toastId);
+    showToast(
+      {
+        title: "Error",
+        message: err instanceof Error ? err.message : String(err),
+        type: "error",
+      },
+      { expire: 5000 },
+    );
+  }
 }
 
 onKeyStroke(["f", "F"], (e) => {


### PR DESCRIPTION
Copy logs silently failed in a few cases.

- `navigator.clipboard` doesn't exist on plain http origins, but `useClipboard({legacy: true})` still reports `isSupported` because of the execCommand fallback. The menu item showed up and then threw. Now falls back to `copy()` when the async clipboard API isn't there.
- The response is `text/plain; charset=UTF-8` while the ClipboardItem key was `text/plain`. Blob is re-wrapped with the exact type.
- The "copied" toast fired when the fetch resolved, not when the write finished, so a failed write still looked like a success. Toast moved after the write, errors now show a toast instead of only hitting the console.

Safari still gets the promise handed to `ClipboardItem` so the user gesture isn't lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)