### PR TITLE
refactor: give every setting a description and drop the card outlines

### DIFF
--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -200,6 +200,7 @@ declare module 'vue' {
     Search: typeof import('./components/Search.vue')['default']
     SearchStatus: typeof import('./components/LogViewer/SearchStatus.vue')['default']
     ServiceLog: typeof import('./components/ServiceViewer/ServiceLog.vue')['default']
+    SettingRow: typeof import('./components/common/SettingRow.vue')['default']
     SideDrawer: typeof import('./components/common/SideDrawer.vue')['default']
     SideMenu: typeof import('./components/SideMenu.vue')['default']
     SidePanel: typeof import('./components/SidePanel.vue')['default']

--- a/assets/components/common/SettingRow.vue
+++ b/assets/components/common/SettingRow.vue
@@ -1,0 +1,28 @@
+<template>
+  <!-- One row of a settings card: label, optional description, control on the right.
+       Renders as a <label> for rows whose control is a single input, so clicking the
+       text toggles it; rows holding a dropdown or a button group stay a <div> to avoid
+       nesting several interactive elements inside one label. -->
+  <component :is="tag" class="flex min-h-13 flex-wrap items-center justify-between gap-3 py-3.5 text-sm font-medium">
+    <span class="min-w-0">
+      <span class="inline-flex items-center gap-2">
+        {{ label }}
+        <slot name="label-suffix" />
+      </span>
+      <span v-if="description" class="text-base-content/60 mt-0.5 block text-xs font-normal">
+        {{ description }}
+      </span>
+    </span>
+    <span class="ml-auto flex flex-wrap items-center gap-2">
+      <slot />
+    </span>
+  </component>
+</template>
+
+<script lang="ts" setup>
+const { tag = "div" } = defineProps<{
+  label: string;
+  description?: string;
+  tag?: "label" | "div";
+}>();
+</script>

--- a/assets/pages/settings.vue
+++ b/assets/pages/settings.vue
@@ -11,12 +11,12 @@
     <!-- ABOUT -->
     <section class="flex flex-col gap-4">
       <div>
-        <h2 class="text-xl font-semibold tracking-tight">{{ $t("settings.about") }}</h2>
+        <h2 class="text-2xl font-semibold tracking-tight">{{ $t("settings.about") }}</h2>
         <p class="text-base-content/60 mt-1 text-sm">{{ $t("settings.about-desc") }}</p>
       </div>
 
-      <div class="border-base-content/15 bg-base-200/40 divide-base-content/10 divide-y rounded-lg border">
-        <div class="flex flex-col gap-2 p-4">
+      <div class="divide-base-content/10 divide-y">
+        <div class="flex flex-col gap-2 py-4">
           <div class="flex flex-wrap items-center gap-3">
             <span class="text-2xl font-semibold tracking-tight">Dozzle</span>
             <span class="status-pill status-pill-neutral font-mono">{{ config.version }}</span>
@@ -40,7 +40,7 @@
           </div>
         </div>
 
-        <div class="flex flex-col gap-3 p-4">
+        <div class="flex flex-col gap-3 py-4">
           <div>
             <div class="text-sm font-medium">{{ $t("settings.support-title") }}</div>
             <div class="text-base-content/60 text-xs">{{ $t("settings.help-support") }}</div>
@@ -73,7 +73,7 @@
     <!-- CLOUD -->
     <section class="flex flex-col gap-4" v-if="config.enableCloud">
       <div>
-        <h2 class="text-xl font-semibold tracking-tight">{{ $t("cloud.title") }}</h2>
+        <h2 class="text-2xl font-semibold tracking-tight">{{ $t("cloud.title") }}</h2>
         <p class="text-base-content/60 mt-1 text-sm">{{ $t("settings.cloud-desc") }}</p>
       </div>
       <CloudSettingsCard />
@@ -82,58 +82,57 @@
     <!-- DISPLAY -->
     <section class="flex flex-col gap-4">
       <div>
-        <h2 class="text-xl font-semibold tracking-tight">{{ $t("settings.display") }}</h2>
+        <h2 class="text-2xl font-semibold tracking-tight">{{ $t("settings.display") }}</h2>
         <p class="text-base-content/60 mt-1 text-sm">{{ $t("settings.display-desc") }}</p>
       </div>
 
       <div class="grid items-stretch gap-3 @3xl:grid-cols-2">
-        <div class="border-base-content/15 bg-base-200/40 divide-base-content/10 divide-y rounded-lg border">
-          <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-            {{ $t("settings.compact") }}
+        <div class="divide-base-content/10 divide-y">
+          <SettingRow tag="label" :label="$t('settings.compact')" :description="$t('settings.compact-desc')">
             <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="compact" />
-          </label>
-          <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-            {{ $t("settings.small-scrollbars") }}
+          </SettingRow>
+          <SettingRow
+            tag="label"
+            :label="$t('settings.small-scrollbars')"
+            :description="$t('settings.small-scrollbars-desc')"
+          >
             <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="smallerScrollbars" />
-          </label>
-          <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-            {{ $t("settings.show-timestamps") }}
+          </SettingRow>
+          <SettingRow
+            tag="label"
+            :label="$t('settings.show-timestamps')"
+            :description="$t('settings.show-timestamps-desc')"
+          >
             <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="showTimestamp" />
-          </label>
-          <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-            {{ $t("settings.show-std") }}
+          </SettingRow>
+          <SettingRow tag="label" :label="$t('settings.show-std')" :description="$t('settings.show-std-desc')">
             <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="showStd" />
-          </label>
-          <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-            {{ $t("settings.soft-wrap") }}
+          </SettingRow>
+          <SettingRow tag="label" :label="$t('settings.soft-wrap')" :description="$t('settings.soft-wrap-desc')">
             <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="softWrap" />
-          </label>
-          <div class="flex min-h-13 flex-wrap items-center justify-between gap-3 p-4 text-sm font-medium">
-            <span>{{ $t("settings.datetime-format") }}</span>
-            <div class="ml-auto flex flex-wrap gap-2">
-              <DropdownMenu
-                v-model="dateLocale"
-                :options="[
-                  { label: 'Auto', value: 'auto' },
-                  { label: 'MM/DD/YYYY', value: 'en-US' },
-                  { label: 'DD/MM/YYYY', value: 'en-GB' },
-                  { label: 'DD.MM.YYYY', value: 'de-DE' },
-                  { label: 'YYYY-MM-DD', value: 'en-CA' },
-                ]"
-              />
-              <DropdownMenu
-                v-model="hourStyle"
-                :options="[
-                  { label: $t('settings.hour.auto'), value: 'auto' },
-                  { label: $t('settings.hour.12'), value: '12' },
-                  { label: $t('settings.hour.24'), value: '24' },
-                ]"
-              />
-            </div>
-          </div>
-          <div class="flex min-h-13 flex-wrap items-center justify-between gap-3 p-4 text-sm font-medium">
-            <span>{{ $t("settings.font-size") }}</span>
-            <div class="join ml-auto">
+          </SettingRow>
+          <SettingRow :label="$t('settings.datetime-format')" :description="$t('settings.datetime-format-desc')">
+            <DropdownMenu
+              v-model="dateLocale"
+              :options="[
+                { label: 'Auto', value: 'auto' },
+                { label: 'MM/DD/YYYY', value: 'en-US' },
+                { label: 'DD/MM/YYYY', value: 'en-GB' },
+                { label: 'DD.MM.YYYY', value: 'de-DE' },
+                { label: 'YYYY-MM-DD', value: 'en-CA' },
+              ]"
+            />
+            <DropdownMenu
+              v-model="hourStyle"
+              :options="[
+                { label: $t('settings.hour.auto'), value: 'auto' },
+                { label: $t('settings.hour.12'), value: '12' },
+                { label: $t('settings.hour.24'), value: '24' },
+              ]"
+            />
+          </SettingRow>
+          <SettingRow :label="$t('settings.font-size')" :description="$t('settings.font-size-desc')">
+            <span class="join">
               <button
                 v-for="opt in [
                   { label: $t('settings.size.small'), value: 'small' },
