### PR TITLE
fix(security)!: scope cloud search, alerts and debug to user labels, add notifications role

### DIFF
--- a/assets/components/Links.vue
+++ b/assets/components/Links.vue
@@ -4,6 +4,7 @@
     <Announcements />
 
     <router-link
+      v-if="config.enableNotifications"
       :to="{ name: '/notifications' }"
       :aria-label="$t('title.notifications')"
       data-testid="notifications"

--- a/assets/stores/config.ts
+++ b/assets/stores/config.ts
@@ -15,6 +15,7 @@ export interface Config {
   enableActions: boolean;
   enableShell: boolean;
   enableDownload: boolean;
+  enableNotifications: boolean;
   disableAvatars: boolean;
   releaseCheckMode: "automatic" | "manual";
   user?: {

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -176,8 +176,12 @@ Dozzle supports the following roles:
 - **shell** - allows attach and exec in the container
 - **actions** - allows performing container actions (start, stop, restart)
 - **download** - allows downloading container logs
+- **notifications** - allows creating and editing notification rules and destinations
 - **none** - denies all actions
 - **all** - allows all actions (default)
+
+> [!WARNING]
+> Notification rules are instance wide. A rule matches containers by expression, not by the user's filter, so a user with the `notifications` role can create a rule for containers their filter otherwise hides and receive those log lines at a destination they control. Only grant it to users you trust with every container on the instance.
 
 ## <Icon icon="mdi:file-document-edit-outline" inline /> Generating users.yml
 

--- a/internal/auth/roles.go
+++ b/internal/auth/roles.go
@@ -14,9 +14,10 @@ const (
 	Shell Role = 1 << iota
 	Actions
 	Download
+	Notifications
 )
 
-const All = Shell | Actions | Download
+const All = Shell | Actions | Download | Notifications
 
 // ParseRole parses a comma-separated string of roles and returns the corresponding Role.
 func ParseRole(input string) Role {
@@ -49,6 +50,8 @@ func ParseRole(input string) Role {
 			roles |= Actions
 		case "download", "dozzle_download":
 			roles |= Download
+		case "notifications", "dozzle_notifications":
+			roles |= Notifications
 		case "none", "dozzle_none":
 			return None
 		case "all", "dozzle_all":

--- a/internal/auth/roles_test.go
+++ b/internal/auth/roles_test.go
@@ -14,6 +14,9 @@ func TestParseRole(t *testing.T) {
 		{"Single shell role", "shell", Shell},
 		{"Single actions role", "actions", Actions},
 		{"Single download role", "download", Download},
+		{"Single notifications role", "notifications", Notifications},
+		{"Single dozzle_notifications role", "dozzle_notifications", Notifications},
+		{"All includes notifications", "all", Shell | Actions | Download | Notifications},
 		{"None role", "none", None},
 		{"All role", "all", All},
 

--- a/internal/web/cloud_alerts.go
+++ b/internal/web/cloud_alerts.go
@@ -63,6 +63,23 @@ func (h *handler) cloudAlerts(w http.ResponseWriter, r *http.Request) {
 		writeAlerts(w, &cloud.AlertResult{Hits: []cloud.AlertHit{}})
 		return
 	}
+	// The client picks which containers to ask about, so run the list through
+	// the caller's label scope before handing it to Cloud.
+	if h.restrictedUser(r) {
+		visible := h.visibleContainerIDs(r)
+		allowed := make([]string, 0, len(containerIDs))
+		for _, id := range containerIDs {
+			if _, ok := visible[id]; ok {
+				allowed = append(allowed, id)
+			}
+		}
+		if len(allowed) == 0 {
+			writeAlerts(w, &cloud.AlertResult{Hits: []cloud.AlertHit{}})
+			return
+		}
+		containerIDs = allowed
+	}
+
 	if len(containerIDs) > maxAlertContainers {
 		writeError(w, http.StatusBadRequest, "too many containerIds")
 		return

--- a/internal/web/cloud_search.go
+++ b/internal/web/cloud_search.go
@@ -25,11 +25,12 @@ const cloudSearchTimeout = 3 * time.Second
 // API key — this handler passes neither user nor instance ids.
 //
 // Status mapping:
-//   200 — hits returned (may be empty)
-//   204 — streamLogs is disabled; nothing to search
-//   503 — cloud not configured (no API key) or no SearchLogs func wired
-//   504 — cloud round-trip exceeded the search timeout
-//   502 — any other cloud-side error
+//
+//	200 — hits returned (may be empty)
+//	204 — streamLogs is disabled; nothing to search
+//	503 — cloud not configured (no API key) or no SearchLogs func wired
+//	504 — cloud round-trip exceeded the search timeout
+//	502 — any other cloud-side error
 func (h *handler) cloudSearchLogs(w http.ResponseWriter, r *http.Request) {
 	if h.config.Cloud.SearchLogs == nil {
 		writeError(w, http.StatusServiceUnavailable, "cloud not configured")
@@ -100,6 +101,21 @@ func (h *handler) cloudSearchLogs(w http.ResponseWriter, r *http.Request) {
 		log.Warn().Err(err).Msg("cloud search failed")
 		writeError(w, http.StatusBadGateway, "cloud search failed")
 		return
+	}
+
+	// Cloud scopes hits to the instance, not to the user. A label-restricted
+	// caller must not see lines from containers outside their scope, so drop
+	// anything the store wouldn't hand them. Fails closed: a container Cloud
+	// still has logs for but the store no longer knows about is dropped too.
+	if h.restrictedUser(r) && result != nil {
+		visible := h.visibleContainerIDs(r)
+		hits := make([]cloud.SearchLogHit, 0, len(result.Hits))
+		for _, hit := range result.Hits {
+			if _, ok := visible[hit.ContainerID]; ok {
+				hits = append(hits, hit)
+			}
+		}
+		result.Hits = hits
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/web/debug.go
+++ b/internal/web/debug.go
@@ -3,14 +3,12 @@ package web
 import (
 	"encoding/json"
 	"net/http"
-
-	"github.com/amir20/dozzle/internal/container"
 )
 
 func (h *handler) debugStore(w http.ResponseWriter, r *http.Request) {
 	respone := make(map[string]any)
 	respone["hosts"] = h.hostService.Hosts()
-	containers, errors := h.hostService.ListAllContainers(container.ContainerLabels{})
+	containers, errors := h.hostService.ListAllContainers(h.resolveLabels(r))
 	respone["containers"] = containers
 	respone["errors"] = errors
 

--- a/internal/web/index.go
+++ b/internal/web/index.go
@@ -76,11 +76,13 @@ func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
 		config["enableShell"] = h.config.EnableShell
 		config["enableActions"] = h.config.EnableActions
 		config["enableDownload"] = true
+		config["enableNotifications"] = true
 
 		if user != nil {
 			config["enableShell"] = h.config.EnableShell && user.Roles.Has(auth.Shell)
 			config["enableActions"] = h.config.EnableActions && user.Roles.Has(auth.Actions)
 			config["enableDownload"] = user.Roles.Has(auth.Download)
+			config["enableNotifications"] = user.Roles.Has(auth.Notifications)
 			config["user"] = user
 		}
 

--- a/internal/web/label_filter_test.go
+++ b/internal/web/label_filter_test.go
@@ -1,0 +1,145 @@
+package web
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/amir20/dozzle/internal/auth"
+	"github.com/amir20/dozzle/internal/cloud"
+	"github.com/amir20/dozzle/internal/container"
+	"github.com/amir20/dozzle/internal/notification"
+	docker_support "github.com/amir20/dozzle/internal/support/docker"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	devContainer  = container.Container{ID: "dev123", Name: "dev-allowed", State: "running", Labels: map[string]string{"env": "dev"}}
+	prodContainer = container.Container{ID: "prod456", Name: "prod-secret", State: "running", Labels: map[string]string{"env": "prod"}}
+	devLabels     = container.ContainerLabels{"env": []string{"dev"}}
+)
+
+// restrictedHandler wires a handler backed by two containers where the caller
+// may only see the dev one.
+func restrictedHandler(t *testing.T) *handler {
+	t.Helper()
+	client := new(MockedClient)
+	client.On("Host").Return(container.Host{ID: "localhost"})
+	client.On("ContainerEvents", mock.Anything, mock.AnythingOfType("chan<- container.ContainerEvent")).Return(nil)
+	client.On("ListContainers", mock.Anything, devLabels).Return([]container.Container{devContainer}, nil)
+	client.On("ListContainers", mock.Anything, mock.Anything).Return([]container.Container{devContainer, prodContainer}, nil)
+	client.On("FindContainer", mock.Anything, "dev123").Return(devContainer, nil)
+	client.On("FindContainer", mock.Anything, "prod456").Return(prodContainer, nil)
+	client.On("ContainerLogsBetweenDates", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(io.NopCloser(strings.NewReader("")), nil)
+
+	manager := docker_support.NewRetriableClientManager(nil, 3*time.Second, tls.Certificate{}, docker_support.NewDockerClientService(client, container.ContainerLabels{}))
+	return &handler{
+		hostService: docker_support.NewMultiHostService(manager, 3*time.Second),
+		config:      &Config{Base: "/", Authorization: Authorization{Provider: SIMPLE}},
+	}
+}
+
+// cloudLinkedService pretends cloud is linked without touching the persister.
+type cloudLinkedService struct {
+	HostService
+	cc *notification.CloudConfig
+}
+
+func (s *cloudLinkedService) CloudConfig() *notification.CloudConfig { return s.cc }
+
+func asRestrictedUser(r *http.Request) *http.Request {
+	return r.WithContext(auth.WithUser(context.Background(), auth.User{ContainerLabels: devLabels}))
+}
+
+func Test_debugStore_respects_user_labels(t *testing.T) {
+	h := restrictedHandler(t)
+	rr := httptest.NewRecorder()
+
+	h.debugStore(rr, asRestrictedUser(httptest.NewRequest(http.MethodGet, "/api/debug/store", nil)))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var body struct {
+		Containers []container.Container `json:"containers"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	require.Len(t, body.Containers, 1)
+	assert.Equal(t, "dev-allowed", body.Containers[0].Name)
+}
+
+func Test_cloudSearchLogs_drops_out_of_scope_hits(t *testing.T) {
+	h := restrictedHandler(t)
+	h.config.Cloud.SearchLogs = func(ctx context.Context, query string, limit int32, hostID, containerID string, before int64) (*cloud.SearchLogResult, error) {
+		return &cloud.SearchLogResult{Hits: []cloud.SearchLogHit{
+			{ContainerID: "dev123", ContainerName: "dev-allowed", Message: "hello"},
+			{ContainerID: "prod456", ContainerName: "prod-secret", Message: "password=hunter2"},
+		}}, nil
+	}
+	h.hostService = &cloudLinkedService{HostService: h.hostService, cc: &notification.CloudConfig{APIKey: "key"}}
+
+	rr := httptest.NewRecorder()
+	h.cloudSearchLogs(rr, asRestrictedUser(httptest.NewRequest(http.MethodGet, "/api/cloud/search/logs?q=password", nil)))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	var result cloud.SearchLogResult
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &result))
+	require.Len(t, result.Hits, 1, "out-of-scope log hits should be dropped")
+	assert.Equal(t, "dev123", result.Hits[0].ContainerID)
+}
+
+func Test_cloudAlerts_filters_requested_containers(t *testing.T) {
+	h := restrictedHandler(t)
+	var asked []string
+	h.config.Cloud.GetAlerts = func(ctx context.Context, containerIDs []string, hostID string, fromNs, toNs int64, limit int32, includeFollowUps, includeEvents bool) (*cloud.AlertResult, error) {
+		asked = containerIDs
+		return &cloud.AlertResult{Hits: []cloud.AlertHit{}}, nil
+	}
+
+	rr := httptest.NewRecorder()
+	h.cloudAlerts(rr, asRestrictedUser(httptest.NewRequest(http.MethodGet, "/api/cloud/alerts?containerIds=dev123,prod456&from=1&to=2", nil)))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, []string{"dev123"}, asked, "only in-scope container ids should reach cloud")
+}
+
+func Test_cloudAlerts_all_out_of_scope_returns_empty(t *testing.T) {
+	h := restrictedHandler(t)
+	called := false
+	h.config.Cloud.GetAlerts = func(ctx context.Context, containerIDs []string, hostID string, fromNs, toNs int64, limit int32, includeFollowUps, includeEvents bool) (*cloud.AlertResult, error) {
+		called = true
+		return &cloud.AlertResult{Hits: []cloud.AlertHit{{AlertID: "leak"}}}, nil
+	}
+
+	rr := httptest.NewRecorder()
+	h.cloudAlerts(rr, asRestrictedUser(httptest.NewRequest(http.MethodGet, "/api/cloud/alerts?containerIds=prod456&from=1&to=2", nil)))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	assert.False(t, called, "cloud should not be queried for out-of-scope containers")
+	assert.NotContains(t, rr.Body.String(), "leak")
+}
+
+func Test_requireNotificationsRole(t *testing.T) {
+	h := restrictedHandler(t)
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) })
+
+	serve := func(user auth.User) int {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/notifications/rules", nil).
+			WithContext(auth.WithUser(context.Background(), user))
+		h.requireNotificationsRole(next).ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	assert.Equal(t, http.StatusForbidden, serve(auth.User{Roles: auth.Download}))
+	assert.Equal(t, http.StatusTeapot, serve(auth.User{Roles: auth.Notifications}))
+	// Unset roles parse to All, which is what a user with only a filter gets.
+	assert.Equal(t, http.StatusTeapot, serve(auth.User{Roles: auth.All, ContainerLabels: devLabels}))
+}

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -69,6 +69,28 @@ func (h *handler) resolveLabels(r *http.Request) container.ContainerLabels {
 	return labels
 }
 
+// restrictedUser reports whether the caller is confined by a per-user label
+// filter. The global --filter applies to everyone, so it doesn't count.
+func (h *handler) restrictedUser(r *http.Request) bool {
+	if h.config.Authorization.Provider == NONE {
+		return false
+	}
+	user := auth.UserFromContext(r.Context())
+	return user != nil && user.ContainerLabels.Exists()
+}
+
+// visibleContainerIDs returns the set of container ids the caller may see.
+// Used by handlers that receive container ids from the client (or get them
+// back from Cloud) and have no other way to run them through the store's ACL.
+func (h *handler) visibleContainerIDs(r *http.Request) map[string]struct{} {
+	containers, _ := h.hostService.ListAllContainers(h.resolveLabels(r))
+	ids := make(map[string]struct{}, len(containers))
+	for _, c := range containers {
+		ids[c.ID] = struct{}{}
+	}
+	return ids
+}
+
 func (h *handler) fetchLogsBetweenDates(w http.ResponseWriter, r *http.Request) {
 	plainText := strings.Contains(r.Header.Get("Accept"), "text/plain")
 	if plainText {

--- a/internal/web/notifications.go
+++ b/internal/web/notifications.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/amir20/dozzle/internal/auth"
 	"github.com/amir20/dozzle/internal/cache"
 	"github.com/amir20/dozzle/internal/container"
 	"github.com/amir20/dozzle/internal/notification"
@@ -500,6 +501,24 @@ func (h *handler) deleteDispatcher(w http.ResponseWriter, r *http.Request) {
 
 	h.hostService.RemoveDispatcher(id)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// requireNotificationsRole gates the notification rule and dispatcher APIs.
+// Rules stream log lines from whatever containers their expression matches and
+// dispatchers hold the destinations (and their secrets), neither of which is
+// scoped per user, so this is a role rather than a label check.
+func (h *handler) requireNotificationsRole(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if h.config.Authorization.Provider != NONE {
+			user := auth.UserFromContext(r.Context())
+			if user == nil || !user.Roles.Has(auth.Notifications) {
+				log.Warn().Msg("user is not permitted to manage notifications")
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // Preview and test handlers

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -193,6 +193,7 @@ func createRouter(h *handler) *chi.Mux {
 
 				// Notifications API
 				r.Route("/notifications", func(r chi.Router) {
+					r.Use(h.requireNotificationsRole)
 					r.Get("/rules", h.listNotificationRules)
 					r.Post("/rules", h.createNotificationRule)
 					r.Get("/rules/{id}", h.getNotificationRule)


### PR DESCRIPTION
Stacked on #4950. Audit of every label-sensitive path in `internal/web` turned up four more spots that ignore per-user container filters.

- `debug.go` listed every container on every host with an empty filter. Now uses `h.resolveLabels(r)`. Only mounted at debug level, but same bug.
- `GET /api/cloud/search/logs` returned hits with full log lines for any container in the instance. Hits outside the caller's scope are dropped.
- `GET /api/cloud/alerts` took `containerIds` straight from the client with no ACL check. Ids are intersected with the caller's scope, and an all-out-of-scope request returns empty without hitting cloud.
- Notification rules and dispatchers are instance-wide. Any authenticated user could write a rule matching containers their filter hides, aim it at a webhook they control, and read those log lines, and `listDispatchers` handed out every destination including its secrets.

For notifications this adds a `notifications` role next to `shell`/`actions`/`download`. It's part of `all`, so users with no `roles:` line keep access exactly as today. Rules and dispatchers 403 without it, and the bell is hidden via a new `enableNotifications` config flag.

The role does not make rules label-scoped, it just decides who can write them. Docs carry a warning that granting it to a filtered user lets them reach containers their filter hides. Per-rule scoping (owner + filter on the subscription, carried to agents in the proto) is a follow-up.

Two new helpers next to `resolveLabels`: `restrictedUser` (per-user filter, ignores the global `--filter` since that applies to everyone) and `visibleContainerIDs`.

Tests cover all four, including that cloud is never queried when every requested container is out of scope, and that unset roles still get notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)