### PR TITLE
fix(auth): resolve roles from users.yml instead of the JWT claim

### DIFF
--- a/internal/auth/simple.go
+++ b/internal/auth/simple.go
@@ -47,18 +47,31 @@ func NewSimpleAuth(userDatabase UserDatabase, ttl time.Duration) *simpleAuthCont
 	}
 }
 
+// find and findByPassword copy the user out of the database rather than handing
+// back the pointer into UserDatabase.Users, so a caller reading it after the lock
+// is released cannot race a reload of users.yml.
 func (a *simpleAuthContext) find(username string) *User {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	return a.UserDatabase.Find(username)
+	return copyUser(a.UserDatabase.Find(username))
 }
 
 func (a *simpleAuthContext) findByPassword(username, password string) *User {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	return a.UserDatabase.FindByPassword(username, password)
+	return copyUser(a.UserDatabase.FindByPassword(username, password))
+}
+
+func copyUser(user *User) *User {
+	if user == nil {
+		return nil
+	}
+
+	copied := *user
+
+	return &copied
 }
 
 func (a *simpleAuthContext) CreateToken(username, password string) (string, error) {
@@ -125,6 +138,10 @@ func (a *simpleAuthContext) userFromToken(ctx context.Context) *User {
 	}
 
 	user := newUser(configured.Username, configured.Email, configured.Name, labels, configured.Roles)
+	// Carry the raw filter and role strings too, so the resolved user is the same
+	// shape as the one users.yml describes rather than a partially filled copy.
+	user.Filter = configured.Filter
+	user.RolesConfigured = configured.RolesConfigured
 
 	return &user
 }

--- a/internal/auth/simple.go
+++ b/internal/auth/simple.go
@@ -1,20 +1,27 @@
 package auth
 
 import (
+	"context"
 	"crypto/sha256"
 	"errors"
 	"maps"
 	"net/http"
 	"slices"
+	"sync"
 	"time"
 
+	"github.com/amir20/dozzle/internal/container"
 	"github.com/go-chi/jwtauth/v5"
+	"github.com/rs/zerolog/log"
 )
 
 type simpleAuthContext struct {
 	UserDatabase UserDatabase
 	tokenAuth    *jwtauth.JWTAuth
 	ttl          time.Duration
+	// UserDatabase.Find reloads users.yml in place, and the middleware now calls it
+	// on every request, so the reload has to be serialized.
+	mu sync.Mutex
 }
 
 var ErrInvalidCredentials = errors.New("invalid credentials")
@@ -40,8 +47,22 @@ func NewSimpleAuth(userDatabase UserDatabase, ttl time.Duration) *simpleAuthCont
 	}
 }
 
+func (a *simpleAuthContext) find(username string) *User {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.UserDatabase.Find(username)
+}
+
+func (a *simpleAuthContext) findByPassword(username, password string) *User {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	return a.UserDatabase.FindByPassword(username, password)
+}
+
 func (a *simpleAuthContext) CreateToken(username, password string) (string, error) {
-	user := a.UserDatabase.FindByPassword(username, password)
+	user := a.findByPassword(username, password)
 	if user == nil {
 		return "", ErrInvalidCredentials
 	}
@@ -62,5 +83,48 @@ func (a *simpleAuthContext) CreateToken(username, password string) (string, erro
 }
 
 func (a *simpleAuthContext) AuthMiddleware(next http.Handler) http.Handler {
-	return jwtauth.Verifier(a.tokenAuth)(next)
+	return jwtauth.Verifier(a.tokenAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The roles claim is a bitmask frozen at login, so it goes stale the moment
+		// the set of roles grows: a session minted before the cloud role existed
+		// carries a mask without that bit and quietly loses the feature until the
+		// user happens to log out. The same is true of a roles or filter edit in
+		// users.yml. Resolve both from the database per request and let the token
+		// prove only who the user is.
+		if user := a.userFromToken(r.Context()); user != nil {
+			r = r.WithContext(WithUser(r.Context(), *user))
+		}
+
+		next.ServeHTTP(w, r)
+	}))
+}
+
+// userFromToken resolves the verified token's subject against users.yml. It returns
+// nil for a missing or invalid token, and for a user who is no longer configured, so
+// the request falls through to RequireAuthentication as unauthenticated.
+func (a *simpleAuthContext) userFromToken(ctx context.Context) *User {
+	_, claims, err := jwtauth.FromContext(ctx)
+	if err != nil {
+		return nil
+	}
+
+	username, ok := claims["username"].(string)
+	if !ok || username == "" {
+		return nil
+	}
+
+	configured := a.find(username)
+	if configured == nil {
+		log.Debug().Str("username", username).Msg("Token is valid but user is no longer in the user database")
+		return nil
+	}
+
+	labels, err := container.ParseContainerFilter(configured.Filter)
+	if err != nil {
+		log.Warn().Err(err).Str("filter", configured.Filter).Msg("Failed to parse container filter")
+		return nil
+	}
+
+	user := newUser(configured.Username, configured.Email, configured.Name, labels, configured.Roles)
+
+	return &user
 }

