### PR TITLE
feat(ui): add loading skeletons to the container table

### DIFF
--- a/assets/components/ContainerTable.vue
+++ b/assets/components/ContainerTable.vue
@@ -36,7 +36,7 @@
         />
       </div>
       <div class="flex flex-1 items-center justify-end gap-2">
-        <div v-show="containers.length > pageSizes[0]">
+        <div v-show="ready && containers.length > pageSizes[0]">
           {{ $t("label.per-page") }}
 
           <DropdownMenu
@@ -95,7 +95,23 @@
           </tr>
         </thead>
         <tbody class="bg-base-300/30">
+          <template v-if="!ready">
+            <tr v-for="i in skeletonRows" :key="`skeleton-${i}`">
+              <td v-if="isVisible('name')" class="max-w-80 max-md:max-w-none">
+                <div class="flex items-center gap-2">
+                  <div class="skeleton size-6 shrink-0 rounded-full"></div>
+                  <div class="skeleton h-4 w-40 max-w-full"></div>
+                </div>
+              </td>
+              <td v-if="isVisible('host')"><div class="skeleton h-4 w-20"></div></td>
+              <td v-if="isVisible('state')"><div class="skeleton h-4 w-16"></div></td>
+              <td v-if="isVisible('created')"><div class="skeleton h-4 w-24"></div></td>
+              <td v-if="isVisible('cpu')"><div class="skeleton h-4 w-full"></div></td>
+              <td v-if="isVisible('mem')"><div class="skeleton h-4 w-full"></div></td>
+            </tr>
+          </template>
           <tr
+            v-else
             v-for="container in paginated"
             :key="container.id"
             v-memo="[container.id, container.state, container.health, statMode, isMobile, showAppIcons]"
@@ -160,7 +176,7 @@
       </table>
     </div>
     <div class="p-4 text-center">
-      <nav class="join" v-if="isPaginated && totalPages <= 15">
+      <nav class="join" v-if="ready && isPaginated && totalPages <= 15">
         <input
           class="btn btn-square join-item"
           type="radio"
@@ -171,7 +187,7 @@
         />
       </nav>
       <DropdownMenu
-        v-else-if="isPaginated"
+        v-else-if="ready && isPaginated"
         class="btn-sm"
         v-model="currentPage"
         :options="Array.from({ length: totalPages }, (_, i) => ({ label: `${i + 1}`, value: i + 1 }))"
@@ -245,6 +261,8 @@ const fields: Record<
 const { containers } = defineProps<{
   containers: Container[];
 }>();
+
+const { ready } = storeToRefs(useContainerStore());
 type keys = keyof typeof fields;
 
 const statMode = useStorage<"chart" | "progress">("DOZZLE_TABLE_STAT_MODE", "chart");
@@ -265,6 +283,7 @@ const sortedContainers = computedWithControl(
   () => filteredContainers.value.sort((a, b) => fields[sortField.value].sortFunc(a, b)),
 );
 
+const skeletonRows = computed(() => Math.min(perPage.value, 5));
 const totalPages = computed(() => Math.ceil(sortedContainers.value.length / perPage.value));
 const isPaginated = computed(() => totalPages.value > 1);
 const currentPage = ref(1);

--- a/assets/components/ContainerTable.vue
+++ b/assets/components/ContainerTable.vue
@@ -96,18 +96,29 @@
         </thead>
         <tbody class="bg-base-300/30">
           <template v-if="!ready">
-            <tr v-for="i in skeletonRows" :key="`skeleton-${i}`">
+            <tr v-for="i in skeletonRows" :key="`skeleton-${i}`" role="status" class="animate-pulse">
               <td v-if="isVisible('name')" class="max-w-80 max-md:max-w-none">
                 <div class="flex items-center gap-2">
-                  <div class="skeleton size-6 shrink-0 rounded-full"></div>
-                  <div class="skeleton h-4 w-40 max-w-full"></div>
+                  <div class="bg-base-content/50 size-6 shrink-0 rounded-full opacity-50"></div>
+                  <div class="bg-base-content/50 h-3 w-40 max-w-full rounded-full opacity-50"></div>
+                  <span class="sr-only">Loading...</span>
                 </div>
               </td>
-              <td v-if="isVisible('host')"><div class="skeleton h-4 w-20"></div></td>
-              <td v-if="isVisible('state')"><div class="skeleton h-4 w-16"></div></td>
-              <td v-if="isVisible('created')"><div class="skeleton h-4 w-24"></div></td>
-              <td v-if="isVisible('cpu')"><div class="skeleton h-4 w-full"></div></td>
-              <td v-if="isVisible('mem')"><div class="skeleton h-4 w-full"></div></td>
+              <td v-if="isVisible('host')">
+                <div class="bg-base-content/50 h-3 w-20 rounded-full opacity-50"></div>
+              </td>
+              <td v-if="isVisible('state')">
+                <div class="bg-base-content/50 h-3 w-16 rounded-full opacity-50"></div>
+              </td>
+              <td v-if="isVisible('created')">
+                <div class="bg-base-content/50 h-3 w-24 rounded-full opacity-50"></div>
+              </td>
+              <td v-if="isVisible('cpu')">
+                <div class="bg-base-content/50 h-3 w-full rounded-full opacity-50"></div>
+              </td>
+              <td v-if="isVisible('mem')">
+                <div class="bg-base-content/50 h-3 w-full rounded-full opacity-50"></div>
+              </td>
             </tr>
           </template>
           <tr

--- a/assets/stores/container.ts
+++ b/assets/stores/container.ts
@@ -63,7 +63,10 @@ export const useContainerStore = defineStore("container", () => {
       }
     });
 
-    es.addEventListener("containers-changed", (e) => updateContainers(parseEventData<ContainerJson[]>(e)));
+    es.addEventListener("containers-changed", (e) => {
+      updateContainers(parseEventData<ContainerJson[]>(e));
+      ready.value = true;
+    });
     es.addEventListener("container-stat", (e) => {
       const stat = parseEventData<ContainerStat>(e);
       const container = allContainersById.value[stat.id] as unknown as UnwrapNestedRefs<Container>;
@@ -132,8 +135,6 @@ export const useContainerStore = defineStore("container", () => {
         containers.value = [];
       }
     };
-
-    watchOnce(containers, () => (ready.value = true));
   }
 
   connect();


### PR DESCRIPTION
The homepage table rendered empty until the first events payload arrived. Now it shows skeleton rows matching the column layout while the container store is loading, and the per-page selector and pagination stay hidden until then.

Also flips `ready` on the first `containers-changed` event instead of watching the containers array. The old version never became ready when a host had zero containers, which left the store stuck loading and fired the 8s timeout toast.

Typecheck and all 241 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P71CaiCVm3uu9jMi2WZtM6