@@ -147,8 +146,8 @@
               >
                 {{ opt.label }}
               </button>
-            </div>
-          </div>
+            </span>
+          </SettingRow>
         </div>
 
         <LogList
@@ -163,25 +162,22 @@
     <!-- OPTIONS -->
     <section class="flex flex-col gap-4">
       <div>
-        <h2 class="text-xl font-semibold tracking-tight">{{ $t("settings.options") }}</h2>
+        <h2 class="text-2xl font-semibold tracking-tight">{{ $t("settings.options") }}</h2>
         <p class="text-base-content/60 mt-1 text-sm">{{ $t("settings.options-desc") }}</p>
       </div>
 
-      <div class="border-base-content/15 bg-base-200/40 divide-base-content/10 divide-y rounded-lg border">
-        <div class="flex min-h-13 flex-wrap items-center justify-between gap-3 p-4 text-sm font-medium">
-          <span>{{ $t("settings.locale") }}</span>
+      <div class="divide-base-content/10 divide-y">
+        <SettingRow :label="$t('settings.locale')" :description="$t('settings.locale-desc')">
           <DropdownMenu
-            class="ml-auto"
             v-model="locale"
             :options="[
               { label: 'Auto', value: '' },
               ...availableLocales.map((l) => ({ label: l.toLocaleUpperCase(), value: l })),
             ]"
           />
-        </div>
-        <div class="flex min-h-13 flex-wrap items-center justify-between gap-3 p-4 text-sm font-medium">
-          <span>{{ $t("settings.color-scheme") }}</span>
-          <div class="join ml-auto">
+        </SettingRow>
+        <SettingRow :label="$t('settings.color-scheme')" :description="$t('settings.color-scheme-desc')">
+          <span class="join">
             <button
               v-for="opt in [
                 { label: $t('settings.theme.light'), value: 'light' },
@@ -195,12 +191,10 @@
             >
               {{ opt.label }}
             </button>
-          </div>
-        </div>
-        <div class="flex min-h-13 flex-wrap items-center justify-between gap-3 p-4 text-sm font-medium">
-          <span>{{ $t("settings.automatic-redirect") }}</span>
+          </span>
+        </SettingRow>
+        <SettingRow :label="$t('settings.automatic-redirect')" :description="$t('settings.automatic-redirect-desc')">
           <DropdownMenu
-            class="ml-auto"
             v-model="automaticRedirect"
             :options="[
               { label: $t('settings.redirect.instant'), value: 'instant' },
@@ -208,11 +202,9 @@
               { label: $t('settings.redirect.none'), value: 'none' },
             ]"
           />
-        </div>
-        <div class="flex min-h-13 flex-wrap items-center justify-between gap-3 p-4 text-sm font-medium">
-          <span>{{ $t("settings.group-containers") }}</span>
+        </SettingRow>
+        <SettingRow :label="$t('settings.group-containers')" :description="$t('settings.group-containers-desc')">
           <DropdownMenu
-            class="ml-auto"
             v-model="groupContainers"
             :options="[
               { label: $t('settings.grouping.always'), value: 'always' },
@@ -220,32 +212,33 @@
               { label: $t('settings.grouping.never'), value: 'never' },
             ]"
           />
-        </div>
-        <label
-          class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium"
+        </SettingRow>
+        <SettingRow
           v-if="config.imageCheckMode !== 'off'"
+          tag="label"
+          :label="$t('settings.show-image-update-alert')"
+          :description="$t('settings.show-image-update-alert-desc')"
         >
-          <span>{{ $t("settings.show-image-update-alert") }}</span>
           <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="showImageUpdateAlert" />
-        </label>
-        <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-          <span class="inline-flex items-center gap-2">
-            {{ $t("settings.search") }}
-            <key-shortcut char="f" />
-          </span>
+        </SettingRow>
+        <SettingRow tag="label" :label="$t('settings.search')" :description="$t('settings.search-desc')">
+          <template #label-suffix><key-shortcut char="f" /></template>
           <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="search" />
-        </label>
-        <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-          {{ $t("settings.show-stopped-containers") }}
+        </SettingRow>
+        <SettingRow
+          tag="label"
+          :label="$t('settings.show-stopped-containers')"
+          :description="$t('settings.show-stopped-containers-desc')"
+        >
           <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="showAllContainers" />
-        </label>
-        <label class="flex min-h-13 items-center justify-between gap-4 p-4 text-sm font-medium">
-          <span>
-            {{ $t("settings.show-app-icons") }}
-            <span class="text-base-content/60 block text-xs font-normal">{{ $t("settings.show-app-icons-desc") }}</span>
-          </span>
+        </SettingRow>
+        <SettingRow
+          tag="label"
+          :label="$t('settings.show-app-icons')"
+          :description="$t('settings.show-app-icons-desc')"
+        >
           <input type="checkbox" class="toggle toggle-primary toggle-sm" v-model="showAppIcons" />
-        </label>
+        </SettingRow>
       </div>
     </section>
   </div>

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -158,6 +158,7 @@ placeholder:
   search: Søg
 settings:
   show-image-update-alert: 'Vis en notifikation når en container har en opdatering'
+  show-image-update-alert-desc: 'Tjekker registret for et nyere tag af det kørende image.'
   help-support: >
     Støt venligst Dozzle ved at donere eller sponsorere os på GitHub. Dine bidrag hjælper os med at forbedre Dozzle for alle. Tak! 🙏🏼
   about-desc: Information om din Dozzle-installation og hvordan du kan støtte projektet.
@@ -168,25 +169,38 @@ settings:
   support-help: Donationer hjælper med at holde Dozzle gratis og vedligeholdt. Tak 🙏
   display: Visning
   locale: Overskriv sprog
+  locale-desc: 'Bruger som standard din browsers sprog.'
   small-scrollbars: Brug mindre scrollbarer
+  small-scrollbars-desc: 'Tyndere scrollbarer, praktisk på mindre skærme.'
   show-timestamps: Vis tids stempler
+  show-timestamps-desc: 'Sæt tidspunktet for hver linje foran den.'
   soft-wrap: Blødt bræk på linjer
+  soft-wrap-desc: 'Ombryd lange linjer i stedet for at rulle sidelæns.'
   datetime-format: Overskriv dato og tids format
+  datetime-format-desc: 'Bruger som standard din browsers sprog og urformat.'
   font-size: Tekststørrelse at bruge til logs
+  font-size-desc: 'Gælder kun for logudskrift, ikke resten af appen.'
   color-scheme: Farve skema
+  color-scheme-desc: 'Auto følger din systemindstilling.'
   options: Muligheder
   show-stopped-containers: Vis stoppet containere
+  show-stopped-containers-desc: 'Medtag stoppede containere i sidepanelet og listerne.'
   group-containers: Gruppér containere efter namespace
+  group-containers-desc: 'Grupperer efter Compose-projekt, Swarm-stack eller dev.dozzle.group.'
   show-app-icons: 'Vis app-ikoner'
   show-app-icons-desc: 'Match kendte images med deres logo. Ikoner følger med Dozzle og hentes aldrig fra internettet.'
   about: Omkring
   search: Aktiver søgning med Dozzle ved brug af
+  search-desc: 'Søg i loggen for den container du kigger på.'
   using-version: Du bruger <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     Ny version er tilgængelig! Opdater til <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Vis stdout og stderr mærker
+  show-std-desc: 'Markér om en linje kom fra stdout eller stderr.'
   automatic-redirect: Automatisk omdiriger til nye containere med det samme navn
+  automatic-redirect-desc: 'Følg med til den nye container, når en container udskiftes.'
   compact: Slå kompakt tilstand til for logs
