### PR TITLE
feat(notifications): add a pattern-keyed cooldown for log alerts

### DIFF
--- a/internal/notification/config.go
+++ b/internal/notification/config.go
@@ -160,6 +160,17 @@ func (m *Manager) HandleNotificationConfig(subscriptions []types.SubscriptionCon
 				})
 			}
 
+			// Carry open log suppression windows across the reload. Dropping them
+			// would make every pattern look new again and re-dispatch a line we
+			// already sent, and would lose the repeats counted so far.
+			s.LogCooldowns = xsync.NewMap[string, *logWindow]()
+			if old.LogCooldowns != nil {
+				old.LogCooldowns.Range(func(key string, w *logWindow) bool {
+					s.LogCooldowns.Store(key, w)
+					return true
+				})
+			}
+
 			// MetricSampleBuffers: start fresh since ring buffers can't be safely cloned
 		}
 
@@ -220,6 +231,9 @@ func (m *Manager) loadSubscription(sub *Subscription) error {
 	}
 	if sub.EventCooldowns == nil {
 		sub.EventCooldowns = xsync.NewMap[string, time.Time]()
+	}
+	if sub.LogCooldowns == nil {
+		sub.LogCooldowns = xsync.NewMap[string, *logWindow]()
 	}
 
 	m.subscriptions.Store(sub.ID, sub)