--- a/internal/auth/simple.go
+++ b/internal/auth/simple.go
@@ -47,36 +47,36 @@ func NewSimpleAuth(userDatabase UserDatabase, ttl time.Duration) *simpleAuthCont
 	}
 }
 
-// find and findByPassword copy the user out of the database rather than handing
-// back the pointer into UserDatabase.Users, so a caller reading it after the lock
-// is released cannot race a reload of users.yml.
-func (a *simpleAuthContext) find(username string) *User {
+// find and findByPassword return the user by value. UserDatabase.Find hands back
+// a pointer into UserDatabase.Users, and dereferencing it under the lock means no
+// caller can read a user while a reload of users.yml is replacing it.
+func (a *simpleAuthContext) find(username string) (User, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	return copyUser(a.UserDatabase.Find(username))
-}
-
-func (a *simpleAuthContext) findByPassword(username, password string) *User {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	return copyUser(a.UserDatabase.FindByPassword(username, password))
-}
-
-func copyUser(user *User) *User {
+	user := a.UserDatabase.Find(username)
 	if user == nil {
-		return nil
+		return User{}, false
 	}
 
-	copied := *user
+	return *user, true
+}
 
-	return &copied
+func (a *simpleAuthContext) findByPassword(username, password string) (User, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	user := a.UserDatabase.FindByPassword(username, password)
+	if user == nil {
+		return User{}, false
+	}
+
+	return *user, true
 }
 
 func (a *simpleAuthContext) CreateToken(username, password string) (string, error) {
-	user := a.findByPassword(username, password)
-	if user == nil {
+	user, ok := a.findByPassword(username, password)
+	if !ok {
 		return "", ErrInvalidCredentials
 	}
 
@@ -125,8 +125,8 @@ func (a *simpleAuthContext) userFromToken(ctx context.Context) *User {
 		return nil
 	}
 
-	configured := a.find(username)
-	if configured == nil {
+	configured, ok := a.find(username)
+	if !ok {
 		log.Debug().Str("username", username).Msg("Token is valid but user is no longer in the user database")
 		return nil
 	}

--- a/internal/auth/simple.go
+++ b/internal/auth/simple.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/amir20/dozzle/internal/container"
 	"github.com/go-chi/jwtauth/v5"
 	"github.com/rs/zerolog/log"
 )
@@ -47,9 +46,9 @@ func NewSimpleAuth(userDatabase UserDatabase, ttl time.Duration) *simpleAuthCont
 	}
 }
 
-// find and findByPassword return the user by value. UserDatabase.Find hands back
-// a pointer into UserDatabase.Users, and dereferencing it under the lock means no
-// caller can read a user while a reload of users.yml is replacing it.
+// find returns the user by value. UserDatabase.Find hands back a pointer into
+// UserDatabase.Users and reloads users.yml as it goes, so dereferencing it under
+// the lock keeps a reload from racing whoever is reading the user.
 func (a *simpleAuthContext) find(username string) (User, bool) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -62,25 +61,15 @@ func (a *simpleAuthContext) find(username string) (User, bool) {
 	return *user, true
 }
 
-func (a *simpleAuthContext) findByPassword(username, password string) (User, bool) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	user := a.UserDatabase.FindByPassword(username, password)
-	if user == nil {
-		return User{}, false
-	}
-
-	return *user, true
-}
-
 func (a *simpleAuthContext) CreateToken(username, password string) (string, error) {
-	user, ok := a.findByPassword(username, password)
-	if !ok {
+	user, ok := a.find(username)
+	if !ok || !CompareHashAndPassword(user.Password, password) {
 		return "", ErrInvalidCredentials
 	}
 
-	claims := map[string]any{"username": user.Username, "email": user.Email, "name": user.Name, "filter": user.Filter, "roles": user.Roles}
+	// Identity only. Everything else about the user is read from users.yml per
+	// request, so anything baked in here would just be a copy that goes stale.
+	claims := map[string]any{"username": user.Username}
 	jwtauth.SetIssuedNow(claims)
 
 	if a.ttl > 0 {
@@ -125,23 +114,13 @@ func (a *simpleAuthContext) userFromToken(ctx context.Context) *User {
 		return nil
 	}
 
-	configured, ok := a.find(username)
+	user, ok := a.find(username)
 	if !ok {
 		log.Debug().Str("username", username).Msg("Token is valid but user is no longer in the user database")
 		return nil
 	}
 
-	labels, err := container.ParseContainerFilter(configured.Filter)
-	if err != nil {
-		log.Warn().Err(err).Str("filter", configured.Filter).Msg("Failed to parse container filter")
-		return nil
-	}
-
-	user := newUser(configured.Username, configured.Email, configured.Name, labels, configured.Roles)
-	// Carry the raw filter and role strings too, so the resolved user is the same
-	// shape as the one users.yml describes rather than a partially filled copy.
-	user.Filter = configured.Filter
-	user.RolesConfigured = configured.RolesConfigured
+	user.Password = ""
 
 	return &user
 }

--- a/internal/auth/simple_test.go
+++ b/internal/auth/simple_test.go
@@ -175,12 +175,3 @@ func TestSimpleAuthResolvesFilterFromDatabase(t *testing.T) {
 	require.Equal(t, "name=foo", user.Filter)
 	require.Equal(t, []string{"foo"}, user.ContainerLabels["name"])
 }
-
-// The resolved user must not alias the database entry, so a reload of users.yml
-// cannot mutate a user another request is already holding.
-func TestSimpleAuthDoesNotAliasTheUserDatabase(t *testing.T) {
-	alice := &User{Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all", Roles: All}
-	a := NewSimpleAuth(UserDatabase{Users: map[string]*User{"alice": alice}}, 0)
-
-	require.NotSame(t, alice, a.find("alice"))
-}

--- a/internal/auth/simple_test.go
+++ b/internal/auth/simple_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -157,14 +159,20 @@ func TestSimpleAuthWithoutTokenHasNoUser(t *testing.T) {
 	require.Nil(t, serveWithAuth(t, NewSimpleAuth(users, 0), ""))
 }
 
-// The container filter comes from users.yml as well, both parsed into labels for
-// downstream filtering and kept as the raw string on the user.
+// The container filter comes from users.yml as well, parsed into labels when the
+// file is read so a token cannot pin a stale one.
 func TestSimpleAuthResolvesFilterFromDatabase(t *testing.T) {
-	users := UserDatabase{
-		Users: map[string]*User{
-			"alice": {Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Filter: "name=foo", RolesConfigured: "all", Roles: All},
-		},
-	}
+	path := filepath.Join(t.TempDir(), "users.yml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+users:
+  alice:
+    name: Alice
+    password: "$2y$11$pTGu6dnTT7Uh3ob7uC6X7OkAamlhHpJ0/mEbsmiPyO85pumillZme"
+    filter: "name=foo"
+`), 0o600))
+
+	users, err := ReadUsersFromFile(path)
+	require.NoError(t, err)
 
 	a := NewSimpleAuth(users, 0)
 	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "alice", "filter": "name=stale"})
@@ -174,4 +182,21 @@ func TestSimpleAuthResolvesFilterFromDatabase(t *testing.T) {
 	require.NotNil(t, user)
 	require.Equal(t, "name=foo", user.Filter)
 	require.Equal(t, []string{"foo"}, user.ContainerLabels["name"])
+	require.Equal(t, All, user.Roles, "no roles key in users.yml means everything")
+	require.Empty(t, user.Password, "the resolved user must not carry the password hash")
+}
+
+// An unparseable filter fails the read instead of silently locking the user out
+// of every container on their next request.
+func TestReadUsersRejectsInvalidFilter(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "users.yml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+users:
+  alice:
+    password: "$2y$11$pTGu6dnTT7Uh3ob7uC6X7OkAamlhHpJ0/mEbsmiPyO85pumillZme"
+    filter: "nope"
+`), 0o600))
+
+	_, err := ReadUsersFromFile(path)
+	require.Error(t, err)
 }

--- a/internal/auth/simple_test.go
+++ b/internal/auth/simple_test.go
@@ -1,6 +1,8 @@
 package auth
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -47,4 +49,110 @@ func TestSimpleAuthSigningKeyChangesWhenCredentialsChange(t *testing.T) {
 	users.Users["bob"].RolesConfigured = "shell,actions"
 	_, err = NewSimpleAuth(users, 0).tokenAuth.Decode(token)
 	require.Error(t, err)
+}
+
+// serveWithAuth runs a request carrying token through the simple auth middleware
+// and returns the user the handlers would see.
+func serveWithAuth(t *testing.T, a *simpleAuthContext, token string) *User {
+	t.Helper()
+
+	var user *User
+	handler := a.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user = UserFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	return user
+}
+
+// The roles claim is a bitmask frozen at login. Adding a role to the code (cloud
+// was the case that broke) leaves every existing session on the old mask without
+// the new bit, and users.yml is unchanged so the signing key does not roll either.
+// Roles have to come from the database on each request, not from the token.
+func TestSimpleAuthUsesCurrentRolesNotTheTokensRoles(t *testing.T) {
+	users := UserDatabase{
+		Users: map[string]*User{
+			"alice": {Username: "alice", Name: "Alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all", Roles: All},
+		},
+	}
+
+	a := NewSimpleAuth(users, 0)
+
+	// A session minted back when All did not include Cloud.
+	stale := All &^ Cloud
+	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "alice", "roles": float64(stale)})
+	require.NoError(t, err)
+
+	user := serveWithAuth(t, a, token)
+	require.NotNil(t, user)
+	require.Equal(t, All, user.Roles)
+	require.True(t, user.Roles.Has(Cloud), "cloud must come back without forcing a re-login")
+}
+
+// A narrowed role in users.yml must apply to live sessions too, not only after
+// the user logs out.
+func TestSimpleAuthAppliesRevokedRolesToExistingSessions(t *testing.T) {
+	users := UserDatabase{
+		Users: map[string]*User{
+			"alice": {Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all,^shell", Roles: ParseRole("all,^shell")},
+		},
+	}
+
+	a := NewSimpleAuth(users, 0)
+	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "alice", "roles": float64(All)})
+	require.NoError(t, err)
+
+	user := serveWithAuth(t, a, token)
+	require.NotNil(t, user)
+	require.False(t, user.Roles.Has(Shell))
+	require.True(t, user.Roles.Has(Actions))
+}
+
+// A token for a user who is gone from users.yml resolves to no user, so the
+// request is unauthenticated rather than running with the token's claims.
+func TestSimpleAuthRejectsTokenForUnknownUser(t *testing.T) {
+	users := UserDatabase{
+		Users: map[string]*User{
+			"alice": {Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all", Roles: All},
+		},
+	}
+
+	a := NewSimpleAuth(users, 0)
+	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "mallory", "roles": float64(All)})
+	require.NoError(t, err)
+
+	require.Nil(t, serveWithAuth(t, a, token))
+}
+
+// A session minted before roles existed at all carries no roles claim. Resolving
+// against users.yml means the session keeps exactly the permissions it is
+// configured for instead of silently losing all of them on upgrade.
+func TestSimpleAuthResolvesTokenWithNoRolesClaim(t *testing.T) {
+	users := UserDatabase{
+		Users: map[string]*User{
+			"alice": {Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all", Roles: All},
+		},
+	}
+
+	a := NewSimpleAuth(users, 0)
+	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "alice"})
+	require.NoError(t, err)
+
+	user := serveWithAuth(t, a, token)
+	require.NotNil(t, user)
+	require.Equal(t, All, user.Roles)
+}
+
+// No token at all stays unauthenticated so the login routes keep working.
+func TestSimpleAuthWithoutTokenHasNoUser(t *testing.T) {
+	users := UserDatabase{
+		Users: map[string]*User{
+			"alice": {Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all", Roles: All},
+		},
+	}
+
+	require.Nil(t, serveWithAuth(t, NewSimpleAuth(users, 0), ""))
 }

--- a/internal/auth/simple_test.go
+++ b/internal/auth/simple_test.go
@@ -156,3 +156,31 @@ func TestSimpleAuthWithoutTokenHasNoUser(t *testing.T) {
 
 	require.Nil(t, serveWithAuth(t, NewSimpleAuth(users, 0), ""))
 }
+
+// The container filter comes from users.yml as well, both parsed into labels for
+// downstream filtering and kept as the raw string on the user.
+func TestSimpleAuthResolvesFilterFromDatabase(t *testing.T) {
+	users := UserDatabase{
+		Users: map[string]*User{
+			"alice": {Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", Filter: "name=foo", RolesConfigured: "all", Roles: All},
+		},
+	}
+
+	a := NewSimpleAuth(users, 0)
+	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "alice", "filter": "name=stale"})
+	require.NoError(t, err)
+
+	user := serveWithAuth(t, a, token)
+	require.NotNil(t, user)
+	require.Equal(t, "name=foo", user.Filter)
+	require.Equal(t, []string{"foo"}, user.ContainerLabels["name"])
+}
+
+// The resolved user must not alias the database entry, so a reload of users.yml
+// cannot mutate a user another request is already holding.
+func TestSimpleAuthDoesNotAliasTheUserDatabase(t *testing.T) {
+	alice := &User{Username: "alice", Password: "$2a$11$aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", RolesConfigured: "all", Roles: All}
+	a := NewSimpleAuth(UserDatabase{Users: map[string]*User{"alice": alice}}, 0)
+
+	require.NotSame(t, alice, a.find("alice"))
+}

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -116,6 +116,12 @@ func decodeUsersFromFile(path string) (UserDatabase, error) {
 		}
 
 		user.Roles = ParseRole(user.RolesConfigured)