+  compact-desc: 'Reducer afstanden mellem loglinjer, så der er plads til flere.'
   size:
     small: Lille
     medium: Mellem

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -158,6 +158,7 @@ placeholder:
   search: Suche
 settings:
   show-image-update-alert: 'Benachrichtigung anzeigen, wenn ein Container ein Update hat'
+  show-image-update-alert-desc: 'Prüft die Registry auf einen neueren Tag des laufenden Images.'
   help-support: >
     Bitte unterstützen Sie Dozzle durch Spenden oder Sponsoring auf GitHub. Ihre Beiträge helfen uns, Dozzle für alle zu verbessern. Vielen Dank! 🙏🏼
   about-desc: Informationen zu Ihrer Dozzle-Installation und wie Sie das Projekt unterstützen können.
@@ -168,25 +169,38 @@ settings:
   support-help: Spenden helfen, Dozzle kostenlos und gepflegt zu halten. Vielen Dank 🙏
   display: Anzeige
   locale: Sprache überschreiben
+  locale-desc: 'Folgt standardmäßig der Sprache deines Browsers.'
   small-scrollbars: Verwende kleinere Scrollbars
+  small-scrollbars-desc: 'Schmalere Scrollleisten, praktisch auf kleineren Bildschirmen.'
   show-timestamps: Zeige Zeitstempel
+  show-timestamps-desc: 'Jeder Zeile die Uhrzeit voranstellen, zu der sie geschrieben wurde.'
   soft-wrap: Zeilenumbruch
+  soft-wrap-desc: 'Lange Zeilen umbrechen statt seitwärts zu scrollen.'
   datetime-format: Datums- und Zeitformat
+  datetime-format-desc: 'Folgt standardmäßig der Sprache und Uhrzeit deines Browsers.'
   font-size: Schriftgröße für Logs
+  font-size-desc: 'Gilt nur für die Logausgabe, nicht für den Rest der App.'
   color-scheme: Farbschema
+  color-scheme-desc: 'Auto folgt deiner Systemeinstellung.'
   options: Optionen
   show-stopped-containers: Zeige gestoppte Container
+  show-stopped-containers-desc: 'Beendete Container in der Seitenleiste und in Listen anzeigen.'
   group-containers: Container nach Namespace gruppieren
+  group-containers-desc: 'Gruppiert nach Compose-Projekt, Swarm-Stack oder dev.dozzle.group.'
   show-app-icons: 'App-Symbole anzeigen'
   show-app-icons-desc: 'Bekannte Images ihrem Logo zuordnen. Die Symbole sind in Dozzle enthalten und werden nie aus dem Internet geladen.'
   about: Über
   search: Aktiviere die Suche mit Dozzle mit
+  search-desc: 'Durchsucht die Logs des Containers, den du gerade ansiehst.'
   using-version: Du verwendest <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     Eine neue Version ist verfügbar! Aktualisiere auf <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Zeige stdout und stderr Labels
+  show-std-desc: 'Kennzeichnen, ob eine Zeile von stdout oder stderr stammt.'
   automatic-redirect: Automatische Weiterleitung zu neuen Containern mit demselben Namen
+  automatic-redirect-desc: 'Wird ein Container ersetzt, zum neuen wechseln.'
   compact: Aktiviere den kompakten Modus für Logs
+  compact-desc: 'Abstände zwischen Logzeilen verringern, damit mehr auf den Bildschirm passt.'
   size:
     small: Klein
     medium: Mittel

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -220,27 +220,41 @@ settings:
   support-help: Donations help keep Dozzle free and maintained. Thank you 🙏
   display: Display
   locale: Override language
+  locale-desc: Defaults to your browser language.
   small-scrollbars: Use smaller scrollbars
+  small-scrollbars-desc: Thinner scrollbars, handy on smaller displays.
   show-timestamps: Show timestamps
+  show-timestamps-desc: Prefix each line with the time it was written.
   soft-wrap: Soft wrap lines
+  soft-wrap-desc: Wrap long lines instead of scrolling sideways.
   datetime-format: Override date and time format
+  datetime-format-desc: Defaults to your browser locale and clock.
   font-size: Font size to use for logs
+  font-size-desc: Applies to log output only, not the rest of the app.
   color-scheme: Color scheme
+  color-scheme-desc: Auto follows your system setting.
   options: Options
   show-stopped-containers: Show stopped containers
+  show-stopped-containers-desc: Include exited containers in the sidebar and lists.
   show-image-update-alert: Show a notification when a container has an update
+  show-image-update-alert-desc: Checks the registry for a newer tag of the running image.
   show-app-icons: Show app icons
   show-app-icons-desc: Match well known images to their logo. Icons ship with Dozzle and are never fetched from the internet.
   group-containers: Group containers by namespace
+  group-containers-desc: Groups by Compose project, Swarm stack, or dev.dozzle.group.
   about: About
   search: Enable searching with Dozzle using
+  search-desc: Search inside the logs of the container you are viewing.
   using-version: You are using <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     New version is available! Update to <a href="{href}" target="_blank"
     rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Show stdout and stderr labels
+  show-std-desc: Mark whether a line came from stdout or stderr.
   automatic-redirect: Automatically redirect to new containers with the same name
+  automatic-redirect-desc: When a container is replaced, follow it to the new one.
   compact: Enable compact mode for logs
+  compact-desc: Reduce padding between log lines to fit more on screen.
   size:
     small: Small
     medium: Medium

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -202,6 +202,7 @@ command-palette:
   open-settings: Abrir configuración
 settings:
   show-image-update-alert: 'Mostrar una notificación cuando un contenedor tenga una actualización'
+  show-image-update-alert-desc: 'Consulta el registro en busca de una etiqueta más reciente de la imagen.'
   help-support: >
     Por favor, apoya a Dozzle donando o patrocinándonos en GitHub. Tus contribuciones nos ayudan a mejorar Dozzle para todos. ¡Gracias! 🙏🏼
   about-desc: Información sobre tu instalación de Dozzle y cómo apoyar el proyecto.
@@ -212,25 +213,38 @@ settings:
   support-help: Las donaciones ayudan a mantener Dozzle gratuito y actualizado. Gracias 🙏
   display: Vista
   locale: Sobrescribir idioma
+  locale-desc: 'Por defecto usa el idioma de tu navegador.'
   small-scrollbars: Utilizar barras de desplazamiento más pequeñas
+  small-scrollbars-desc: 'Barras de desplazamiento más finas, útiles en pantallas pequeñas.'
   show-timestamps: Mostrar marcas de tiempo
+  show-timestamps-desc: 'Antepone a cada línea la hora en que se escribió.'
   soft-wrap: Líneas de texto con ajuste suave
+  soft-wrap-desc: 'Ajusta las líneas largas en lugar de desplazarse en horizontal.'
   datetime-format: Sobrescribir el formato de fecha y hora
+  datetime-format-desc: 'Por defecto usa el idioma y el reloj de tu navegador.'
   font-size: Tamaño de letra a utilizar para los registros
+  font-size-desc: 'Solo afecta a la salida de los logs, no al resto de la aplicación.'
   color-scheme: Esquema de colores
+  color-scheme-desc: 'Auto sigue la configuración de tu sistema.'
   options: Opciones
   show-stopped-containers: Mostrar contenedores parados
+  show-stopped-containers-desc: 'Incluye los contenedores parados en la barra lateral y en las listas.'
   group-containers: Agrupar contenedores por namespace
+  group-containers-desc: 'Agrupa por proyecto de Compose, stack de Swarm o dev.dozzle.group.'
   show-app-icons: 'Mostrar iconos de aplicaciones'
   show-app-icons-desc: 'Asocia las imágenes conocidas con su logotipo. Los iconos vienen incluidos en Dozzle y nunca se descargan de internet.'
   about: Acerca de
   search: Activar la búsqueda con Dozzle mediante
+  search-desc: 'Busca dentro de los logs del contenedor que estás viendo.'
   using-version: Estás usando <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     ¡La nueva versión está disponible! Actualizar a la <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Mostrar etiquetas de salida estándar y salida de error estándar
