### PR TITLE
perf: shrink entry bundle from 628 kB to 85 kB

### DIFF
--- a/assets/build.spec.ts
+++ b/assets/build.spec.ts
@@ -9,16 +9,15 @@ describe("production build", () => {
       build: { write: false },
     });
     const outputs = Array.isArray(result) ? result : [result];
-    const stylesheet = outputs
+    // Routes are code split, so the build emits several stylesheets. The fonts live in
+    // whichever one carries the @font-face rules.
+    const stylesheets = outputs
       .flatMap((output) => ("output" in output ? output.output : []))
-      .find((item) => item.type === "asset" && item.fileName.endsWith(".css"));
+      .filter((item) => item.type === "asset" && item.fileName.endsWith(".css"))
+      .map((item) => String((item as { source: string | Uint8Array }).source));
 
-    expect(stylesheet).toBeDefined();
-    if (!stylesheet || stylesheet.type !== "asset") {
-      throw new Error("Production build did not emit a stylesheet");
-    }
-    const css = String(stylesheet.source);
-    expect(css).toMatch(/url\(\.\/jetbrains-mono/);
-    expect(css).not.toMatch(/url\(\/assets\/jetbrains-mono/);
+    expect(stylesheets.length).toBeGreaterThan(0);
+    expect(stylesheets.some((css) => /url\(\.\/jetbrains-mono/.test(css))).toBe(true);
+    expect(stylesheets.some((css) => /url\(\/assets\//.test(css))).toBe(false);
   }, 15_000);
 });

--- a/assets/layouts/default.vue
+++ b/assets/layouts/default.vue
@@ -64,6 +64,9 @@ const { component: drawerComponent, properties: drawerProperties, width: drawerW
 
 import { useFuzzySearch } from "@/composable/fuzzySearch";
 
+// Pulls fuse.js (~48 KB) with it, and the palette only renders once the user opens it.
+const FuzzySearchModal = defineAsyncComponent(() => import("@/components/FuzzySearchModal.vue"));
+
 const modal = ref<HTMLDialogElement>();
 const { open, openSearch: showFuzzySearch, closeSearch } = useFuzzySearch();
 const searchParams = new URLSearchParams(window.location.search);

--- a/assets/shims/entities.ts
+++ b/assets/shims/entities.ts
@@ -1,0 +1,14 @@
+// ansi-to-html pulls in `entities`, whose full HTML entity table is ~135 KB of the main
+// bundle. We call it with escapeXML: false (see assets/utils/ansi.ts), so only encodeXML is
+// ever reachable and the table is dead weight. Alias `entities` to this in vite.config.ts.
+const XML_ESCAPES: Record<string, string> = {
+  '"': "&quot;",
+  "&": "&amp;",
+  "'": "&apos;",
+  "<": "&lt;",
+  ">": "&gt;",
+};
+
+export const encodeXML = (str: string): string => str.replace(/["&'<>]/g, (c) => XML_ESCAPES[c]);
+
+export default { encodeXML };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,9 @@ export default defineConfig(() => ({
   resolve: {
     alias: {
       "@/": `${path.resolve(import.meta.dirname, "assets")}/`,
+      // ansi-to-html drags in the full `entities` HTML entity table (~135 KB raw). We build
+      // the converter with escapeXML: false, so only encodeXML is reachable. See the shim.
+      entities: path.resolve(import.meta.dirname, "assets/shims/entities.ts"),
     },
   },
   build: {
@@ -42,7 +45,9 @@ export default defineConfig(() => ({
         src: "./assets/pages",
       },
       dts: "./assets/typed-router.d.ts",
-      importMode: "sync", // this can't be async because it won't work with custom base
+      // Async keeps each page out of the entry chunk. Vite resolves the dynamic import
+      // against import.meta.url, so this works under a custom base too.
+      importMode: "async",
     }),
     VueMacros({
       plugins: {


### PR DESCRIPTION
main.js was 628 kB raw / 204 kB gzipped. Now 85 kB / 29 kB.

### Async route imports

The big one, 553 kB -> 132 kB. The `importMode: "sync"` comment said async "won't work with custom base", which is stale. Vite emits `import("./pages-x.js")` resolved through `import.meta.url`, so chunks resolve relative to the module rather than the app base.

Verified headless against a server running on `--base /dozzle`: index loads, `/settings` renders its lazy chunk, no JS errors.

### `entities` shim

`ansi-to-html` does `require('entities')`, which pulls in the full HTML entity table (135 kB raw). `assets/utils/ansi.ts` builds the converter with `escapeXML: false`, so `encodeXML` is the only reachable export. Aliased to a 5 line shim, output checked byte for byte against the real one.

This is the only change here that shrinks total bundle size rather than just deferring it.

### Lazy FuzzySearchModal

132 kB -> 85 kB. Already behind `v-if="open"`, but the static import dragged fuse.js (48 kB) and the modal (20 kB) into the entry chunk anyway.

### Test fix

`build.spec.ts` grabbed the first CSS asset to assert relative font URLs. Routes now emit their own stylesheets, so it checks all of them.

### Not done

- `main.css` is now the largest file at 268 kB, bigger than the entry JS
- HostMenu / K8sMenu / SwarmMenu are all eager (29 kB combined) but only one mode is ever active
- `logo.svg` inlines at 9.2 kB
- vue-router's devtools module (11.5 kB) can't be shaken out, it's a barrel that also re-exports core utils, so `__VUE_PROD_DEVTOOLS__: false` does nothing

241 frontend tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTutJxHggFq6qsAGMgrM8h