### PR TITLE
fix(notification): name the signal behind a container's exit code

### DIFF
--- a/internal/notification/processing.go
+++ b/internal/notification/processing.go
@@ -254,7 +254,7 @@ func (m *Manager) processDockerEvent(event *ContainerEventEntry) {
 
 		detail := fmt.Sprintf("Container event: %s", event.Event.Name)
 		if exitCode, ok := event.Event.ActorAttributes["exitCode"]; ok && event.Event.Name == "die" {
-			detail = fmt.Sprintf("Container event: %s (exit code %s)", event.Event.Name, exitCode)
+			detail = fmt.Sprintf("Container event: %s (exit code %s)", event.Event.Name, describeExitCode(exitCode))
 		}
 
 		notification := types.Notification{
@@ -280,6 +280,38 @@ func (m *Manager) processDockerEvent(event *ContainerEventEntry) {
 		}
 		return true
 	})
+}
+
+// signalExitCodes maps the 128+N exit codes a container gets when a signal kills
+// it to that signal's name.
+//
+// A bare "exit code 137" is routinely misread as an out-of-memory kill, both by
+// people and by Dozzle Cloud's triage model, which was shipping headlines like
+// "exited with code 137 — likely OOM" for ordinary Watchtower update cycles.
+// 137 is SIGKILL: it is what `docker stop`, a host reboot, a redeploy, or an
+// image updater produces whenever a container does not exit on SIGTERM within
+// the grace period. A genuine out-of-memory kill arrives as its own "oom" event,
+// so naming the signal costs nothing and removes the ambiguity at the source.
+//
+// Only codes that mean the same signal everywhere Docker runs are listed; the
+// rest are returned unchanged rather than risking a wrong name.
+var signalExitCodes = map[string]string{
+	"129": "SIGHUP",
+	"130": "SIGINT",
+	"131": "SIGQUIT",
+	"134": "SIGABRT",
+	"137": "SIGKILL",
+	"139": "SIGSEGV",
+	"143": "SIGTERM",
+}
+
+// describeExitCode annotates a container exit code with its signal name when it
+// has one, and otherwise returns it unchanged.
+func describeExitCode(exitCode string) string {
+	if signal, ok := signalExitCodes[exitCode]; ok {
+		return exitCode + ", " + signal
+	}
+	return exitCode
 }
 
 func formatLogMessage(message any) string {

--- a/internal/notification/processing_test.go
+++ b/internal/notification/processing_test.go
@@ -1,0 +1,34 @@
+package notification
+
+import "testing"
+
+// A bare "exit code 137" reads as an OOM kill to both people and to Dozzle
+// Cloud's triage model, when it actually means SIGKILL — what `docker stop`, a
+// reboot, or a Watchtower update cycle produces once a container misses the
+// SIGTERM grace period. Naming the signal keeps that misreading from starting
+// here, at the only place the exit code is turned into prose.
+func TestDescribeExitCode(t *testing.T) {
+	tests := []struct {
+		name     string
+		exitCode string
+		want     string
+	}{
+		{"SIGKILL is named, not left to be read as OOM", "137", "137, SIGKILL"},
+		{"graceful stop", "143", "143, SIGTERM"},
+		{"interrupt", "130", "130, SIGINT"},
+		{"segfault", "139", "139, SIGSEGV"},
+		{"clean exit stays bare", "0", "0"},
+		{"application failure stays bare", "1", "1"},
+		{"docker error stays bare", "125", "125"},
+		{"unknown code stays bare", "42", "42"},
+		{"empty stays empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := describeExitCode(tt.exitCode); got != tt.want {
+				t.Errorf("describeExitCode(%q) = %q, want %q", tt.exitCode, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The report

A Dozzle Cloud user, on alerts fired by Watchtower update cycles:

> it also constantly thinks it is an OOM issue when watchtower restarts it.

## The bug

The detail line for a `die` event reads:

```
Container event: die (exit code 137)
```

A bare `137` is routinely misread as an out-of-memory kill — by people, and by Dozzle Cloud's triage model, which has been shipping headlines like *"Jellyfin exited with code 137 — likely OOM"* for ordinary Watchtower restarts. In August that was 328 exit-137 `die` notifications across 17 users against 21 real `oom` events across 6.

**137 is SIGKILL.** It is what `docker stop`, a reboot, a redeploy, or an image updater produces when a container doesn't exit on SIGTERM within the grace period — which is exactly what Watchtower does on every upgrade. A genuine out-of-memory kill already arrives as its own `oom` event (`event_listener.go:20`), so the exit code is never needed to infer one.

## The fix

```
Container event: die (exit code 137, SIGKILL)
```

`describeExitCode` names the 128+N codes that mean the same signal everywhere Docker runs (129, 130, 131, 134, 137, 139, 143). Anything else is returned unchanged, so genuine failures — 1, 2, 125, app-specific codes — still read as failures rather than picking up a misleading label.

This is the one place the exit code becomes prose, so it fixes the reading for notification recipients and for anything downstream consuming `detail`.

## Related

- `amir20/doligence#405` teaches the triage model the same thing from the other end, and has the production numbers.
- Not fixed here, worth its own issue: `c823617f` (May 28) fixed the **default** exit rule to exclude `0/130/143/137`, but it lives in `WelcomeModal.vue` and only runs at first setup — existing subscriptions were never migrated. August traffic shows 17 users still on the old expression receiving 137, 8 receiving 143, and 3 receiving exit **0**. That's the "I had to manually write filters" half of the report.

## Tests

`go test ./internal/notification/...` passes; `processing_test.go` covers the named signals, the bare passthrough, and the empty case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qi3A5SqTasEpL6cGfbWGLs