+  show-std-desc: 'Indica si una línea proviene de stdout o de stderr.'
   automatic-redirect: Redireccionar automáticamente a nuevos contenedores con el mismo nombre
+  automatic-redirect-desc: 'Cuando se reemplaza un contenedor, seguirlo hasta el nuevo.'
   compact: Modo compacto
+  compact-desc: 'Reduce el espaciado entre líneas para que quepan más en pantalla.'
   size:
     small: Pequeño
     medium: Mediano

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -158,6 +158,7 @@ placeholder:
   search: Recherche
 settings:
   show-image-update-alert: 'Afficher une notification lorsqu''un conteneur a une mise à jour'
+  show-image-update-alert-desc: 'Vérifie dans le registre s''il existe un tag plus récent de l''image.'
   help-support: >
     Veuillez soutenir Dozzle en faisant un don ou en nous parrainant sur GitHub. Vos contributions nous aident à améliorer Dozzle pour tout le monde. Merci ! 🙏🏼
   about-desc: Informations sur votre installation de Dozzle et comment soutenir le projet.
@@ -168,25 +169,38 @@ settings:
   support-help: Les dons aident à garder Dozzle gratuit et maintenu. Merci 🙏
   display: Afficher
   locale: Langue de remplacement
+  locale-desc: 'Suit par défaut la langue de votre navigateur.'
   small-scrollbars: Utiliser des barres de défilement plus petites
+  small-scrollbars-desc: 'Barres de défilement plus fines, pratiques sur les petits écrans.'
   show-timestamps: Afficher les horodatages
+  show-timestamps-desc: 'Préfixe chaque ligne avec l''heure à laquelle elle a été écrite.'
   soft-wrap: Lignes d'enroulement souples
+  soft-wrap-desc: 'Renvoie les lignes longues à la ligne au lieu de défiler latéralement.'
   datetime-format: Remplacer le format de la date et de l'heure
+  datetime-format-desc: 'Suit par défaut la langue et l''horloge de votre navigateur.'
   font-size: Taille de police à utiliser pour les journaux
+  font-size-desc: 'S''applique uniquement aux logs, pas au reste de l''application.'
   color-scheme: Schéma de couleurs
+  color-scheme-desc: 'Auto suit le réglage de votre système.'
   options: Options
   show-stopped-containers: Afficher les conteneurs arrêtés
+  show-stopped-containers-desc: 'Inclut les conteneurs arrêtés dans la barre latérale et les listes.'
   group-containers: Regrouper les conteneurs par namespace
+  group-containers-desc: 'Regroupe par projet Compose, stack Swarm ou dev.dozzle.group.'
   show-app-icons: 'Afficher les icônes des applications'
   show-app-icons-desc: 'Associe les images connues à leur logo. Les icônes sont fournies avec Dozzle et ne sont jamais téléchargées depuis internet.'
   about: A propos de
   search: Activer la recherche avec Dozzle en utilisant
+  search-desc: 'Recherche dans les logs du conteneur que vous consultez.'
   using-version: Vous utilisez <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     Nouvelle version disponible! Mise à jour de <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Afficher les étiquettes stdout et stderr
+  show-std-desc: 'Indique si une ligne provient de stdout ou de stderr.'
   automatic-redirect: Redirection automatique vers de nouveaux conteneurs portant le même nom
+  automatic-redirect-desc: 'Lorsqu''un conteneur est remplacé, basculer vers le nouveau.'
   compact: Activer le mode compact pour les journaux
+  compact-desc: 'Réduit l''espacement entre les lignes pour en afficher davantage.'
   size:
     small: Petit
     medium: Moyen

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -166,6 +166,7 @@ placeholder:
 
 settings:
   show-image-update-alert: 'Tampilkan notifikasi saat kontainer memiliki pembaruan'
+  show-image-update-alert-desc: 'Memeriksa registry untuk tag image yang lebih baru.'
   help-support: >
     Silakan dukung Dozzle dengan berdonasi atau mensponsori kami di GitHub. Kontribusi Anda membantu kami meningkatkan Dozzle untuk semua orang. Terima kasih! 🙏🏼
   about-desc: Informasi tentang instalasi Dozzle Anda dan cara mendukung proyek ini.
@@ -176,25 +177,38 @@ settings:
   support-help: Donasi membantu menjaga Dozzle tetap gratis dan terawat. Terima kasih 🙏
   display: Tampilan
   locale: Ganti bahasa
+  locale-desc: 'Secara bawaan mengikuti bahasa peramban Anda.'
   small-scrollbars: Gunakan scrollbar kecil
+  small-scrollbars-desc: 'Bilah gulir lebih tipis, berguna pada layar kecil.'
   show-timestamps: Tampilkan cap waktu
+  show-timestamps-desc: 'Tambahkan waktu penulisan di awal setiap baris.'
   soft-wrap: Bungkus baris secara lunak
+  soft-wrap-desc: 'Bungkus baris panjang alih-alih menggulir ke samping.'
   datetime-format: Ganti format tanggal dan waktu
+  datetime-format-desc: 'Secara bawaan mengikuti bahasa dan format jam peramban Anda.'
   font-size: Ukuran font untuk log
+  font-size-desc: 'Hanya berlaku untuk keluaran log, bukan bagian lain aplikasi.'
   color-scheme: Skema warna
+  color-scheme-desc: 'Auto mengikuti pengaturan sistem Anda.'
   options: Opsi
   show-stopped-containers: Tampilkan kontainer yang dihentikan
+  show-stopped-containers-desc: 'Sertakan kontainer yang berhenti di bilah sisi dan daftar.'
   group-containers: Kelompokkan kontainer berdasarkan namespace
+  group-containers-desc: 'Mengelompokkan berdasarkan proyek Compose, stack Swarm, atau dev.dozzle.group.'
   show-app-icons: 'Tampilkan ikon aplikasi'
   show-app-icons-desc: 'Cocokkan image yang dikenal dengan logonya. Ikon disertakan dalam Dozzle dan tidak pernah diunduh dari internet.'
   about: Tentang
   search: Aktifkan pencarian dengan Dozzle menggunakan
+  search-desc: 'Cari di dalam log kontainer yang sedang Anda lihat.'
   using-version: Anda menggunakan <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     Versi baru tersedia! Perbarui ke <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Tampilkan label stdout dan stderr
+  show-std-desc: 'Tandai apakah baris berasal dari stdout atau stderr.'
   automatic-redirect: Alihkan otomatis ke kontainer baru dengan nama yang sama
+  automatic-redirect-desc: 'Saat kontainer diganti, ikuti ke kontainer yang baru.'
   compact: Aktifkan mode ringkas untuk log
+  compact-desc: 'Kurangi jarak antar baris log agar lebih banyak yang muat di layar.'
   size:
     small: Kecil
     medium: Sedang

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -158,6 +158,7 @@ placeholder:
   search: Cerca
 settings:
   show-image-update-alert: 'Mostra una notifica quando un container ha un aggiornamento'
+  show-image-update-alert-desc: 'Controlla nel registry se esiste un tag più recente dell''immagine.'
   help-support: >
     Per favore sostieni Dozzle donando o sponsorizzandoci su GitHub. I tuoi contributi ci aiutano a migliorare Dozzle per tutti. Grazie! 🙏🏼
   about-desc: Informazioni sulla tua installazione di Dozzle e su come sostenere il progetto.
@@ -168,25 +169,38 @@ settings:
   support-help: Le donazioni aiutano a mantenere Dozzle gratuito e curato. Grazie 🙏
   display: Visualizza
   locale: Sovrascrivi Lingua
+  locale-desc: 'Per impostazione predefinita segue la lingua del browser.'
   small-scrollbars: Usa una scrollbars più piccola
+  small-scrollbars-desc: 'Barre di scorrimento più sottili, utili su schermi piccoli.'
   show-timestamps: Visualizza timestamp
