### PR TITLE
fix(cloud): report remote agents to Dozzle Cloud

### DIFF
--- a/internal/support/docker/multi_host_service.go
+++ b/internal/support/docker/multi_host_service.go
@@ -188,6 +188,23 @@ func (m *MultiHostService) LocalClientServices() []container_support.ClientServi
 	return m.manager.LocalClientServices()
 }
 
+// ClientServices returns every client this Dozzle serves — the local docker
+// daemon, --remote-host daemons and --remote-agent agents alike. Unlike
+// LocalClientServices it does not filter by client type, so a caller that needs
+// the whole fleet (the cloud client) sees agents too.
+//
+// retry re-dials agents that were unreachable the last time they were tried, so
+// one that came up since joins the returned set. It costs a connection attempt
+// per still-unreachable agent, up to the configured timeout each — pass it on
+// the periodic fan-out calls, not on per-container lookups.
+func (m *MultiHostService) ClientServices(retry bool) []container_support.ClientService {
+	if !retry {
+		return m.manager.List()
+	}
+	services, _ := m.manager.RetryAndList()
+	return services
+}
+
 func (m *MultiHostService) TotalClients() int {
 	return len(m.manager.List())
 }

--- a/internal/support/docker/retriable_client_manager.go
+++ b/internal/support/docker/retriable_client_manager.go
@@ -18,12 +18,23 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// hostSubscriber is one registered listener for "a host became available".
+//
+// Subscriptions are keyed by this pointer rather than by their context: one
+// caller may open several subscriptions under a single context (the cloud
+// client's log and stat streamers share one stream lifetime), and keying by
+// context would let the second registration silently evict the first.
+type hostSubscriber struct {
+	ctx     context.Context
+	channel chan<- container.Host
+}
+
 type RetriableClientManager struct {
 	clients      map[string]container_support.ClientService
 	failedAgents []string
 	certs        tls.Certificate
 	mu           sync.RWMutex
-	subscribers  *xsync.Map[context.Context, chan<- container.Host]
+	subscribers  *xsync.Map[*hostSubscriber, struct{}]
 	timeout      time.Duration
 }
 
@@ -95,17 +106,18 @@ func NewRetriableClientManager(agents []string, timeout time.Duration, certs tls
 		clients:      clientMap,
 		failedAgents: failedList,
 		certs:        certs,
-		subscribers:  xsync.NewMap[context.Context, chan<- container.Host](),
+		subscribers:  xsync.NewMap[*hostSubscriber, struct{}](),
 		timeout:      timeout,
 	}
 }
 
 func (m *RetriableClientManager) Subscribe(ctx context.Context, channel chan<- container.Host) {
-	m.subscribers.Store(ctx, channel)
+	sub := &hostSubscriber{ctx: ctx, channel: channel}
+	m.subscribers.Store(sub, struct{}{})
 
 	go func() {
 		<-ctx.Done()
-		m.subscribers.Delete(ctx)
+		m.subscribers.Delete(sub)
 	}()
 }
 