--- a/internal/notification/log_cooldown_test.go
+++ b/internal/notification/log_cooldown_test.go
@@ -1,0 +1,196 @@
+package notification
+
+import (
+	"testing"
+	"time"
+
+	"github.com/amir20/dozzle/types"
+	"github.com/puzpuzpuz/xsync/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func logCooldownSub(cooldown int) *Subscription {
+	return &Subscription{Cooldown: cooldown, LogCooldowns: xsync.NewMap[string, *logWindow]()}
+}
+
+func containerFixture(id string) types.NotificationContainer {
+	return types.NotificationContainer{ID: id, Name: "app-" + id}
+}
+
+func logFixture(message string) types.NotificationLog {
+	return types.NotificationLog{Message: message, Level: "error"}
+}
+
+func TestRecordLogMatch_FirstSightingDispatches(t *testing.T) {
+	sub := logCooldownSub(300)
+	c := containerFixture("c1")
+
+	assert.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+}
+
+func TestRecordLogMatch_RepeatIsSuppressed(t *testing.T) {
+	sub := logCooldownSub(300)
+	c := containerFixture("c1")
+
+	require.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	assert.False(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	assert.False(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+}
+
+func TestRecordLogMatch_VaryingTokensCollapseToOnePattern(t *testing.T) {
+	// Same failure, different IP each time. This is the case the cooldown exists
+	// for: it is one incident, not three.
+	sub := logCooldownSub(300)
+	c := containerFixture("c1")
+
+	require.True(t, sub.RecordLogMatch(c, logFixture("Connection refused to database at 10.0.0.5:5432")))
+	assert.False(t, sub.RecordLogMatch(c, logFixture("Connection refused to database at 192.168.1.1:5432")))
+}
+
+func TestRecordLogMatch_DifferentErrorSameContainerStillDispatches(t *testing.T) {
+	// The property that makes a pattern-keyed cooldown safe. A per-container
+	// cooldown would swallow the second line and Cloud would never learn the
+	// app fell over.
+	sub := logCooldownSub(300)
+	c := containerFixture("c1")
+
+	require.True(t, sub.RecordLogMatch(c, logFixture("FATAL: could not extend file: No space left on device")))
+	assert.True(t, sub.RecordLogMatch(c, logFixture("FATAL: connection refused")))
+}
+
+func TestRecordLogMatch_SamePatternDifferentContainersBothDispatch(t *testing.T) {
+	sub := logCooldownSub(300)
+
+	require.True(t, sub.RecordLogMatch(containerFixture("c1"), logFixture("connection refused")))
+	assert.True(t, sub.RecordLogMatch(containerFixture("c2"), logFixture("connection refused")))
+}
+
+func TestRecordLogMatch_NoCooldownAlwaysDispatches(t *testing.T) {
+	// Existing rules all carry cooldown 0 and must keep behaving exactly as before.
+	sub := logCooldownSub(0)
+	c := containerFixture("c1")
+
+	assert.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	assert.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+}
+
+func TestRecordLogMatch_EmptyMessageDispatches(t *testing.T) {
+	sub := logCooldownSub(300)
+	c := containerFixture("c1")
+
+	assert.True(t, sub.RecordLogMatch(c, logFixture("")))
+	assert.True(t, sub.RecordLogMatch(c, logFixture("")))
+}
+
+func TestRecordLogMatch_FailsOpenPastPatternLimit(t *testing.T) {
+	sub := logCooldownSub(300)
+	c := containerFixture("c1")
+
+	for i := range maxTrackedLogPatterns {
+		require.True(t, sub.RecordLogMatch(c, logFixture("unique failure "+lettersFor(i))))
+	}
+
+	// Map is full: a new pattern is dispatched rather than tracked, and repeats
+	// of it are dispatched too, because we would not be able to account for them.
+	assert.True(t, sub.RecordLogMatch(c, logFixture("brand new failure mode")))
+	assert.True(t, sub.RecordLogMatch(c, logFixture("brand new failure mode")))
+	assert.Equal(t, maxTrackedLogPatterns, sub.LogCooldowns.Size())
+}
+
+func TestCollectLogRollups_NothingWhileWindowOpen(t *testing.T) {
+	sub := logCooldownSub(300)
+	c := containerFixture("c1")
+
+	require.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	sub.RecordLogMatch(c, logFixture("connection refused"))
+
+	assert.Empty(t, sub.CollectLogRollups())
+}
+
+func TestCollectLogRollups_EmitsCountWhenWindowCloses(t *testing.T) {
+	sub := logCooldownSub(1)
+	c := containerFixture("c1")
+
+	require.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	for range 4 {
+		sub.RecordLogMatch(c, logFixture("connection refused"))
+	}
+
+	expireLogWindows(sub)
+
+	rollups := sub.CollectLogRollups()
+	require.Len(t, rollups, 1)
+	assert.Equal(t, int64(4), rollups[0].Count)
+	assert.Equal(t, "c1", rollups[0].Container.ID)
+	assert.Equal(t, "connection refused", rollups[0].Log.Message)
+}
+
+func TestCollectLogRollups_QuietWindowIsDroppedAndPatternIsNewsAgain(t *testing.T) {
+	sub := logCooldownSub(1)
+	c := containerFixture("c1")
+
+	require.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	expireLogWindows(sub)
+
+	assert.Empty(t, sub.CollectLogRollups())
+	assert.Zero(t, sub.LogCooldowns.Size())
+	assert.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+}
+
+func TestCollectLogRollups_OngoingPatternCostsOneNotificationPerWindow(t *testing.T) {
+	sub := logCooldownSub(1)
+	c := containerFixture("c1")
+
+	require.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	sub.RecordLogMatch(c, logFixture("connection refused"))
+	expireLogWindows(sub)
+	require.Len(t, sub.CollectLogRollups(), 1)
+
+	// Window was reset, not deleted: still suppressing, and the next close
+	// reports only the repeats seen since.
+	assert.False(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	expireLogWindows(sub)
+	rollups := sub.CollectLogRollups()
+	require.Len(t, rollups, 1)
+	assert.Equal(t, int64(1), rollups[0].Count)
+}
+
+func TestCollectLogRollups_CapFlushesBeforeWindowCloses(t *testing.T) {
+	sub := logCooldownSub(3600)
+	c := containerFixture("c1")
+
+	require.True(t, sub.RecordLogMatch(c, logFixture("connection refused")))
+	for range maxSuppressedPerWindow {
+		sub.RecordLogMatch(c, logFixture("connection refused"))
+	}
+
+	rollups := sub.CollectLogRollups()
+	require.Len(t, rollups, 1)
+	assert.Equal(t, int64(maxSuppressedPerWindow), rollups[0].Count)
+}
+
+// lettersFor builds a distinct all-letter token, so pattern extraction keeps it
+// verbatim instead of shaping digits into a placeholder and collapsing them.
+func lettersFor(n int) string {
+	var b []byte
+	for {
+		b = append([]byte{byte('a' + n%26)}, b...)
+		n /= 26
+		if n == 0 {
+			return string(b)
+		}
+		n--
+	}
+}
+
+// expireLogWindows backdates every open window so the next collection treats it
+// as closed, without making the test wait out a real cooldown.
+func expireLogWindows(sub *Subscription) {
+	sub.LogCooldowns.Range(func(_ string, w *logWindow) bool {
+		w.mu.Lock()
+		w.openedAt = w.openedAt.Add(-time.Hour)
+		w.mu.Unlock()
+		return true
+	})
+}

--- a/internal/notification/manager.go
+++ b/internal/notification/manager.go
@@ -55,6 +55,9 @@ func NewManager(listener *ContainerLogListener, statsListener *ContainerStatsLis
 	// Start processing Docker events from the event listener
 	go m.processDockerEvents()
 
+	// Start flushing suppressed log rollups
+	go m.flushLogWindows()
+
 	return m
 }
 
@@ -88,6 +91,7 @@ func (m *Manager) AddSubscription(sub *Subscription) error {
 	sub.MetricCooldowns = xsync.NewMap[string, time.Time]()
 	sub.MetricSampleBuffers = xsync.NewMap[string, *utils.RingBuffer[bool]]()
 	sub.EventCooldowns = xsync.NewMap[string, time.Time]()
+	sub.LogCooldowns = xsync.NewMap[string, *logWindow]()
 
 	if err := sub.CompileExpressions(); err != nil {
 		return err
@@ -115,6 +119,7 @@ func (m *Manager) ReplaceSubscription(sub *Subscription) error {
 	sub.MetricCooldowns = xsync.NewMap[string, time.Time]()
 	sub.MetricSampleBuffers = xsync.NewMap[string, *utils.RingBuffer[bool]]()
 	sub.EventCooldowns = xsync.NewMap[string, time.Time]()
+	sub.LogCooldowns = xsync.NewMap[string, *logWindow]()
 
 	if err := sub.CompileExpressions(); err != nil {
 		return err
@@ -146,23 +151,24 @@ func (m *Manager) UpdateSubscription(id int, updates map[string]any) error {
 
 		// Clone the subscription
 		updated := &Subscription{
-			ID:                  sub.ID,
-			Name:                sub.Name,
-			Enabled:             sub.Enabled,
-			DispatcherID:        sub.DispatcherID,
-			ContainerExpression: sub.ContainerExpression,
-			ContainerProgram:    sub.ContainerProgram,
-			LogExpression:       sub.LogExpression,
-			LogProgram:          sub.LogProgram,
-			MetricExpression:    sub.MetricExpression,
-			MetricProgram:       sub.MetricProgram,
-			EventExpression:     sub.EventExpression,
-			EventProgram:        sub.EventProgram,
-			EventCooldowns:      sub.EventCooldowns,
-			Cooldown:            sub.Cooldown,
-			SampleWindow:        sub.SampleWindow,
-			MetricCooldowns:     sub.MetricCooldowns,
-			MetricSampleBuffers: sub.MetricSampleBuffers,
+			ID:                    sub.ID,
+			Name:                  sub.Name,
+			Enabled:               sub.Enabled,
+			DispatcherID:          sub.DispatcherID,
+			ContainerExpression:   sub.ContainerExpression,
+			ContainerProgram:      sub.ContainerProgram,
+			LogExpression:         sub.LogExpression,
+			LogProgram:            sub.LogProgram,
+			MetricExpression:      sub.MetricExpression,
+			MetricProgram:         sub.MetricProgram,
+			EventExpression:       sub.EventExpression,
+			EventProgram:          sub.EventProgram,
+			EventCooldowns:        sub.EventCooldowns,
+			LogCooldowns:          sub.LogCooldowns,
+			Cooldown:              sub.Cooldown,
+			SampleWindow:          sub.SampleWindow,
+			MetricCooldowns:       sub.MetricCooldowns,
+			MetricSampleBuffers:   sub.MetricSampleBuffers,
 			TriggeredContainerIDs: sub.TriggeredContainerIDs,
 		}
 
@@ -344,7 +350,6 @@ func (m *Manager) ResetCloudDispatcherBreaker() {
 		}
 	}
 }
-
 
 // getDispatcher resolves a dispatcher by subscription's DispatcherID.
 // DispatcherID == 0 means the cloud dispatcher; otherwise lookup in the dispatchers map.

--- a/internal/notification/pattern.go
+++ b/internal/notification/pattern.go
@@ -1,0 +1,158 @@
+package notification
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Log pattern extraction, kept byte-for-byte in sync with Dozzle Cloud's
+// api/internal/pattern package. Both sides must derive the same pattern from the
+// same line: the client uses it to collapse a repeating log into one notification
+// plus a suppressed count, and the server uses it to group notifications into
+// incidents. If the two implementations drift, a client-side rollup and the
+// server's own grouping stop lining up. Change them together.
+
+// tokenShape converts a token to its canonical shape for pattern matching.
+// Short tokens (≤2 chars) are preserved as-is.
+// Numeric-only tokens become <n>.
+// Timestamp-like tokens (numbers with /, :, ., -) become <ts>.
+// Alphanumeric tokens that look like IDs become <id>.
+// Very long tokens become <v>.
+func tokenShape(token string) string {
+	runeCount := 0
+	hasLetter := false
+	hasDigit := false
+	hasSpecial := false
+
+	for _, r := range token {
+		runeCount++
+		switch {
+		case unicode.IsLetter(r):
+			hasLetter = true
+		case unicode.IsDigit(r):
+			hasDigit = true
+		case r == '-' || r == '_' || r == ':' || r == '/' || r == '.':
+			hasSpecial = true
+		}
+	}
+
+	if runeCount <= 2 {
+		return token
+	}
+
+	switch {
+	case !hasLetter && hasDigit && hasSpecial:
+		return "<ts>" // "1/22/2026", "10:30:45", "192.168.1.1"
+	case !hasLetter && hasDigit:
+		return "<n>" // "12345"
+	case hasLetter && hasDigit && runeCount > 8:
+		return "<id>" // UUIDs, hashes, etc.
+	case hasLetter && hasDigit && hasSpecial:
+		return "<id>" // Mixed alphanumeric with special chars
+	case runeCount > 32:
+		return "<v>" // Very long values
+	default:
+		return token
+	}
+}
+
+// ExtractPattern takes a log message and returns its pattern by tokenizing
+// and replacing variable parts with placeholders.
+func ExtractPattern(message string) string {
+	if message == "" {
+		return ""
+	}
+
+	tokens := tokenize(message)
+	result := make([]string, len(tokens))
+
+	for i, token := range tokens {
+		result[i] = tokenShape(token)
+	}
+
+	return strings.Join(result, " ")
+}
+
+// tokenize splits a log message into tokens, preserving punctuation as separate tokens
+// where appropriate for pattern matching.
+func tokenize(message string) []string {
+	var tokens []string
+	var current strings.Builder
+
+	flush := func() {
+		if current.Len() > 0 {
+			tokens = append(tokens, current.String())
+			current.Reset()
+		}
+	}
+
+	for _, r := range message {
+		switch {
+		case unicode.IsSpace(r):
+			flush()
+		case r == '[' || r == ']' || r == '(' || r == ')' || r == '{' || r == '}':
+			// Brackets are separate tokens
+			flush()
+			tokens = append(tokens, string(r))
+		case r == '=' || r == ',' || r == ';':
+			// Key-value separators are separate tokens
+			flush()
+			tokens = append(tokens, string(r))
+		default:
+			current.WriteRune(r)
+		}
+	}
+	flush()
+
+	return tokens
+}
+
+// HashPattern returns the stable hash used to key a pattern. Matches the
+// server's hashing so the same line produces the same key on both sides.
+func HashPattern(pattern string) string {
+	if pattern == "" {
+		return ""
+	}
+	h := sha256.Sum256([]byte(pattern))
+	return hex.EncodeToString(h[:])
+}
+
+// MessageText flattens a NotificationLog message into the plain text that
+// pattern extraction runs on. Messages arrive as a string for simple and
+// grouped logs, or as a map for structured (JSON) logs.
+func MessageText(msg any) string {
+	if msg == nil {
+		return ""
+	}
+	switch v := msg.(type) {
+	case string:
+		return v
+	case []any:
+		parts := make([]string, len(v))
+		for i, elem := range v {
+			switch e := elem.(type) {
+			case string:
+				parts[i] = e
+			case map[string]any:
+				if m, ok := e["m"]; ok {
+					parts[i] = fmt.Sprintf("%v", m)
+				} else {
+					parts[i] = fmt.Sprintf("%v", e)
+				}
+			default:
+				parts[i] = fmt.Sprintf("%v", elem)
+			}
+		}
+		return strings.Join(parts, "\n")
+	case map[string]any:
+		for _, key := range []string{"message", "msg", "text", "log"} {
+			if val, ok := v[key]; ok {
+				return fmt.Sprintf("%v", val)
+			}
+		}
+	}
+	return fmt.Sprintf("%v", msg)
+}

--- a/internal/notification/pattern_test.go
+++ b/internal/notification/pattern_test.go
@@ -1,0 +1,264 @@
+package notification
+
+import (
+	"testing"
+)
+
+// These cases are ported from Dozzle Cloud's api/internal/pattern package and
+// must keep passing identically on both sides. See pattern.go.
+
+func TestTokenShape(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Short tokens (≤2 chars) preserved
+		{"short token - single char", "a", "a"},
+		{"short token - two chars", "ab", "ab"},
+		{"short token - number", "12", "12"},
+
+		// Numeric tokens
+		{"pure number", "12345", "<n>"},
+		{"port number", "8080", "<n>"},
+
+		// Timestamp-like tokens
+		{"date format", "1/22/2026", "<ts>"},
+		{"time format", "10:30:45", "<ts>"},
+		{"ip address", "192.168.1.1", "<ts>"},
+		{"datetime", "2024-01-15", "<ts>"},
+
+		// ID-like tokens
+		{"uuid", "550e8400-e29b-41d4-a716-446655440000", "<id>"},
+		{"short hash", "abc123def", "<id>"},
+		{"container id", "web-server-1234abcd", "<id>"},
+
+		// Long values
+		{"very long string", "this-is-a-very-long-string-that-exceeds-thirty-two-characters", "<v>"},
+
+		// Regular words preserved
+		{"word", "error", "error"},
+		{"uppercase word", "ERROR", "ERROR"},
+		{"mixed case", "Warning", "Warning"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tokenShape(tt.input)
+			if result != tt.expected {
+				t.Errorf("tokenShape(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "simple message",
+			input:    "Connection refused",
+			expected: "Connection refused",
+		},
+		{
+			name:     "message with port",
+			input:    "Listening on port 8080",
+			expected: "Listening on port <n>",
+		},
+		{
+			name:     "message with ip and port",
+			input:    "Connected to 192.168.1.100:5432",
+			expected: "Connected to <ts>",
+		},
+		{
+			name:     "log with timestamp",
+			input:    "[2024-01-15 10:30:45] Error occurred",
+			expected: "[ <ts> <ts> ] Error occurred",
+		},
+		{
+			name:     "key-value pairs",
+			input:    "user=admin action=login status=success",
+			expected: "user = admin action = login status = success",
+		},
+		{
+			name:     "message with container id",
+			input:    "Container abc123def456 started",
+			expected: "Container <id> started",
+		},
+		{
+			name:     "bracketed content",
+			input:    "[INFO] Starting service",
+			expected: "[ INFO ] Starting service",
+		},
+		{
+			name:     "parenthetical content",
+			input:    "Error (code 500) occurred",
+			expected: "Error ( code <n> ) occurred",
+		},
+		{
+			name:     "comma separated values",
+			input:    "hosts: server1, server2, server3",
+			expected: "hosts: server1 , server2 , server3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExtractPattern(tt.input)
+			if result != tt.expected {
+				t.Errorf("ExtractPattern(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractPattern_SimilarLogsProduceSamePattern(t *testing.T) {
+	// These log messages should all produce the same pattern
+	logs := []string{
+		"Connection refused to database at 10.0.0.5:5432",
+		"Connection refused to database at 192.168.1.1:5432",
+		"Connection refused to database at 172.16.0.100:5432",
+	}
+
+	var patterns []string
+	for _, log := range logs {
+		patterns = append(patterns, ExtractPattern(log))
+	}
+
+	for i := 1; i < len(patterns); i++ {
+		if patterns[i] != patterns[0] {
+			t.Errorf("Expected same pattern for similar logs\nLog 0: %q -> %q\nLog %d: %q -> %q",
+				logs[0], patterns[0], i, logs[i], patterns[i])
+		}
+	}
+}
+
+func TestExtractPattern_DifferentErrorsProduceDifferentPatterns(t *testing.T) {
+	// Two failures from the same container must not collapse into one pattern,
+	// or the cooldown would suppress the second one and Cloud would never see it.
+	a := ExtractPattern("FATAL: could not extend file: No space left on device")
+	b := ExtractPattern("FATAL: connection refused")
+
+	if a == b {
+		t.Errorf("expected distinct patterns, both were %q", a)
+	}
+	if HashPattern(a) == HashPattern(b) {
+		t.Error("expected distinct pattern hashes")
+	}
+}
+
+func TestHashPattern(t *testing.T) {
+	if got := HashPattern(""); got != "" {
+		t.Errorf("HashPattern(\"\") = %q, want empty", got)
+	}
+
+	a := HashPattern("Connection refused")
+	if len(a) != 64 {
+		t.Errorf("HashPattern returned %d chars, want 64", len(a))
+	}
+	if b := HashPattern("Connection refused"); a != b {
+		t.Error("HashPattern is not stable across calls")
+	}
+}
+
+func TestMessageText(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{"nil", nil, ""},
+		{"string", "connection refused", "connection refused"},
+		{"grouped strings", []any{"line one", "line two"}, "line one\nline two"},
+		{"grouped fragments", []any{map[string]any{"m": "line one"}}, "line one"},
+		{"structured message", map[string]any{"message": "disk full"}, "disk full"},
+		{"structured msg", map[string]any{"msg": "disk full"}, "disk full"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := MessageText(tt.input); got != tt.expected {
+				t.Errorf("MessageText(%v) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTokenize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "simple words",
+			input:    "hello world",
+			expected: []string{"hello", "world"},
+		},
+		{
+			name:     "with brackets",
+			input:    "[INFO] message",
+			expected: []string{"[", "INFO", "]", "message"},
+		},
+		{
+			name:     "with parentheses",
+			input:    "func(arg)",
+			expected: []string{"func", "(", "arg", ")"},
+		},
+		{
+			name:     "with curly braces",
+			input:    "{key: value}",
+			expected: []string{"{", "key:", "value", "}"},
+		},
+		{
+			name:     "with equals",
+			input:    "key=value",
+			expected: []string{"key", "=", "value"},
+		},
+		{
+			name:     "with commas",
+			input:    "a, b, c",
+			expected: []string{"a", ",", "b", ",", "c"},
+		},
+		{
+			name:     "with semicolons",
+			input:    "a; b; c",
+			expected: []string{"a", ";", "b", ";", "c"},
+		},
+		{
+			name:     "multiple spaces",
+			input:    "hello    world",
+			expected: []string{"hello", "world"},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tokenize(tt.input)
+			if len(result) != len(tt.expected) {
+				t.Errorf("tokenize(%q) returned %d tokens, want %d\ngot: %v\nwant: %v",
+					tt.input, len(result), len(tt.expected), result, tt.expected)
+				return
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("tokenize(%q)[%d] = %q, want %q",
+						tt.input, i, result[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/notification/processing.go
+++ b/internal/notification/processing.go
@@ -63,7 +63,9 @@ func (m *Manager) processLogEvent(logEvent *container.LogEvent) {
 			return true
 		}
 
-		// Update stats
+		// Update stats. Suppressed lines still count here: the rule really did
+		// match, and hiding repeats would understate exactly the noisy case the
+		// user needs to see.
 		sub.AddTriggeredContainer(notificationContainer.ID)
 		sub.TriggerCount.Add(1)
 		now := time.Now()
@@ -71,28 +73,13 @@ func (m *Manager) processLogEvent(logEvent *container.LogEvent) {
 
 		log.Debug().Str("containerID", notificationContainer.ID).Interface("log", notificationLog.Message).Msg("Matched subscription")
 
-		// Create notification
-		notification := types.Notification{
-			ID:        fmt.Sprintf("%s-%d", c.ID, time.Now().UnixNano()),
-			Type:      types.LogNotification,
-			Detail:    formatLogMessage(notificationLog.Message),
-			Container: notificationContainer,
-			Log:       &notificationLog,
-			Subscription: types.SubscriptionConfig{
-				ID:                  sub.ID,
-				Name:                sub.Name,
-				Enabled:             sub.Enabled,
-				DispatcherID:        sub.DispatcherID,
-				LogExpression:       sub.LogExpression,
-				ContainerExpression: sub.ContainerExpression,
-			},
-			Timestamp: time.Now(),
+		// Hold back repeats of a line we already reported. A different pattern,
+		// even on the same container, opens its own window and goes out now.
+		if !sub.RecordLogMatch(notificationContainer, notificationLog) {
+			return true
 		}
 
-		// Send to the subscription's dispatcher
-		if d, ok := m.getDispatcher(sub.DispatcherID); ok {
-			go m.sendNotification(d, notification, sub.DispatcherID)
-		}
+		m.dispatchLogNotification(sub, notificationContainer, notificationLog, 0)
 		return true
 	})
 }
@@ -310,5 +297,59 @@ func (m *Manager) sendNotification(d dispatcher.Dispatcher, notification types.N
 
 	if err := d.Send(ctx, notification); err != nil {
 		log.Error().Err(err).Int("subscription", id).Msg("Failed to send notification")
+	}
+}
+
+// dispatchLogNotification sends one log notification for a subscription.
+// suppressedCount is the number of identical lines collapsed into this one:
+// zero for a first sighting, non-zero for a rollup closing a cooldown window.
+func (m *Manager) dispatchLogNotification(sub *Subscription, c types.NotificationContainer, l types.NotificationLog, suppressedCount int64) {
+	notification := types.Notification{
+		ID:        fmt.Sprintf("%s-%d", c.ID, time.Now().UnixNano()),
+		Type:      types.LogNotification,
+		Detail:    formatLogMessage(l.Message),
+		Container: c,
+		Log:       &l,
+		Subscription: types.SubscriptionConfig{
+			ID:                  sub.ID,
+			Name:                sub.Name,
+			Enabled:             sub.Enabled,
+			DispatcherID:        sub.DispatcherID,
+			LogExpression:       sub.LogExpression,
+			ContainerExpression: sub.ContainerExpression,
+			Cooldown:            sub.Cooldown,
+		},
+		Timestamp:       time.Now(),
+		SuppressedCount: suppressedCount,
+	}
+
+	if d, ok := m.getDispatcher(sub.DispatcherID); ok {
+		go m.sendNotification(d, notification, sub.DispatcherID)
+	}
+}
+
+// flushLogWindows periodically closes expired log suppression windows and sends
+// the rollups they accumulated.
+func (m *Manager) flushLogWindows() {
+	ticker := time.NewTicker(logWindowSweepInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.subscriptions.Range(func(_ int, sub *Subscription) bool {
+				for _, rollup := range sub.CollectLogRollups() {
+					log.Debug().
+						Str("containerID", rollup.Container.ID).
+						Str("subscription", sub.Name).
+						Int64("suppressed", rollup.Count).
+						Msg("Flushing suppressed log rollup")
+					m.dispatchLogNotification(sub, rollup.Container, rollup.Log, rollup.Count)
+				}
+				return true
+			})
+		}
 	}
 }

--- a/internal/notification/types.go
+++ b/internal/notification/types.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -145,6 +146,11 @@ type Subscription struct {
 
 	// Per-container cooldown tracking for event alerts (containerID -> last triggered time)
 	EventCooldowns *xsync.Map[string, time.Time] `json:"-" yaml:"-"`
+
+	// Open log suppression windows, keyed by container ID + log pattern hash.
+	// Keyed on the pattern rather than the container so a different error from
+	// the same container is never suppressed. See RecordLogMatch.
+	LogCooldowns *xsync.Map[string, *logWindow] `json:"-" yaml:"-"`
 
 	// Per-container sample buffers for windowed metric evaluation (containerID -> ring buffer of match results)
 	MetricSampleBuffers *xsync.Map[string, *utils.RingBuffer[bool]] `json:"-" yaml:"-"`
@@ -389,4 +395,147 @@ func (s *Subscription) RecordMetricSample(containerID string, matched bool) bool
 	}
 
 	return float64(trueCount)/float64(buf.Len()) >= 0.8
+}
+
+const (
+	// maxSuppressedPerWindow forces a rollup out early once this many repeats
+	// have piled up, so a genuine firehose is reported promptly instead of
+	// waiting out the full cooldown.
+	maxSuppressedPerWindow = 10000
+
+	// maxTrackedLogPatterns bounds the suppression map per subscription. Past
+	// this we stop tracking and dispatch every match, because dropping a line we
+	// cannot account for is worse than sending it.
+	maxTrackedLogPatterns = 5000
+
+	// logWindowSweepInterval is how often closed suppression windows are checked
+	// for rollups to send. It bounds how late a rollup can be, so keep it well
+	// under the shortest cooldown anyone would set.
+	logWindowSweepInterval = 5 * time.Second
+)
+
+// logWindow is an open suppression window for one (container, log pattern)
+// pair. The first line of a pattern always dispatches immediately and opens the
+// window; identical lines that follow are counted here rather than dropped, and
+// leave as a single rollup notification when the window closes.
+type logWindow struct {
+	mu        sync.Mutex
+	openedAt  time.Time
+	count     int64
+	container types.NotificationContainer
+	log       types.NotificationLog
+}
+
+// logRollup is a pending "this repeated N more times" notification, produced
+// when a suppression window closes with repeats recorded against it.
+type logRollup struct {
+	Container types.NotificationContainer
+	Log       types.NotificationLog
+	Count     int64
+}
+
+// logCooldownKey scopes a suppression window to one pattern on one container.
+func logCooldownKey(containerID, patternHash string) string {
+	return containerID + "|" + patternHash
+}
+
+// RecordLogMatch registers a matched log line and reports whether it should be
+// dispatched right now.
+//
+// The first sighting of a pattern always dispatches and opens a cooldown
+// window. Identical lines arriving while that window is open are counted for
+// the rollup instead, so nothing is lost, only deferred. A line with a
+// different pattern has its own window and is never held back by this one.
+//
+// Returns true (dispatch now) when the subscription has no cooldown configured,
+// when the message carries no usable pattern, or when we are already tracking
+// more patterns than we are willing to hold.
+func (s *Subscription) RecordLogMatch(c types.NotificationContainer, l types.NotificationLog) bool {
+	if s.GetCooldownSeconds() == 0 || s.LogCooldowns == nil {
+		return true
+	}
+
+	patternHash := HashPattern(ExtractPattern(MessageText(l.Message)))
+	if patternHash == "" {
+		return true
+	}
+
+	key := logCooldownKey(c.ID, patternHash)
+	if _, open := s.LogCooldowns.Load(key); !open && s.LogCooldowns.Size() >= maxTrackedLogPatterns {
+		return true
+	}
+
+	dispatch := false
+	s.LogCooldowns.Compute(key, func(w *logWindow, loaded bool) (*logWindow, xsync.ComputeOp) {
+		if !loaded {
+			dispatch = true
+			return &logWindow{openedAt: time.Now(), container: c, log: l}, xsync.UpdateOp
+		}
+		w.mu.Lock()
+		w.count++
+		// Keep the most recent line so the rollup quotes something current.
+		w.log = l
+		w.container = c
+		w.mu.Unlock()
+		return w, xsync.UpdateOp
+	})
+
+	return dispatch
+}
+
+// CollectLogRollups closes every suppression window that has run out its
+// cooldown or hit the suppression cap, and returns the rollups to dispatch.
+//
+// A window that closed with no repeats is deleted, so the next occurrence of
+// that pattern is treated as news again and dispatches immediately. A window
+// that closed with repeats is reset rather than deleted, so a pattern that
+// keeps firing costs one notification per cooldown for as long as it lasts.
+func (s *Subscription) CollectLogRollups() []logRollup {
+	if s.LogCooldowns == nil {
+		return nil
+	}
+
+	cooldown := time.Duration(s.GetCooldownSeconds()) * time.Second
+	now := time.Now()
+
+	var rollups []logRollup
+	var expired []string
+
+	s.LogCooldowns.Range(func(key string, w *logWindow) bool {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+
+		if w.count < maxSuppressedPerWindow && now.Sub(w.openedAt) < cooldown {
+			return true
+		}
+
+		if w.count == 0 {
+			expired = append(expired, key)
+			return true
+		}
+
+		rollups = append(rollups, logRollup{Container: w.container, Log: w.log, Count: w.count})
+		w.openedAt = now
+		w.count = 0
+		return true
+	})
+
+	// Delete under Compute rather than outright: a repeat can land between the
+	// scan and the delete, and a plain Delete would drop a line we had already
+	// told the caller to suppress.
+	for _, key := range expired {
+		s.LogCooldowns.Compute(key, func(w *logWindow, loaded bool) (*logWindow, xsync.ComputeOp) {
+			if !loaded {
+				return nil, xsync.CancelOp
+			}
+			w.mu.Lock()
+			defer w.mu.Unlock()
+			if w.count > 0 {
+				return w, xsync.UpdateOp
+			}
+			return nil, xsync.DeleteOp
+		})
+	}
+
+	return rollups
 }

--- a/types/notification.go
+++ b/types/notification.go
@@ -22,6 +22,12 @@ type Notification struct {
 	Event        *NotificationEvent    `json:"event,omitempty"`
 	Subscription SubscriptionConfig    `json:"subscription"`
 	Timestamp    time.Time             `json:"timestamp"`
+
+	// SuppressedCount is the number of additional identical log lines that were
+	// collapsed into this one while a log alert's cooldown window was open. Zero
+	// on a first sighting and on every non-log notification. Consumers should
+	// treat this notification as representing SuppressedCount+1 occurrences.
+	SuppressedCount int64 `json:"suppressedCount,omitempty"`
 }
 
 // NotificationContainer represents a simplified container structure for notifications


### PR DESCRIPTION
Log alerts have no rate limiting. `processLog` matches a line and dispatches it, skipping the cooldown gating that metric and event alerts already get (`processing.go` checks `IsMetricCooldownActive` and `IsEventCooldownActive`, nothing equivalent for logs). A container that logs the same error in a loop sends one notification per line. One rule in the wild produced 63k notifications in two weeks across 5,867 distinct patterns.

## Keyed on the pattern, not the container

A per-container cooldown is the obvious fix and it's wrong. Postgres logs `FATAL: could not extend file: No space left on device`, then 20 seconds later `connection refused`. Same container, different root cause, and a container-keyed cooldown drops the second one. That's worse than the noise.

So the key is `containerID|patternHash`. A different error opens its own window and goes out immediately, always.

## Counts, doesn't drop

- First line of a pattern dispatches right away and opens a window.
- Identical lines during that window are counted, not discarded.
- The window closes into one rollup carrying `suppressedCount`, so "this repeated 4,812 times" reaches the dispatcher instead of 4,812 rows.
- A window that closed with no repeats is deleted, so the pattern is news again next time. A window with repeats is reset rather than deleted, so an ongoing loop costs one notification per cooldown for as long as it runs.

Two backstops: `maxSuppressedPerWindow` (10,000) flushes a rollup early so a real firehose reports promptly instead of sitting on a full cooldown of silence, and `maxTrackedLogPatterns` (5,000) bounds the map per subscription. Past that limit it fails open and dispatches, because sending a line we can't account for beats losing it.

Suppressed lines still increment `TriggerCount`. The event path skips stats while cooling down; I didn't copy that. The rule did match, and zeroing the stat hides exactly the noisy case the number exists to show.

## Pattern extraction is shared with Cloud

`ExtractPattern` / `HashPattern` are ported from Dozzle Cloud's `api/internal/pattern`, with its test cases. Both sides have to derive the same key from the same line or a client-side rollup stops lining up with the server's own grouping. The ported tests mean drift breaks a build instead of doing that silently.

## Compatibility

Nothing changes for existing rules. `Cooldown: 0` still means no cooldown and every log rule in the wild carries 0 today, so this only takes effect once rules start being created with one.

`SuppressedCount` is `omitempty`, so the wire format is byte-identical for a first sighting and older servers ignore the field.

Open windows survive a config reload (`config.go`), or saving a rule would make every pattern look new and re-send a line already sent.

## Tests

`go build ./...`, `go vet`, and `go test ./internal/...` pass, including `-race`. New coverage in `log_cooldown_test.go` for: first sighting dispatches, repeats suppressed, varying tokens collapsing to one pattern, **a different error on the same container still dispatching**, same pattern on different containers both dispatching, cooldown 0 unchanged, rollup counts and window reset, quiet windows dropped, cap flushing early, and failing open past the pattern limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrPz8dqK2BGad9Vo8Zufpi