+  show-timestamps-desc: 'Antepone a ogni riga l''ora in cui è stata scritta.'
   soft-wrap: Soft Wrap
+  soft-wrap-desc: 'Manda a capo le righe lunghe invece di scorrere in orizzontale.'
   datetime-format: Sovrascrivi data e formato dell'ora
+  datetime-format-desc: 'Per impostazione predefinita segue lingua e orologio del browser.'
   font-size: Grandezza del Font da usare nei log
+  font-size-desc: 'Vale solo per l''output dei log, non per il resto dell''app.'
   color-scheme: Tema colori
+  color-scheme-desc: 'Auto segue l''impostazione di sistema.'
   options: Opzioni
   show-stopped-containers: Visualizza i container arrestati
+  show-stopped-containers-desc: 'Includi i container arrestati nella barra laterale e negli elenchi.'
   group-containers: Raggruppa i container per namespace
+  group-containers-desc: 'Raggruppa per progetto Compose, stack Swarm o dev.dozzle.group.'
   show-app-icons: 'Mostra le icone delle applicazioni'
   show-app-icons-desc: 'Associa le immagini note al loro logo. Le icone sono incluse in Dozzle e non vengono mai scaricate da internet.'
   about: Circa
   search: Abilita la ricerca attraverso Dozzle
+  search-desc: 'Cerca nei log del container che stai visualizzando.'
   using-version: Stai utilizzando <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     Nuova versione disponibile! Aggiorna a <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Visualizza stdout e stderr
+  show-std-desc: 'Indica se una riga proviene da stdout o da stderr.'
   automatic-redirect: Reindirizza automaticamente al nuovo container con lo stesso nome
+  automatic-redirect-desc: 'Quando un container viene sostituito, passa a quello nuovo.'
   compact: Abilita la modalità compatta per i log
+  compact-desc: 'Riduce la spaziatura tra le righe per mostrarne di più.'
   size:
     small: Piccolo
     medium: Medio

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -160,6 +160,7 @@ placeholder:
   search: 검색
 settings:
   show-image-update-alert: '컨테이너에 업데이트가 있을 때 알림 표시'
+  show-image-update-alert-desc: '레지스트리에서 실행 중인 이미지의 최신 태그를 확인합니다.'
   help-support: >
     GitHub에서 후원하거나 기부로 Dozzle을 응원해 주세요. 여러분의 도움으로
     모두를 위한 더 나은 Dozzle을 만들 수 있습니다. 감사합니다! 🙏🏼
@@ -171,26 +172,39 @@ settings:
   support-help: 기부는 Dozzle을 무료로 유지하고 관리하는 데 도움이 됩니다. 감사합니다 🙏
   display: 화면 설정
   locale: 언어 변경
+  locale-desc: '기본적으로 브라우저 언어를 따릅니다.'
   small-scrollbars: 작은 스크롤바 사용
+  small-scrollbars-desc: '더 얇은 스크롤바로, 작은 화면에서 유용합니다.'
   show-timestamps: 타임스탬프 표시
+  show-timestamps-desc: '각 줄 앞에 기록된 시각을 표시합니다.'
   soft-wrap: 자동 줄바꿈
+  soft-wrap-desc: '가로로 스크롤하는 대신 긴 줄을 줄바꿈합니다.'
   datetime-format: 날짜 및 시간 형식 변경
+  datetime-format-desc: '기본적으로 브라우저의 언어와 시간 형식을 따릅니다.'
   font-size: 로그 글꼴 크기
+  font-size-desc: '로그 출력에만 적용되며 앱의 나머지 부분에는 적용되지 않습니다.'
   color-scheme: 색상 테마
+  color-scheme-desc: '자동은 시스템 설정을 따릅니다.'
   options: 옵션
   show-stopped-containers: 중지된 컨테이너 보기
+  show-stopped-containers-desc: '중지된 컨테이너를 사이드바와 목록에 포함합니다.'
   group-containers: 네임스페이스별로 컨테이너 그룹화
+  group-containers-desc: 'Compose 프로젝트, Swarm 스택 또는 dev.dozzle.group으로 그룹화합니다.'
   show-app-icons: '앱 아이콘 표시'
   show-app-icons-desc: '잘 알려진 이미지를 해당 로고와 연결합니다. 아이콘은 Dozzle에 포함되어 있으며 인터넷에서 가져오지 않습니다.'
   about: 정보
   search: Dozzle 검색 기능 사용
+  search-desc: '현재 보고 있는 컨테이너의 로그 안에서 검색합니다.'
   using-version: <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}을 사용하고 있습니다.
   update-available: >-
     새 버전이 있습니다! <a href="{href}" target="_blank"
     rel="noreferrer noopener">{nextVersion}</a>으로 업데이트하세요.
   show-std: stdout 및 stderr 라벨 표시
+  show-std-desc: '줄이 stdout에서 왔는지 stderr에서 왔는지 표시합니다.'
   automatic-redirect: 같은 이름의 새 컨테이너로 자동 이동
+  automatic-redirect-desc: '컨테이너가 교체되면 새 컨테이너로 따라갑니다.'
   compact: 로그 간단하게 보기
+  compact-desc: '로그 줄 사이 여백을 줄여 화면에 더 많이 표시합니다.'
   size:
     small: 작게
     medium: 중간

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -159,6 +159,7 @@ placeholder:
   search: Zoeken
 settings:
   show-image-update-alert: 'Toon een melding wanneer een container een update heeft'
+  show-image-update-alert-desc: 'Controleert de registry op een nieuwere tag van de draaiende image.'
   help-support: >
     Steun Dozzle door te doneren of door ons te sponsoren op GitHub. Jouw bijdrage helpt ons om Dozzle verder te verbeteren voor iedereen. Hartelijk dank! 🙏🏼
   about-desc: Informatie over jouw Dozzle-installatie en hoe je het project kunt ondersteunen.
@@ -169,25 +170,38 @@ settings:
   support-help: Donaties houden Dozzle gratis en onderhouden. Bedankt 🙏
   display: Weergave
   locale: Taal aanpassen
+  locale-desc: 'Volgt standaard de taal van je browser.'
   small-scrollbars: Kleinere scrollbalk gebruiken
+  small-scrollbars-desc: 'Dunnere schuifbalken, handig op kleinere schermen.'
   show-timestamps: Tijdstempel tonen
+  show-timestamps-desc: 'Zet voor elke regel het tijdstip waarop die geschreven is.'
   soft-wrap: Regels zacht afbreken
+  soft-wrap-desc: 'Breek lange regels af in plaats van zijwaarts te scrollen.'
   datetime-format: Datum- en tijdnotatie aanpassen
+  datetime-format-desc: 'Volgt standaard de taal en klok van je browser.'
   font-size: Lettergrootte voor logs
+  font-size-desc: 'Geldt alleen voor de loguitvoer, niet voor de rest van de app.'
   color-scheme: Kleurmodus
+  color-scheme-desc: 'Auto volgt je systeeminstelling.'
   options: Opties
   show-stopped-containers: Gestopte containers tonen
+  show-stopped-containers-desc: 'Toon gestopte containers in de zijbalk en in lijsten.'
   group-containers: Groepeer containers op namespace
+  group-containers-desc: 'Groepeert op Compose-project, Swarm-stack of dev.dozzle.group.'
   show-app-icons: 'App-pictogrammen tonen'
   show-app-icons-desc: 'Koppel bekende images aan hun logo. De pictogrammen zitten in Dozzle en worden nooit van internet opgehaald.'
   about: Over
   search: Doorzoeken inschakelen via Dozzle
+  search-desc: 'Zoek in de logs van de container die je bekijkt.'
   using-version: Je gebruikt <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     Er is een nieuwe versie beschikbaar! Update naar <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Toon stdout- en stderr-labels
+  show-std-desc: 'Geef aan of een regel van stdout of stderr komt.'
   automatic-redirect: Automatisch omleiden naar nieuwe containers met dezelfde naam