@@ -166,12 +178,12 @@ func (m *RetriableClientManager) RetryAndList() ([]container_support.ClientServi
 		m.clients[r.host.ID] = r.service
 		host := r.host
 		host.Available = true
-		m.subscribers.Range(func(ctx context.Context, channel chan<- container.Host) bool {
+		m.subscribers.Range(func(sub *hostSubscriber, _ struct{}) bool {
 			// We don't want to block the subscribers in event.go
 			go func() {
 				select {
-				case channel <- host:
-				case <-ctx.Done():
+				case sub.channel <- host:
+				case <-sub.ctx.Done():
 				}
 			}()
 			return true

--- a/internal/support/docker/retriable_client_manager_test.go
+++ b/internal/support/docker/retriable_client_manager_test.go
@@ -1,0 +1,41 @@
+package docker_support
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+	"time"
+
+	"github.com/amir20/dozzle/internal/container"
+	"github.com/stretchr/testify/assert"
+)
+
+// One caller may open several host subscriptions under a single context — the
+// cloud client's log and stat streamers share one stream lifetime — so keying
+// the subscriber set by context would let the second registration silently
+// evict the first, and one of the two would never hear that an agent came up.
+func TestRetriableClientManager_SubscribeSharedContext(t *testing.T) {
+	m := NewRetriableClientManager(nil, time.Second, tls.Certificate{})
+
+	ctx := t.Context()
+
+	first := make(chan container.Host, 1)
+	second := make(chan container.Host, 1)
+	m.Subscribe(ctx, first)
+	m.Subscribe(ctx, second)
+
+	assert.Equal(t, 2, m.subscribers.Size())
+}
+
+func TestRetriableClientManager_SubscribeUnregistersOnDone(t *testing.T) {
+	m := NewRetriableClientManager(nil, time.Second, tls.Certificate{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.Subscribe(ctx, make(chan container.Host, 1))
+	assert.Equal(t, 1, m.subscribers.Size())
+
+	cancel()
+	assert.Eventually(t, func() bool {
+		return m.subscribers.Size() == 0
+	}, time.Second, 5*time.Millisecond)
+}

--- a/internal/support/docker/swarm_client_manager.go
+++ b/internal/support/docker/swarm_client_manager.go
@@ -25,7 +25,7 @@ type SwarmClientManager struct {
 	clients      map[string]container_support.ClientService
 	certs        tls.Certificate
 	mu           sync.RWMutex
-	subscribers  *xsync.Map[context.Context, chan<- container.Host]
+	subscribers  *xsync.Map[*hostSubscriber, struct{}]
 	localClient  container.Client
 	localIPs     []string
 	name         string
@@ -75,7 +75,7 @@ func NewSwarmClientManager(localClient *docker.DockerClient, certs tls.Certifica
 		localClient:  localClient,
 		clients:      clientMap,
 		certs:        certs,
-		subscribers:  xsync.NewMap[context.Context, chan<- container.Host](),
+		subscribers:  xsync.NewMap[*hostSubscriber, struct{}](),
 		localIPs:     localIPs(),
 		name:         serviceName,
 		timeout:      timeout,
@@ -84,12 +84,13 @@ func NewSwarmClientManager(localClient *docker.DockerClient, certs tls.Certifica
 }
 
 func (m *SwarmClientManager) Subscribe(ctx context.Context, channel chan<- container.Host) {
-	m.subscribers.Store(ctx, channel)
+	sub := &hostSubscriber{ctx: ctx, channel: channel}
+	m.subscribers.Store(sub, struct{}{})
 	m.agentManager.Subscribe(ctx, channel)
 
 	go func() {
 		<-ctx.Done()
-		m.subscribers.Delete(ctx)
+		m.subscribers.Delete(sub)
 	}()
 }
 
@@ -162,15 +163,15 @@ func (m *SwarmClientManager) RetryAndList() ([]container_support.ClientService, 
 		m.clients[host.ID] = client
 		log.Info().Stringer("ip", ip).Str("id", host.ID).Str("name", host.Name).Msg("added new swarm agent")
 
-		m.subscribers.Range(func(ctx context.Context, channel chan<- container.Host) bool {
+		m.subscribers.Range(func(sub *hostSubscriber, _ struct{}) bool {
 			host.Available = true
 			host.Type = "swarm"
 
 			// We don't want to block the subscribers in event.go
 			go func() {
 				select {
-				case channel <- host:
-				case <-ctx.Done():
+				case sub.channel <- host:
+				case <-sub.ctx.Done():
 				}
 			}()
 

--- a/main.go
+++ b/main.go
@@ -369,13 +369,21 @@ func newCloudHostService(mode string, hs web.HostService) cloud.LogStreamHostSer
 	}
 }
 
+// reattachInterval is how often log and stat subscriptions re-scan the fleet.
+// A var, not a const, so tests need not wait a real minute.
+var reattachInterval = time.Minute
+
 func (l *cloudHostService) hostTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), 5*time.Second)
 }
 
 // hostID caches a service's host ID. A host ID is stable for the lifetime of
-// the client that serves it, so one successful lookup per service is enough;
-// a failed lookup is not cached so a flaky agent can answer next time.
+// the client that serves it, so one lookup per service is enough.
+//
+// An agent answers Host over the wire and can fail transiently, but it returns
+// its last known host alongside the error, and a service only enters the fleet
+// after one successful Host call. So an id is taken whenever there is one,
+// error or not; only a service that has never identified itself yields "".
 func (l *cloudHostService) hostID(s container_support.ClientService) string {
 	l.mu.Lock()
 	id, ok := l.hostIDs[s]
@@ -385,9 +393,9 @@ func (l *cloudHostService) hostID(s container_support.ClientService) string {
 	}
 
 	ctx, cancel := l.hostTimeout()
-	h, err := s.Host(ctx)
+	h, _ := s.Host(ctx)
 	cancel()
-	if err != nil {
+	if h.ID == "" {
 		return ""
 	}
 
@@ -449,20 +457,28 @@ func (l *cloudHostService) FindContainer(host string, id string, labels containe
 
 // watchNewServices calls attach again whenever a host that was unreachable at
 // startup joins, so a late agent gets subscribed without waiting for a restart.
-// attach is only ever called from this one goroutine after the caller's initial
-// synchronous call has returned, so it needs no locking of its own.
+//
+// The ticker is the backstop. SubscribeAvailableHosts only fires on the
+// unreachable-to-reachable edge, so anything attach skipped for another reason
+// — a host whose id could not be resolved at the time — would otherwise stay
+// skipped for the life of the connection. A re-attach that finds nothing new is
+// a map lookup per service, so this is cheap enough to run unconditionally.
+//
+// attach is only ever called from this one goroutine, after the caller's
+// initial synchronous call has returned, so it needs no locking of its own.
 func (l *cloudHostService) watchNewServices(ctx context.Context, attach func()) {
-	if l.hs == nil {
-		return
-	}
 	hosts := make(chan container.Host, 8)
 	l.hs.SubscribeAvailableHosts(ctx, hosts)
+	ticker := time.NewTicker(reattachInterval)
 	go func() {
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-hosts:
+				attach()
+			case <-ticker.C:
 				attach()
 			}
 		}
@@ -486,7 +502,8 @@ func (l *cloudHostService) SubscribeStats(ctx context.Context, samples chan<- cl
 			hostID := l.hostID(s)
 			if hostID == "" {
 				// Unstamped samples can't be told apart on the cloud side.
-				// Leave the service unsubscribed so the next attach retries it.
+				// Leave the service unsubscribed; watchNewServices re-attaches
+				// on a timer, so this resolves itself once the host answers.
 				continue
 			}
 			subscribed[s] = true

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ func main() {
 		instanceID = h.ID
 	}
 
-	cloudHostService := newLocalCloudHostService(hostService)
+	cloudHostService := newCloudHostService(args.Mode, hostService)
 
 	cloudClient := cloud.NewClient(apiKeyFunc, instanceID, args.Version(), cloud.ToolDeps{
 		EnableActions:       args.EnableActions,
@@ -322,50 +322,86 @@ func createServer(args cli.Args, hostService web.HostService, cloudHooks web.Clo
 	return web.CreateServer(hostService, assets, config)
 }
 
-// localCloudHostService scopes the cloud client to local docker only;
-// otherwise every connection re-reports its peers, multiplying hosts
-// by connection count on the cloud side.
-type localCloudHostService struct {
-	services    []container_support.ClientService
-	hostIDByIdx []string // parallel to services, populated lazily
-	hostIDOnce  sync.Once
+// cloudHostService is the view of the fleet the cloud client is given.
+//
+// In swarm mode every replica discovers every peer, so a replica reporting the
+// whole fleet would multiply hosts — and duplicate log and stat ingestion — by
+// replica count on the cloud side. There the view is scoped to this process's
+// own docker daemon.
+//
+// Everywhere else there is exactly one Dozzle holding the fleet: --remote-host
+// and --remote-agent endpoints are configured on it and on nothing else, so
+// scoping them away simply hid them from the cloud. --remote-host survived only
+// because it happens to be a *DockerClientService; agents did not appear at all.
+//
+// services is a func, not a slice, because an agent that is unreachable at boot
+// joins later. Reading it per call means such an agent shows up as soon as it
+// connects rather than at the next restart. Its retry argument asks for
+// unreachable agents to be re-dialed, which costs a connection attempt each —
+// only the periodic fan-out calls pay it.
+type cloudHostService struct {
+	services func(retry bool) []container_support.ClientService
+	// hs is the underlying host service, used only to learn when a previously
+	// unreachable host becomes available so log and stat subscriptions can be
+	// extended to it.
+	hs web.HostService
+
+	mu      sync.Mutex
+	hostIDs map[container_support.ClientService]string
 }
 
-func newLocalCloudHostService(hs web.HostService) cloud.LogStreamHostService {
-	services := hs.LocalClientServices()
-	if len(services) == 0 {
-		// k8s has no docker LocalClientServices but its HostService already
+func newCloudHostService(mode string, hs web.HostService) cloud.LogStreamHostService {
+	services := func(bool) []container_support.ClientService { return hs.LocalClientServices() }
+	if mode != "swarm" {
+		if mhs, ok := hs.(*docker_support.MultiHostService); ok {
+			services = mhs.ClientServices
+		}
+	}
+	if len(services(false)) == 0 {
+		// k8s has no docker client services but its HostService already
 		// exposes only what this process can see, so use it directly.
 		return hs
 	}
-	return &localCloudHostService{services: services}
+	return &cloudHostService{
+		services: services,
+		hs:       hs,
+		hostIDs:  make(map[container_support.ClientService]string),
+	}
 }
 
-func (l *localCloudHostService) localHostTimeout() (context.Context, context.CancelFunc) {
+func (l *cloudHostService) hostTimeout() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), 5*time.Second)
 }
 
-// resolveHostIDs caches each service's host ID once. Local docker host IDs
-// are stable for the process lifetime, so a one-time lookup is enough.
-func (l *localCloudHostService) resolveHostIDs() []string {
-	l.hostIDOnce.Do(func() {
-		l.hostIDByIdx = make([]string, len(l.services))
-		for i, s := range l.services {
-			ctx, cancel := l.localHostTimeout()
-			h, err := s.Host(ctx)
-			cancel()
-			if err == nil {
-				l.hostIDByIdx[i] = h.ID
-			}
-		}
-	})
-	return l.hostIDByIdx
+// hostID caches a service's host ID. A host ID is stable for the lifetime of
+// the client that serves it, so one successful lookup per service is enough;
+// a failed lookup is not cached so a flaky agent can answer next time.
+func (l *cloudHostService) hostID(s container_support.ClientService) string {
+	l.mu.Lock()
+	id, ok := l.hostIDs[s]
+	l.mu.Unlock()
+	if ok {
+		return id
+	}
+
+	ctx, cancel := l.hostTimeout()
+	h, err := s.Host(ctx)
+	cancel()
+	if err != nil {
+		return ""
+	}
+
+	l.mu.Lock()
+	l.hostIDs[s] = h.ID
+	l.mu.Unlock()
+	return h.ID
 }
 
-func (l *localCloudHostService) Hosts() []container.Host {
-	hosts := make([]container.Host, 0, len(l.services))
-	for _, s := range l.services {
-		ctx, cancel := l.localHostTimeout()
+func (l *cloudHostService) Hosts() []container.Host {
+	services := l.services(true)
+	hosts := make([]container.Host, 0, len(services))
+	for _, s := range services {
+		ctx, cancel := l.hostTimeout()
 		h, err := s.Host(ctx)
 		cancel()
 		if err != nil {
@@ -377,11 +413,11 @@ func (l *localCloudHostService) Hosts() []container.Host {
 	return hosts
 }
 
-func (l *localCloudHostService) ListAllContainers(labels container.ContainerLabels) ([]container.Container, []error) {
+func (l *cloudHostService) ListAllContainers(labels container.ContainerLabels) ([]container.Container, []error) {
 	var all []container.Container
 	var errs []error
-	for _, s := range l.services {
-		ctx, cancel := l.localHostTimeout()
+	for _, s := range l.services(true) {
+		ctx, cancel := l.hostTimeout()
 		list, err := s.ListContainers(ctx, labels)
 		cancel()
 		if err != nil {
@@ -393,13 +429,14 @@ func (l *localCloudHostService) ListAllContainers(labels container.ContainerLabe
 	return all, errs
 }
 
-func (l *localCloudHostService) FindContainer(host string, id string, labels container.ContainerLabels) (*container_support.ContainerService, error) {
-	hostIDs := l.resolveHostIDs()
-	for i, s := range l.services {
-		if hostIDs[i] != host {
+func (l *cloudHostService) FindContainer(host string, id string, labels container.ContainerLabels) (*container_support.ContainerService, error) {
+	// No retry: this runs once per log reader, and a run of them against an
+	// unreachable agent would each wait out the dial timeout.
+	for _, s := range l.services(false) {
+		if l.hostID(s) != host {
 			continue
 		}
-		ctx, cancel := l.localHostTimeout()
+		ctx, cancel := l.hostTimeout()
 		cont, err := s.FindContainer(ctx, id, labels)
 		cancel()
 		if err != nil {
@@ -407,68 +444,114 @@ func (l *localCloudHostService) FindContainer(host string, id string, labels con
 		}
 		return container_support.NewContainerService(s, cont), nil
 	}
-	return nil, fmt.Errorf("host %s not local to this process", host)
+	return nil, fmt.Errorf("host %s is not served by this Dozzle instance", host)
 }
 
-// SubscribeStats fans stats in from every local client service, stamping the
+// watchNewServices calls attach again whenever a host that was unreachable at
+// startup joins, so a late agent gets subscribed without waiting for a restart.
+// attach is only ever called from this one goroutine after the caller's initial
+// synchronous call has returned, so it needs no locking of its own.
+func (l *cloudHostService) watchNewServices(ctx context.Context, attach func()) {
+	if l.hs == nil {
+		return
+	}
+	hosts := make(chan container.Host, 8)
+	l.hs.SubscribeAvailableHosts(ctx, hosts)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-hosts:
+				attach()
+			}
+		}
+	}()
+}
+
+// SubscribeStats fans stats in from every client service, stamping the
 // originating host on each sample. container.ContainerStat has no host field,
 // so without this the cloud side could not tell two same-named containers on
 // different hosts apart.
-func (l *localCloudHostService) SubscribeStats(ctx context.Context, samples chan<- cloud.StatSample) {
-	hostIDs := l.resolveHostIDs()
+func (l *cloudHostService) SubscribeStats(ctx context.Context, samples chan<- cloud.StatSample) {
 	// One inbound channel + forwarder goroutine per service, matching
 	// SubscribeContainersStarted: a burst on one service must not stall the others.
 	var dropWarn sync.Once
-	for i, s := range l.services {
-		hostID := hostIDs[i]
-		ch := make(chan container.ContainerStat, 64)
-		s.SubscribeStats(ctx, ch)
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case stat := <-ch:
-					// Non-blocking on purpose. The stats collector dispatches to
-					// each subscriber with a blocking send, so if cloud ingest
-					// ever wedged, backpressure would travel all the way up and
-					// starve the live UI's stats subscriber on this host. Losing
-					// a sample only nudges a 30s average; stalling the UI is not
-					// an acceptable trade for that.
-					select {
-					case samples <- cloud.StatSample{Stat: stat, HostID: hostID}:
-					default:
-						dropWarn.Do(func() {
-							log.Warn().Msg("cloud stats: consumer is not keeping up, dropping samples (further drops are silent)")
-						})
-					}
-				}
+	subscribed := make(map[container_support.ClientService]bool)
+	attach := func() {
+		for _, s := range l.services(false) {
+			if subscribed[s] {
+				continue
 			}
-		}()
-	}
-}
-
-func (l *localCloudHostService) SubscribeContainersStarted(ctx context.Context, containers chan<- container.Container, filter container_support.ContainerFilter) {
-	// One inbound channel + forwarder goroutine per service so a slow consumer
-	// or a burst on one service can't cause the others to drop events.
-	for _, s := range l.services {
-		ch := make(chan container.Container, 64)
-		s.SubscribeContainersStarted(ctx, ch)
-		go func() {
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case c := <-ch:
-					if filter(&c) {
+			hostID := l.hostID(s)
+			if hostID == "" {
+				// Unstamped samples can't be told apart on the cloud side.
+				// Leave the service unsubscribed so the next attach retries it.
+				continue
+			}
+			subscribed[s] = true
+			ch := make(chan container.ContainerStat, 64)
+			s.SubscribeStats(ctx, ch)
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case stat := <-ch:
+						// Non-blocking on purpose. The stats collector dispatches to
+						// each subscriber with a blocking send, so if cloud ingest
+						// ever wedged, backpressure would travel all the way up and
+						// starve the live UI's stats subscriber on this host. Losing
+						// a sample only nudges a 30s average; stalling the UI is not
+						// an acceptable trade for that.
 						select {
-						case containers <- c:
-						case <-ctx.Done():
-							return
+						case samples <- cloud.StatSample{Stat: stat, HostID: hostID}:
+						default:
+							dropWarn.Do(func() {
+								log.Warn().Msg("cloud stats: consumer is not keeping up, dropping samples (further drops are silent)")
+							})
 						}
 					}
 				}
-			}
-		}()
+			}()
+		}
 	}
+
+	attach()
+	l.watchNewServices(ctx, attach)
+}
+
+func (l *cloudHostService) SubscribeContainersStarted(ctx context.Context, containers chan<- container.Container, filter container_support.ContainerFilter) {
+	// One inbound channel + forwarder goroutine per service so a slow consumer
+	// or a burst on one service can't cause the others to drop events.
+	subscribed := make(map[container_support.ClientService]bool)
+	attach := func() {
+		for _, s := range l.services(false) {
+			if subscribed[s] {
+				continue
+			}
+			subscribed[s] = true
+			ch := make(chan container.Container, 64)
+			s.SubscribeContainersStarted(ctx, ch)
+			go func() {
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case c := <-ch:
+						if filter(&c) {
+							select {
+							case containers <- c:
+							case <-ctx.Done():
+								return
+							}
+						}
+					}
+				}
+			}()
+		}
+	}
+
+	attach()
+	l.watchNewServices(ctx, attach)
 }

--- a/main.go
+++ b/main.go
@@ -384,6 +384,11 @@ func (l *cloudHostService) hostTimeout() (context.Context, context.CancelFunc) {
 // its last known host alongside the error, and a service only enters the fleet
 // after one successful Host call. So an id is taken whenever there is one,
 // error or not; only a service that has never identified itself yields "".
+//
+// The lock is dropped across the lookup on purpose. Two callers racing a cold
+// cache both dial and both store, which costs one redundant call and writes the
+// same id twice; holding the lock instead would serialise every caller behind a
+// network round trip, including callers asking about other hosts.
 func (l *cloudHostService) hostID(s container_support.ClientService) string {
 	l.mu.Lock()
 	id, ok := l.hostIDs[s]

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -17,19 +19,33 @@ import (
 type fakeClientService struct {
 	container_support.ClientService
 	host container.Host
+
+	subscribed atomic.Bool // set when SubscribeContainersStarted is called
 }
 
 func (f *fakeClientService) Host(context.Context) (container.Host, error) {
 	return f.host, nil
 }
 
+func (f *fakeClientService) SubscribeContainersStarted(context.Context, chan<- container.Container) {
+	f.subscribed.Store(true)
+}
+
 // fakeClientManager mimics a hub: one local docker daemon plus one
 // --remote-agent endpoint. LocalClientServices filters agents out, exactly as
 // the real managers do by concrete type.
 type fakeClientManager struct {
-	local  container_support.ClientService
-	agent  container_support.ClientService
-	hostCh chan container.Host
+	mu    sync.Mutex
+	local container_support.ClientService
+	agent container_support.ClientService
+}
+
+// addAgent makes an agent reachable, standing in for one that was down at boot
+// and joined later.
+func (m *fakeClientManager) addAgent(s container_support.ClientService) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.agent = s
 }
 
 func (m *fakeClientManager) Find(id string) (container_support.ClientService, bool) {
@@ -43,6 +59,9 @@ func (m *fakeClientManager) Find(id string) (container_support.ClientService, bo
 
 // all skips a nil agent so a hub can be built with its agent still unreachable.
 func (m *fakeClientManager) all() []container_support.ClientService {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	services := []container_support.ClientService{m.local}
 	if m.agent != nil {
 		services = append(services, m.agent)
@@ -116,7 +135,29 @@ func TestCloudHostService_PicksUpLateJoiningAgents(t *testing.T) {
 	svc := newCloudHostService("server", docker_support.NewMultiHostService(mgr, time.Second))
 	assert.Equal(t, []string{"local-id"}, hostIDs(svc.Hosts()))
 
-	mgr.agent = &fakeClientService{host: container.Host{ID: "agent-id", Name: "home-assistant", Type: "agent"}}
+	mgr.addAgent(&fakeClientService{host: container.Host{ID: "agent-id", Name: "home-assistant", Type: "agent"}})
 
 	assert.ElementsMatch(t, []string{"local-id", "agent-id"}, hostIDs(svc.Hosts()))
+}
+
+// Appearing in Hosts() is not enough — a late agent has to be picked up by the
+// log and stat subscriptions too, or the cloud sees the host and never a line
+// from it. SubscribeAvailableHosts only fires on the unreachable-to-reachable
+// edge, so the re-attach timer is what has to carry this.
+func TestCloudHostService_SubscribesLateJoiningAgents(t *testing.T) {
+	reattachInterval = 10 * time.Millisecond
+	t.Cleanup(func() { reattachInterval = time.Minute })
+
+	local := &fakeClientService{host: container.Host{ID: "local-id", Name: "hub", Type: "local"}}
+	mgr := &fakeClientManager{local: local}
+	svc := newCloudHostService("server", docker_support.NewMultiHostService(mgr, time.Second))
+
+	ctx := t.Context()
+	svc.SubscribeContainersStarted(ctx, make(chan container.Container, 1), func(*container.Container) bool { return true })
+	assert.True(t, local.subscribed.Load())
+
+	agent := &fakeClientService{host: container.Host{ID: "agent-id", Name: "home-assistant", Type: "agent"}}
+	mgr.addAgent(agent)
+
+	assert.Eventually(t, agent.subscribed.Load, time.Second, 5*time.Millisecond)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/amir20/dozzle/internal/container"
+	container_support "github.com/amir20/dozzle/internal/support/container"
+	docker_support "github.com/amir20/dozzle/internal/support/docker"
+	"github.com/stretchr/testify/assert"
+)
+
+// fakeClientService is a ClientService that only knows its own host. Every
+// other method is left nil on the embedded interface — the cloud host service
+// selection logic under test never calls them.
+type fakeClientService struct {
+	container_support.ClientService
+	host container.Host
+}
+
+func (f *fakeClientService) Host(context.Context) (container.Host, error) {
+	return f.host, nil
+}
+
+// fakeClientManager mimics a hub: one local docker daemon plus one
+// --remote-agent endpoint. LocalClientServices filters agents out, exactly as
+// the real managers do by concrete type.
+type fakeClientManager struct {
+	local  container_support.ClientService
+	agent  container_support.ClientService
+	hostCh chan container.Host
+}
+
+func (m *fakeClientManager) Find(id string) (container_support.ClientService, bool) {
+	for _, s := range m.all() {
+		if h, _ := s.Host(context.Background()); h.ID == id {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+// all skips a nil agent so a hub can be built with its agent still unreachable.
+func (m *fakeClientManager) all() []container_support.ClientService {
+	services := []container_support.ClientService{m.local}
+	if m.agent != nil {
+		services = append(services, m.agent)
+	}
+	return services
+}
+
+func (m *fakeClientManager) List() []container_support.ClientService { return m.all() }
+
+func (m *fakeClientManager) RetryAndList() ([]container_support.ClientService, []error) {
+	return m.all(), nil
+}
+
+func (m *fakeClientManager) Subscribe(ctx context.Context, channel chan<- container.Host) {}
+
+func (m *fakeClientManager) Hosts(ctx context.Context) []container.Host {
+	hosts := make([]container.Host, 0, 2)
+	for _, s := range m.all() {
+		h, _ := s.Host(ctx)
+		hosts = append(hosts, h)
+	}
+	return hosts
+}
+
+func (m *fakeClientManager) LocalClients() []container.Client { return nil }
+
+func (m *fakeClientManager) LocalClientServices() []container_support.ClientService {
+	return []container_support.ClientService{m.local}
+}
+
+func newFakeHub() *docker_support.MultiHostService {
+	return docker_support.NewMultiHostService(&fakeClientManager{
+		local: &fakeClientService{host: container.Host{ID: "local-id", Name: "hub", Type: "local"}},
+		agent: &fakeClientService{host: container.Host{ID: "agent-id", Name: "home-assistant", Type: "agent"}},
+	}, time.Second)
+}
+
+func hostIDs(hosts []container.Host) []string {
+	ids := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		ids = append(ids, h.ID)
+	}
+	return ids
+}
+
+// A hub with a --remote-agent is the only process that knows about that agent,
+// so the cloud must see it. Scoping the cloud view to local docker hid every
+// agent from Dozzle Cloud entirely — no host, no containers, no logs, no metrics.
+func TestNewCloudHostService_ServerModeIncludesAgents(t *testing.T) {
+	svc := newCloudHostService("server", newFakeHub())
+
+	assert.ElementsMatch(t, []string{"local-id", "agent-id"}, hostIDs(svc.Hosts()))
+}
+
+// Swarm is the exception: every replica discovers every peer, so a replica
+// reporting the whole fleet would multiply hosts — and duplicate log and stat
+// ingestion — by replica count on the cloud side.
+func TestNewCloudHostService_SwarmModeStaysLocal(t *testing.T) {
+	svc := newCloudHostService("swarm", newFakeHub())
+
+	assert.Equal(t, []string{"local-id"}, hostIDs(svc.Hosts()))
+}
+
+// An agent that is unreachable at boot joins later through RetryAndList. The
+// cloud view reads the fleet per call rather than snapshotting it at startup,
+// so such an agent appears without a restart.
+func TestCloudHostService_PicksUpLateJoiningAgents(t *testing.T) {
+	mgr := &fakeClientManager{
+		local: &fakeClientService{host: container.Host{ID: "local-id", Name: "hub", Type: "local"}},
+	}
+	svc := newCloudHostService("server", docker_support.NewMultiHostService(mgr, time.Second))
+	assert.Equal(t, []string{"local-id"}, hostIDs(svc.Hosts()))
+
+	mgr.agent = &fakeClientService{host: container.Host{ID: "agent-id", Name: "home-assistant", Type: "agent"}}
+
+	assert.ElementsMatch(t, []string{"local-id", "agent-id"}, hostIDs(svc.Hosts()))
+}


### PR DESCRIPTION
A hub with `--remote-agent` shows only its own Docker host in Dozzle Cloud. The agent's host, containers, logs and metrics never arrive — not hidden in the UI, never sent.

## Cause

`newLocalCloudHostService` scoped everything the cloud client can see to `LocalClientServices()`, which filters to `*DockerClientService`. An agent is an `agentService`, so it was dropped. That one wrapper backs `list_hosts`, `find_containers`, `list_running_containers`, the log streamer and the stats streamer, so an agent was invisible to all of them.

`--remote-host` kept working only because a `tcp://` daemon happens to be a `DockerClientService` — that asymmetry is the tell.

The scoping exists for swarm, where every replica discovers every peer and reporting the fleet from each would multiply hosts, and duplicate log and stat ingestion, by replica count. Outside swarm there is exactly one Dozzle holding the fleet: `--remote-agent` and `--remote-host` endpoints are configured on it and on nothing else.

## Fix

Keep the local scope in swarm mode only. Elsewhere the cloud client gets the whole fleet, via a new `MultiHostService.ClientServices(retry bool)` that does not filter by client type.

Two related fixes while in here:

- The fleet is read per call instead of snapshotted at startup, and log/stat subscriptions extend to hosts that become available later. An agent that is down at boot no longer stays invisible until a restart.
- Retrying unreachable agents is opt-in per call site. The periodic fan-outs pay for it; `FindContainer` does not, because it runs once per log reader and a run of them against a black-holed agent would each wait out the dial timeout.

## Tests

`main_test.go`: agents present in server mode, absent in swarm, and a late-joining agent appearing without a restart.

## Affected versions

The scoping landed in c5c301f (v10.5.1), so anyone on an older Dozzle never had this.

Fixes #4986 https://github.com/amir20/dozzle/issues/4992

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YoEbYyS65nfGsazg3egEd
