### PR TITLE
feat(logs): add download JSON button to log details

### DIFF
--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -96,6 +96,7 @@ declare module 'vue' {
     LogViewer: typeof import('./components/LogViewer/LogViewer.vue')['default']
     'MaterialSymbols:codeBlocksRounded': typeof import('~icons/material-symbols/code-blocks-rounded')['default']
     'MaterialSymbols:contentCopy': typeof import('~icons/material-symbols/content-copy')['default']
+    'MaterialSymbols:download': typeof import('~icons/material-symbols/download')['default']
     'MaterialSymbols:eyeTracking': typeof import('~icons/material-symbols/eye-tracking')['default']
     'MaterialSymbols:link': typeof import('~icons/material-symbols/link')['default']
     'MaterialSymbols:logout': typeof import('~icons/material-symbols/logout')['default']

--- a/assets/components/LogViewer/LogDetails.vue
+++ b/assets/components/LogViewer/LogDetails.vue
@@ -35,6 +35,10 @@
             <material-symbols:content-copy class="swap-off" />
           </button>
         </UseClipboard>
+
+        <button class="outline-hidden" @click="downloadJSON()" title="Download JSON">
+          <material-symbols:download />
+        </button>
       </div>
       <div class="bg-base-200 max-h-125 overflow-scroll rounded-sm border border-white/20 p-2">
         <JsonFormatted :value="entry.rawMessage" class="text-sm" />
@@ -82,6 +86,25 @@ const visibleKeys = persistentVisibleKeysForContainer(container);
 const { hosts } = useHosts();
 
 const { useSortable } = await import("@vueuse/integrations/useSortable");
+
+function downloadJSON() {
+  let content = entry.rawMessage;
+  try {
+    content = JSON.stringify(JSON.parse(content), null, 2);
+  } catch {
+    // not valid JSON, download as is
+  }
+
+  const name = (container.value?.name ?? "log").replace(/[^\w.-]+/g, "-");
+  const timestamp = entry.date.toISOString().replace(/[:.]/g, "-");
+
+  const url = URL.createObjectURL(new Blob([content], { type: "application/json" }));
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${name}-${timestamp}.json`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
 
 function toggleField(key: string[]) {
   if (visibleKeys.value.size === 0) {


### PR DESCRIPTION
Adds a download button next to the copy icon in the Raw JSON section of the log details drawer.

- pretty prints the JSON before download, falls back to raw text if it doesn't parse
- filename is `{container-name}-{iso-timestamp}.json`

Closes #4989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vh4kiCEZwQBBTDGa8xnxdp