+
+		labels, err := container.ParseContainerFilter(user.Filter)
+		if err != nil {
+			return users, fmt.Errorf("user %s has an invalid filter %q: %w", username, user.Filter, err)
+		}
+		user.ContainerLabels = labels
 	}
 
 	return users, nil
@@ -152,20 +158,6 @@ func (u *UserDatabase) Find(username string) *User {
 	if !ok {
 		return nil
 	}
-	return user
-}
-
-func (u *UserDatabase) FindByPassword(username, password string) *User {
-	user := u.Find(username)
-
-	if user == nil {
-		return nil
-	}
-
-	if !CompareHashAndPassword(user.Password, password) {
-		return nil
-	}
-
 	return user
 }
 

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/amir20/dozzle/internal/container"
-	"github.com/go-chi/jwtauth/v5"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/yaml.v3"
@@ -185,47 +184,17 @@ func CompareHashAndPassword(hash, password string) bool {
 	return false
 }
 
+// UserFromContext returns the user an authentication middleware resolved for this
+// request. Both providers resolve the user themselves: proxy auth from the request
+// headers, simple auth from users.yml keyed by the verified token's username. Roles
+// deliberately are not read back out of the JWT, because a bitmask frozen at login
+// goes stale the moment the role set grows or users.yml changes.
 func UserFromContext(ctx context.Context) *User {
 	if user, ok := ctx.Value(remoteUser).(User); ok {
 		return &user
-	} else {
-		if _, claims, err := jwtauth.FromContext(ctx); err == nil {
-			username, ok := claims["username"].(string)
-			if !ok {
-				return nil
-			}
-			if username == "" {
-				return nil
-			}
-			email := claims["email"].(string)
-			name := claims["name"].(string)
-			containerFilter := container.ContainerLabels{}
-
-			if filter, ok := claims["filter"].(string); ok {
-				containerFilter, err = container.ParseContainerFilter(filter)
-				if err != nil {
-					log.Warn().Err(err).Str("filter", filter).Msg("Failed to parse container filter")
-					return nil
-				}
-			}
-			// A token minted before roles existed carries no roles claim at all.
-			// Defaulting to None silently stripped every permission from a session
-			// that is otherwise still valid, so an upgrade quietly hid notifications,
-			// cloud and downloads until the user happened to log out. Absent means
-			// full access here, matching an absent `roles` in users.yml and an absent
-			// roles header in proxy auth.
-			roles := All
-			if r, ok := claims["roles"].(float64); ok {
-				roles = Role(r)
-			} else if claims["roles"] != nil {
-				log.Warn().Interface("roles", claims["roles"]).Msg("Failed to parse roles from JWT claims")
-			}
-
-			user := newUser(username, email, name, containerFilter, roles)
-			return &user
-		}
-		return nil
 	}
+
+	return nil
 }
 
 func RequireAuthentication(next http.Handler) http.Handler {

--- a/internal/auth/users_test.go
+++ b/internal/auth/users_test.go
@@ -1,88 +1,10 @@
 package auth
 
 import (
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
-	"github.com/go-chi/jwtauth/v5"
 	"github.com/stretchr/testify/require"
 )
-
-// userFromToken runs claims through the real Verifier so the test exercises the
-// same path a browser's session cookie takes.
-func userFromToken(t *testing.T, claims map[string]any) *User {
-	t.Helper()
-
-	tokenAuth := jwtauth.New("HS256", []byte("secret"), nil)
-	_, tokenString, err := tokenAuth.Encode(claims)
-	require.NoError(t, err)
-
-	var user *User
-	handler := jwtauth.Verifier(tokenAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		user = UserFromContext(r.Context())
-	}))
-
-	req := httptest.NewRequest(http.MethodGet, "/", nil)
-	req.Header.Set("Authorization", "Bearer "+tokenString)
-	handler.ServeHTTP(httptest.NewRecorder(), req)
-
-	return user
-}
-
-// Tokens minted before roles existed carry no roles claim. Reading that as None
-// silently stripped every permission from sessions that were otherwise still
-// valid, so upgrading Dozzle hid notifications, cloud and downloads until the
-// user happened to log out. Absent means full access, the same as an absent
-// `roles` in users.yml and an absent roles header in proxy auth.
-func TestUserFromContextMissingRolesClaimGrantsAll(t *testing.T) {
-	user := userFromToken(t, map[string]any{
-		"username": "alice",
-		"email":    "alice@example.com",
-		"name":     "Alice",
-	})
-
-	require.NotNil(t, user)
-	require.Equal(t, All, user.Roles)
-	for name, role := range map[string]Role{
-		"shell":         Shell,
-		"actions":       Actions,
-		"download":      Download,
-		"notifications": Notifications,
-		"cloud":         Cloud,
-	} {
-		require.Truef(t, user.Roles.Has(role), "expected %s to be granted", name)
-	}
-}
-
-// An explicit claim still wins, including one that grants nothing.
-func TestUserFromContextHonoursExplicitRolesClaim(t *testing.T) {
-	user := userFromToken(t, map[string]any{
-		"username": "alice",
-		"email":    "alice@example.com",
-		"name":     "Alice",
-		"roles":    float64(Shell | Actions),
-	})
-
-	require.NotNil(t, user)
-	require.True(t, user.Roles.Has(Shell))
-	require.True(t, user.Roles.Has(Actions))
-	require.False(t, user.Roles.Has(Cloud))
-	require.False(t, user.Roles.Has(Download))
-}
-
-func TestUserFromContextExplicitNoneGrantsNothing(t *testing.T) {
-	user := userFromToken(t, map[string]any{
-		"username": "alice",
-		"email":    "alice@example.com",
-		"name":     "Alice",
-		"roles":    float64(None),
-	})
-
-	require.NotNil(t, user)
-	require.Equal(t, None, user.Roles)
-	require.False(t, user.Roles.Has(Cloud))
-}
 
 // Every role bit must be covered by All. Adding a new role without adding it to
 // All is what let Cloud fall outside the default in the first place.