+  automatic-redirect-desc: 'Als een container wordt vervangen, ga mee naar de nieuwe.'
   compact: Compacte modus inschakelen voor logs
+  compact-desc: 'Verklein de ruimte tussen logregels zodat er meer op het scherm past.'
   size:
     small: Klein
     medium: Middel

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -160,6 +160,7 @@ placeholder:
   search: Szukaj
 settings:
   show-image-update-alert: 'Pokaż powiadomienie, gdy kontener ma aktualizację'
+  show-image-update-alert-desc: 'Sprawdza w rejestrze nowszy tag uruchomionego obrazu.'
   help-support: >
     Prosimy o wsparcie Dozzle poprzez darowizny lub sponsoring na GitHub. Twoje wkłady pomagają nam ulepszać Dozzle dla wszystkich. Dziękujemy! 🙏🏼
   about-desc: Informacje o Twojej instalacji Dozzle i o tym, jak wesprzeć projekt.
@@ -170,26 +171,39 @@ settings:
   support-help: Darowizny pomagają utrzymać Dozzle darmowym i rozwijanym. Dziękujemy 🙏
   display: Wyświetlanie
   locale: Nadpisz język
+  locale-desc: 'Domyślnie używa języka przeglądarki.'
   small-scrollbars: Użyj mniejszych suwaków
+  small-scrollbars-desc: 'Cieńsze paski przewijania, przydatne na mniejszych ekranach.'
   show-timestamps: Pokaż date i godzinę
+  show-timestamps-desc: 'Poprzedza każdy wiersz godziną jego zapisania.'
   soft-wrap: Zwijaj linie
+  soft-wrap-desc: 'Zawija długie wiersze zamiast przewijania w bok.'
   datetime-format: Nadpisz format daty i godziny
+  datetime-format-desc: 'Domyślnie używa języka i formatu zegara przeglądarki.'
   font-size: Rozmiar czcionki używany dla logów
+  font-size-desc: 'Dotyczy tylko logów, nie reszty aplikacji.'
   color-scheme: Motyw
+  color-scheme-desc: 'Auto podąża za ustawieniem systemu.'
   options: Opcje
   show-stopped-containers: Pokaż zatrzymane kontenery
+  show-stopped-containers-desc: 'Uwzględnia zatrzymane kontenery na pasku bocznym i listach.'
   group-containers: Grupuj kontenery według przestrzeni nazw
+  group-containers-desc: 'Grupuje według projektu Compose, stosu Swarm lub dev.dozzle.group.'
   show-app-icons: 'Pokaż ikony aplikacji'
   show-app-icons-desc: 'Dopasuj znane obrazy do ich logo. Ikony są dołączone do Dozzle i nigdy nie są pobierane z internetu.'
   about: Informacje
   search: Włącz szukanie z dozzle
+  search-desc: 'Szuka w logach kontenera, który właśnie przeglądasz.'
   using-version: Używasz <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> w wersji {version}.
   update-available: >-
     Nowa wersja jest dostępna! Zaktualizuj do <a href="{href}" target="_blank"
     rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Pokaż etykiety dla stdout i stderr
+  show-std-desc: 'Oznacza, czy wiersz pochodzi ze stdout czy ze stderr.'
   automatic-redirect: Automatycznie przekieruj na kontener o tej samej nazwie
+  automatic-redirect-desc: 'Gdy kontener zostanie zastąpiony, przejdź do nowego.'
   compact: Włącz tryb kompaktowy dla logów
+  compact-desc: 'Zmniejsza odstępy między wierszami logów, aby zmieściło się ich więcej.'
   size:
     small: Mały
     medium: Średni

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -158,6 +158,7 @@ placeholder:
   search: Pesquisar
 settings:
   show-image-update-alert: 'Mostrar uma notificação quando um contêiner tiver uma atualização'
+  show-image-update-alert-desc: 'Consulta o registro por uma tag mais recente da imagem em execução.'
   help-support: >
     Por favor, apoie o Dozzle doando ou nos patrocinando no GitHub. Suas contribuições nos ajudam a melhorar o Dozzle para todos. Obrigado! 🙏🏼
   about-desc: Informações sobre sua instalação do Dozzle e como apoiar o projeto.
@@ -168,25 +169,38 @@ settings:
   support-help: As doações ajudam a manter o Dozzle gratuito e com manutenção contínua. Obrigado 🙏
   display: Exibição
   locale: Sobrescrever idioma
+  locale-desc: 'Por padrão segue o idioma do seu navegador.'
   small-scrollbars: Usar barras de rolagem menores
+  small-scrollbars-desc: 'Barras de rolagem mais finas, úteis em telas menores.'
   show-timestamps: Mostrar marcas de tempo
+  show-timestamps-desc: 'Prefixa cada linha com o horário em que foi escrita.'
   soft-wrap: Quebrar linhas automaticamente
+  soft-wrap-desc: 'Quebra linhas longas em vez de rolar na horizontal.'
   datetime-format: Sobrescrever formato de data e hora
+  datetime-format-desc: 'Por padrão segue o idioma e o relógio do seu navegador.'
   font-size: Tamanho da fonte para logs
+  font-size-desc: 'Vale apenas para a saída dos logs, não para o resto do app.'
   color-scheme: Esquema de cores
+  color-scheme-desc: 'Auto segue a configuração do seu sistema.'
   options: Opções
   show-stopped-containers: Mostrar containers parados
+  show-stopped-containers-desc: 'Inclui contêineres parados na barra lateral e nas listas.'
   group-containers: Agrupar containers por namespace
+  group-containers-desc: 'Agrupa por projeto do Compose, stack do Swarm ou dev.dozzle.group.'
   show-app-icons: 'Mostrar ícones dos aplicativos'
   show-app-icons-desc: 'Associa imagens conhecidas ao seu logotipo. Os ícones vêm com o Dozzle e nunca são baixados da internet.'
   about: Sobre
   search: Habilitar pesquisa com Dozzle usando
+  search-desc: 'Busca dentro dos logs do contêiner que você está vendo.'
   using-version: Você está usando <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     Nova versão disponível! Atualize para <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Mostrar rótulos stdout e stderr
+  show-std-desc: 'Indica se a linha veio do stdout ou do stderr.'
   automatic-redirect: Redirecionar automaticamente para novos containers com o mesmo nome
+  automatic-redirect-desc: 'Quando um contêiner é substituído, seguir para o novo.'
   compact: Ativar modo compacto para logs
+  compact-desc: 'Reduz o espaçamento entre as linhas para caber mais na tela.'
   size:
     small: Pequeno
     medium: Médio

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -158,6 +158,7 @@ placeholder:
   search: Поиск
 settings:
   show-image-update-alert: 'Показывать уведомление, когда у контейнера есть обновление'
+  show-image-update-alert-desc: 'Проверяет в реестре более новый тег запущенного образа.'
   help-support: >
     Пожалуйста, поддержите Dozzle, сделав пожертвование или спонсорство на GitHub. Ваши вклады помогают нам улучшать Dozzle для всех. Спасибо! 🙏🏼
   about-desc: Информация о вашей установке Dozzle и о том, как поддержать проект.
@@ -168,25 +169,38 @@ settings:
   support-help: Пожертвования помогают сохранять Dozzle бесплатным и поддерживаемым. Спасибо 🙏
   display: Вид
   locale: Язык
+  locale-desc: 'По умолчанию следует языку браузера.'
   small-scrollbars: Уменьшенная полоса прокрутки
+  small-scrollbars-desc: 'Более тонкие полосы прокрутки, удобно на небольших экранах.'
   show-timestamps: Показывать временные метки
+  show-timestamps-desc: 'Добавляет в начало каждой строки время её записи.'
   soft-wrap: Плавный перенос текста
+  soft-wrap-desc: 'Переносит длинные строки вместо горизонтальной прокрутки.'
   datetime-format: Формат даты и времени
+  datetime-format-desc: 'По умолчанию следует языку и формату времени браузера.'
   font-size: Размер шрифта
+  font-size-desc: 'Влияет только на вывод логов, а не на остальной интерфейс.'
   color-scheme: Цветовая схема
+  color-scheme-desc: 'Авто следует настройке системы.'
   options: Опции
   show-stopped-containers: Показывать остановленные контейнеры
+  show-stopped-containers-desc: 'Показывать остановленные контейнеры в боковой панели и списках.'
   group-containers: Группировать контейнеры по пространству имён
+  group-containers-desc: 'Группирует по проекту Compose, стеку Swarm или dev.dozzle.group.'
   show-app-icons: 'Показывать значки приложений'
   show-app-icons-desc: 'Сопоставлять известные образы с их логотипами. Значки поставляются вместе с Dozzle и никогда не загружаются из интернета.'
   about: Информация
   search: Включить поиск с помощью Dozzle, используя
+  search-desc: 'Ищет внутри логов контейнера, который вы просматриваете.'
   using-version: Вы используете <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}.
   update-available: >-
     Доступна новая версия! Обновить до <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Показывать метки stdout и stderr
+  show-std-desc: 'Помечает, из stdout или stderr пришла строка.'
   automatic-redirect: Автоматическое перенаправление на новые контейнеры с тем же именем.
+  automatic-redirect-desc: 'Когда контейнер заменён, перейти к новому.'
   compact: Компактный режим
+  compact-desc: 'Уменьшает отступы между строками логов, чтобы их помещалось больше.'
   size:
     small: Маленький
     medium: Средний

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -160,6 +160,7 @@ placeholder:
   search: Iskanje
 settings:
   show-image-update-alert: 'Pokaži obvestilo, ko je za vsebnik na voljo posodobitev'
+  show-image-update-alert-desc: 'V registru preveri, ali obstaja novejša oznaka slike.'
   about-desc: Informacije o vaši namestitvi Dozzle in kako podpreti projekt.
   display-desc: Prilagodite videz dnevnikov in preostalega dela aplikacije. Predogled v živo prikazuje vaše spremembe.
   options-desc: Nastavitve jezika, navigacije in združevanja.
@@ -168,23 +169,35 @@ settings:
   support-help: Donacije pomagajo, da Dozzle ostane brezplačen in vzdrževan. Hvala 🙏
   display: Prikaz
   locale: Preglasi jezik
+  locale-desc: 'Privzeto sledi jeziku brskalnika.'
   small-scrollbars: Uporabite manjše drsne trakove
+  small-scrollbars-desc: 'Tanjši drsniki, priročno na manjših zaslonih.'
   show-timestamps: Prikaži časovne žige
+  show-timestamps-desc: 'Pred vsako vrstico doda čas, ko je bila zapisana.'
   soft-wrap: Mehke ovojne linije
+  soft-wrap-desc: 'Prelomi dolge vrstice namesto drsenja vstran.'
   datetime-format: Preglasi obliko zapisa datuma in časa
+  datetime-format-desc: 'Privzeto sledi jeziku in uri v brskalniku.'
   font-size: Velikost pisave za dnevnike
+  font-size-desc: 'Velja samo za izpis dnevnika, ne za preostanek aplikacije.'
   color-scheme: Barvna shema
+  color-scheme-desc: 'Samodejno sledi nastavitvi sistema.'
   options: Možnosti
   show-stopped-containers: Prikaži ustavljene zabojnike
+  show-stopped-containers-desc: 'Vključi ustavljene vsebnike v stranski vrstici in seznamih.'
   group-containers: Združi zabojnike po imenskem prostoru
+  group-containers-desc: 'Združuje po projektu Compose, skladu Swarm ali dev.dozzle.group.'
   show-app-icons: 'Prikaži ikone aplikacij'
   show-app-icons-desc: 'Znane slike poveži z njihovim logotipom. Ikone so priložene Dozzle in se nikoli ne prenašajo iz interneta.'
   about: O programu
   search: Omogočite iskanje z Dozzle z uporabo
+  search-desc: 'Išče po dnevniku vsebnika, ki ga gledate.'
   update-available: Nova različica je na voljo! Posodobi na <a href="{href}"
     target="_blank" rel="noreferrer noopener">{nextVersion}</a>.
   show-std: Prikaži oznake stdout in stderr
+  show-std-desc: 'Označi, ali vrstica prihaja iz stdout ali stderr.'
   compact: Omogoči kompaktni način za dnevnike
+  compact-desc: 'Zmanjša razmike med vrsticami dnevnika, da jih je na zaslonu več.'
   size:
     small: Majhna
     medium: Srednja
@@ -222,6 +235,7 @@ settings:
   help-support: "Prosimo, podprite Dozzle z donacijo ali sponzoriranjem na GitHubu.
     Vaši prispevki nam pomagajo izboljšati Dozzle za vse. Hvala! 🙏🏼\n"
   automatic-redirect: Samodejna preusmeritev na nove zabojnike z istim imenom
+  automatic-redirect-desc: 'Ko je vsebnik zamenjan, sledi novemu.'
 releases:
   features: ena nova funkcija | {count} funkcij
   bugFixes: en popravek napake | {count} popravkov

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -161,6 +161,7 @@ placeholder:
   search: Ara
 settings:
   show-image-update-alert: 'Bir kapsayıcının güncellemesi olduğunda bildirim göster'
+  show-image-update-alert-desc: 'Çalışan imajın daha yeni bir etiketi için kayıt defterini denetler.'
   help-support: >
     Lütfen GitHub'da bağış yaparak veya bizi sponsor olarak destekleyerek Dozzle'ı destekleyin. Katkılarınız Dozzle'ı herkes için geliştirmemize yardımcı oluyor. Teşekkürler! 🙏🏼
   about-desc: Dozzle kurulumunuz ve projeyi nasıl destekleyebileceğiniz hakkında bilgiler.
@@ -171,26 +172,39 @@ settings:
   support-help: Bağışlar Dozzle'ın ücretsiz kalmasına ve bakımının sürmesine yardımcı olur. Teşekkürler 🙏
   display: Görünüm
   locale: Dili geçersiz kıl
+  locale-desc: 'Varsayılan olarak tarayıcınızın dilini kullanır.'
   small-scrollbars: Daha küçük kaydırma çubukları kullan
+  small-scrollbars-desc: 'Daha ince kaydırma çubukları, küçük ekranlarda kullanışlıdır.'
   show-timestamps: Zaman damgalarını göster
+  show-timestamps-desc: 'Her satırın başına yazıldığı saati ekler.'
   soft-wrap: Satırları yumuşak kaydır
+  soft-wrap-desc: 'Yana kaydırmak yerine uzun satırları alt satıra kaydırır.'
   datetime-format: Tarih ve saat biçimini geçersiz kıl
+  datetime-format-desc: 'Varsayılan olarak tarayıcınızın dilini ve saat biçimini kullanır.'
   font-size: Günlükler için kullanılacak yazı tipi boyutu
+  font-size-desc: 'Yalnızca günlük çıktısı için geçerlidir, uygulamanın geri kalanı için değil.'
   color-scheme: Renk düzeni
+  color-scheme-desc: 'Otomatik, sistem ayarınızı izler.'
   options: Seçenekler
   show-stopped-containers: Durdurulan konteynerleri göster
+  show-stopped-containers-desc: 'Durdurulmuş konteynerleri kenar çubuğuna ve listelere dahil eder.'
   group-containers: Konteynerleri ad alanına göre grupla
+  group-containers-desc: 'Compose projesine, Swarm yığınına veya dev.dozzle.group değerine göre gruplar.'
   show-app-icons: 'Uygulama simgelerini göster'
   show-app-icons-desc: 'Bilinen imajları logolarıyla eşleştir. Simgeler Dozzle ile birlikte gelir ve hiçbir zaman internetten indirilmez.'
   about: Hakkında
   search: Dozzle kullanarak aramayı etkinleştir