@@ -98,8 +20,7 @@ func TestAllCoversEveryRole(t *testing.T) {
 	}
 }
 
-// A user in users.yml with no roles key gets everything, which is the behaviour
-// the JWT default above mirrors.
+// A user in users.yml with no roles key gets everything.
 func TestUserWithoutConfiguredRolesGetsAll(t *testing.T) {
 	require.Equal(t, All, ParseRole("all"))
 }


### PR DESCRIPTION
#4979 only covered tokens with no `roles` claim. A session minted between the roles feature (5f24657b) and the cloud role (3794a3b6) has a claim, it just predates the `Cloud` bit, so it carries `roles: 30` and parses fine. The `roles := All` default never applies and cloud stays hidden. The signing key digest hashes users.yml, and adding a role in code does not touch users.yml, so the key does not roll either. Only logging out fixes it.

Same thing happens for any future role bit, and for a `roles:` or `filter:` edit in users.yml on a live session.

Simple auth now resolves the user from users.yml on every request and puts them in the request context, the same way proxy auth already does. The token proves identity, nothing else.

- `UserFromContext` drops the claims fallback, so roles have one source of truth. That also closes the path where a still-valid token for a user removed from users.yml got `All`.
- `UserDatabase.Find` reloads users.yml in place and now runs per request, so it is behind a mutex.
- Replaced the JWT-claims tests with middleware tests: stale mask picks up cloud, revoked role applies to a live session, token with no roles claim, unknown user, no token.

Role and filter edits in users.yml now take effect on the next request rather than at next login.

`go build ./...`, `go vet ./internal/...` and `go test -race ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X8fhaUTBkCruxzHioZSCQn