+  search-desc: 'Görüntülediğiniz konteynerin günlüklerinde arama yapar.'
   using-version: <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version} kullanıyorsunuz.
   update-available: >-
     Yeni sürüm mevcut! <a href="{href}" target="_blank"
     rel="noreferrer noopener">{nextVersion}</a> sürümüne güncelleyin.
   show-std: stdout ve stderr etiketlerini göster
+  show-std-desc: 'Satırın stdout''tan mı stderr''den mi geldiğini gösterir.'
   automatic-redirect: Aynı ada sahip yeni konteynerlere otomatik olarak yönlendir
+  automatic-redirect-desc: 'Bir konteyner değiştirildiğinde yenisine geç.'
   compact: Günlükler için kompakt modu etkinleştir
+  compact-desc: 'Günlük satırları arasındaki boşluğu azaltarak ekrana daha fazlası sığar.'
   size:
     small: Küçük
     medium: Orta

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -160,6 +160,7 @@ placeholder:
   search: 搜尋
 settings:
   show-image-update-alert: '當容器有更新時顯示通知'
+  show-image-update-alert-desc: '檢查登錄檔中是否有執行中映像的較新標籤。'
   help-support: >
     請透過在 GitHub 上捐款或贊助我們來支持 Dozzle。您的貢獻幫助我們為所有人改進 Dozzle。謝謝！ 🙏🏼
   about-desc: 關於您的 Dozzle 安裝以及如何支持本專案的資訊。
@@ -170,26 +171,39 @@ settings:
   support-help: 捐款有助於維持 Dozzle 免費並持續維護。謝謝 🙏
   display: 顯示
   locale: 變更語言
+  locale-desc: '預設沿用瀏覽器的語言。'
   small-scrollbars: 使用較小的捲軸
+  small-scrollbars-desc: '較細的捲軸，在小螢幕上很實用。'
   show-timestamps: 顯示時間戳記
+  show-timestamps-desc: '在每一行前面加上寫入時間。'
   soft-wrap: 自動換行
+  soft-wrap-desc: '自動換行顯示長行，而非左右捲動。'
   datetime-format: 變更日期與時間格式
+  datetime-format-desc: '預設沿用瀏覽器的語言與時間格式。'
   font-size: 日誌字型大小
+  font-size-desc: '僅套用於日誌輸出，不影響應用程式其他部分。'
   color-scheme: 顏色設定
+  color-scheme-desc: '自動會跟隨系統設定。'
   options: 選項
   show-stopped-containers: 顯示已停止的容器
+  show-stopped-containers-desc: '在側邊欄與清單中顯示已停止的容器。'
   group-containers: 依命名空間分組容器
+  group-containers-desc: '依 Compose 專案、Swarm 堆疊或 dev.dozzle.group 分組。'
   show-app-icons: '顯示應用程式圖示'
   show-app-icons-desc: '將常見映像對應到其標誌。圖示隨 Dozzle 一起提供，不會從網際網路下載。'
   about: 關於
   search: 啟用 Dozzle 搜尋功能
+  search-desc: '在目前檢視的容器日誌中搜尋。'
   using-version: 您目前使用的是 <a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}。
   update-available: >-
     有新版本可用！請更新至 <a href="{href}" target="_blank"
     rel="noreferrer noopener">{nextVersion}</a>。
   show-std: 顯示標準輸出(stdout)與標準錯誤(stderr)標籤
+  show-std-desc: '標示該行來自 stdout 或 stderr。'
   automatic-redirect: 自動重新導向至相同名稱的新容器
+  automatic-redirect-desc: '當容器被取代時，自動切換到新的容器。'
   compact: 啟用緊湊模式
+  compact-desc: '縮小日誌行之間的間距，讓畫面顯示更多內容。'
   size:
     small: 小
     medium: 中

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -158,6 +158,7 @@ placeholder:
   search: 搜索
 settings:
   show-image-update-alert: '当容器有更新时显示通知'
+  show-image-update-alert-desc: '检查仓库中是否有运行镜像的更新标签。'
   help-support: >
     请通过在 GitHub 上捐赠或赞助我们来支持 Dozzle。您的贡献帮助我们为所有人改进 Dozzle。谢谢！ 🙏🏼
   about-desc: 关于您的 Dozzle 安装及如何支持本项目的信息。
@@ -168,25 +169,38 @@ settings:
   support-help: 捐赠有助于保持 Dozzle 免费并持续维护。谢谢 🙏
   display: 显示
   locale: 显示语言
+  locale-desc: '默认跟随浏览器的语言。'
   small-scrollbars: 使用较小的滚动条
+  small-scrollbars-desc: '更细的滚动条，在小屏幕上很实用。'
   show-timestamps: 显示时间戳
+  show-timestamps-desc: '在每一行前面加上写入时间。'
   soft-wrap: 断行
+  soft-wrap-desc: '自动换行显示长行，而不是左右滚动。'
   datetime-format: 自定义日期和时间格式
+  datetime-format-desc: '默认跟随浏览器的语言和时间格式。'
   font-size: 字体大小
+  font-size-desc: '仅作用于日志输出，不影响应用的其他部分。'
   color-scheme: 颜色方案
+  color-scheme-desc: '自动会跟随系统设置。'
   options: 选项
   show-stopped-containers: 显示已停止的容器
+  show-stopped-containers-desc: '在侧边栏和列表中显示已停止的容器。'
   group-containers: 按命名空间分组容器
+  group-containers-desc: '按 Compose 项目、Swarm 堆栈或 dev.dozzle.group 分组。'
   show-app-icons: '显示应用图标'
   show-app-icons-desc: '将常见镜像匹配到对应的标志。图标随 Dozzle 一起提供，不会从互联网下载。'
   about: 关于
   search: 使用Dozzle启用搜索
+  search-desc: '在当前查看的容器日志中搜索。'
   using-version: 您正在使用<a href="https://dozzle.dev/" target="_blank" rel="noreferrer noopener">Dozzle</a> {version}。
   update-available: >-
     新版本可用！更新到 <a href="{href}" target="_blank" rel="noreferrer noopener">{nextVersion}</a>。
   show-std: 显示stdout和stderr标签
+  show-std-desc: '标示该行来自 stdout 还是 stderr。'
   automatic-redirect: 自动重定向到同名的新容器
+  automatic-redirect-desc: '当容器被替换时，自动跳转到新容器。'
   compact: 紧凑模式
+  compact-desc: '缩小日志行之间的间距，让屏幕显示更多内容。'
   size:
     small: 小
     medium: 中


### PR DESCRIPTION
Stacked on #4976. Review that one first; this diff is only the settings page.

The settings page was a stack of bare labels inside outlined boxes. Several labels had grown into full sentences to compensate ("Automatically redirect to new containers with the same name"), and the boxes made an already dense page feel crowded.

## Descriptions

Every row gets a short description underneath, so the label can go back to being a label. 14 new description keys, translated across all 16 locales.

## SettingRow

Rows moved into a `SettingRow` component, which cut a lot of repeated flex markup out of `settings.vue`. It renders as a `<label>` when the control is a single input, so clicking the text still toggles it, and as a `<div>` for dropdowns and button groups so several interactive elements are not nested inside one label.

## Chrome

Section cards lose the outline and the tinted background, keeping only hairline dividers. Rows lose their horizontal padding as well, which lines them up with the section heading instead of sitting inset. Headings go from `text-xl` to `text-2xl`.

The log preview keeps its border, since that frames a preview rather than a section. The Dozzle Cloud card also keeps its border, since it reads as a call-to-action banner and not a settings list. Happy to strip either if you want them uniform.

## Testing

Rendered the page in English and German through the real locale switcher, not by poking localStorage, so the i18n path is exercised. `pnpm test` 241 passing, `pnpm typecheck` and `pnpm build` clean.

Note the translations are mine, not a native speaker's. Worth a community pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4tza33QFYH98eidfoccyf