### PR TITLE
feat(ui): suggest dev.dozzle.url from traefik router labels

### DIFF
--- a/assets/components/ContainerViewer/ContainerLinkHint.vue
+++ b/assets/components/ContainerViewer/ContainerLinkHint.vue
@@ -9,16 +9,16 @@
 
     <p class="text-base-content/80 mb-2 leading-relaxed">{{ $t("link-hint.description") }}</p>
 
-    <div v-if="ports.length > 1" class="mb-2 flex flex-wrap gap-1">
+    <div v-if="suggestions.length > 1" class="mb-2 flex flex-wrap gap-1">
       <button
-        v-for="port in ports"
-        :key="port"
+        v-for="suggestion in suggestions"
+        :key="suggestion.url"
         type="button"
-        class="btn btn-xs"
-        :class="port === selectedPort ? 'btn-primary' : 'btn-ghost border-base-content/20 border'"
-        @click="selectedPort = port"
+        class="btn btn-xs max-w-full truncate"
+        :class="suggestion.url === selected ? 'btn-primary' : 'btn-ghost border-base-content/20 border'"
+        @click="selected = suggestion.url"
       >
-        {{ port }}
+        {{ suggestion.label }}
       </button>
     </div>
 
@@ -44,19 +44,28 @@ const { t } = useI18n();
 const { copy, copied, isSupported } = useClipboard({ legacy: true });
 const { showToast } = useToast();
 
-const ports = computed(() => container.publishedPorts);
-const show = computed(() => !dismissedLinkHint.value && !container.url && ports.value.length > 0);
+// Traefik labels name an address that actually reaches the container from outside, so they
+// come first. A published host port is only a guess: the browser's own hostname is the best
+// stand-in we have for the docker host. Either way this only ever prefills the snippet,
+// it is never rendered as a link.
+const suggestions = computed(() => [
+  ...container.traefikUrls.map((url) => ({ label: url.replace(/^https?:\/\//, ""), url })),
+  ...container.publishedPorts.map((port) => ({
+    label: `:${port}`,
+    url: `http://${window.location.hostname}:${port}`,
+  })),
+]);
 
-const selectedPort = ref(ports.value[0]);
-watch(ports, (value) => {
-  if (!value.includes(selectedPort.value)) selectedPort.value = value[0];
+const show = computed(() => !dismissedLinkHint.value && !container.url && suggestions.value.length > 0);
+
+const selected = ref(suggestions.value[0]?.url);
+watch(suggestions, (value) => {
+  if (!value.some(({ url }) => url === selected.value)) selected.value = value[0]?.url;
 });
 
-// The browser's own hostname is the best guess we have for an address that reaches the
-// container. It only ever prefills the snippet, it is never rendered as a link.
 const snippet = computed(
   () => `labels:
-  dev.dozzle.url: http://${window.location.hostname}:${selectedPort.value}`,
+  dev.dozzle.url: ${selected.value}`,
 );
 
 function dismiss() {

--- a/assets/models/Container.spec.ts
+++ b/assets/models/Container.spec.ts
@@ -251,3 +251,94 @@ describe("Container.portMappings", () => {
     ]);
   });
 });
+
+describe("Container.traefikUrls", () => {
+  test("empty without traefik labels", () => {
+    expect(makeContainer().traefikUrls).toEqual([]);
+    expect(makeContainer({ labels: { "traefik.enable": "true" } }).traefikUrls).toEqual([]);
+  });
+
+  test("reads the host out of a router rule", () => {
+    expect(
+      makeContainer({ labels: { "traefik.http.routers.grafana.rule": "Host(`grafana.example.com`)" } }).traefikUrls,
+    ).toEqual(["http://grafana.example.com"]);
+  });
+
+  test("uses https when the router terminates tls", () => {
+    const tls = { "traefik.http.routers.g.rule": "Host(`g.example.com`)", "traefik.http.routers.g.tls": "true" };
+    expect(makeContainer({ labels: tls }).traefikUrls).toEqual(["https://g.example.com"]);
+
+    const resolver = {
+      "traefik.http.routers.g.rule": "Host(`g.example.com`)",
+      "traefik.http.routers.g.tls.certresolver": "le",
+    };
+    expect(makeContainer({ labels: resolver }).traefikUrls).toEqual(["https://g.example.com"]);
+  });
+
+  test("uses https for a secure entrypoint", () => {
+    const labels = {
+      "traefik.http.routers.g.rule": "Host(`g.example.com`)",
+      "traefik.http.routers.g.entrypoints": "web,websecure",
+    };
+    expect(makeContainer({ labels }).traefikUrls).toEqual(["https://g.example.com"]);
+  });
+
+  test("stays http when tls is explicitly off", () => {
+    const labels = {
+      "traefik.http.routers.g.rule": "Host(`g.example.com`)",
+      "traefik.http.routers.g.tls": "false",
+      "traefik.http.routers.g.entrypoints": "web",
+    };
+    expect(makeContainer({ labels }).traefikUrls).toEqual(["http://g.example.com"]);
+  });
+
+  test("appends a path matcher", () => {
+    const labels = {
+      "traefik.http.routers.g.rule": "Host(`example.com`) && PathPrefix(`/grafana`)",
+      "traefik.http.routers.g.tls": "true",
+    };
+    expect(makeContainer({ labels }).traefikUrls).toEqual(["https://example.com/grafana"]);
+  });
+
+  test("drops a bare root path", () => {
+    const labels = { "traefik.http.routers.g.rule": "Host(`example.com`) && PathPrefix(`/`)" };
+    expect(makeContainer({ labels }).traefikUrls).toEqual(["http://example.com"]);
+  });
+
+  test("expands every host in a rule and across routers", () => {
+    const labels = {
+      "traefik.http.routers.b.rule": "Host(`b.example.com`)",
+      "traefik.http.routers.a.rule": "Host(`a.example.com`, `www.a.example.com`)",
+    };
+    expect(makeContainer({ labels }).traefikUrls).toEqual([
+      "http://a.example.com",
+      "http://www.a.example.com",
+      "http://b.example.com",
+    ]);
+  });
+
+  test("dedupes the same host across routers", () => {
+    const labels = {
+      "traefik.http.routers.web.rule": "Host(`example.com`)",
+      "traefik.http.routers.websecure.rule": "Host(`example.com`)",
+    };
+    expect(makeContainer({ labels }).traefikUrls).toEqual(["http://example.com"]);
+  });
+
+  test("ignores rules without a host matcher", () => {
+    expect(makeContainer({ labels: { "traefik.http.routers.g.rule": "PathPrefix(`/grafana`)" } }).traefikUrls).toEqual(
+      [],
+    );
+    expect(
+      makeContainer({ labels: { "traefik.http.routers.g.rule": "HostRegexp(`{sub:.+}.example.com`)" } }).traefikUrls,
+    ).toEqual([]);
+  });
+
+  test("respects traefik.enable=false", () => {
+    const labels = {
+      "traefik.enable": "false",
+      "traefik.http.routers.g.rule": "Host(`g.example.com`)",
+    };
+    expect(makeContainer({ labels }).traefikUrls).toEqual([]);
+  });
+});

--- a/assets/models/Container.ts
+++ b/assets/models/Container.ts
@@ -168,6 +168,51 @@ export class Container {
     return this.portMappings.map(({ host }) => host);
   }
 
+  /**
+   * Public URLs read out of Traefik v2/v3 router labels. A container behind a reverse proxy
+   * publishes no host port, so the only place its browser-reachable address exists is here.
+   * Suggestions for the `dev.dozzle.url` snippet only, never rendered as a link.
+   */
+  get traefikUrls() {
+    if (this.labels["traefik.enable"]?.trim().toLowerCase() === "false") return [];
+
+    const routers = new Map<string, { rule?: string; entrypoints?: string; tls: boolean }>();
+    for (const [key, value] of Object.entries(this.labels)) {
+      const match = key.match(/^traefik\.http\.routers\.([^.]+)\.(rule|entrypoints|tls)(\..+)?$/i);
+      if (!match) continue;
+      const [, name, prop, suffix] = match;
+      const router = routers.get(name) ?? { tls: false };
+      switch (prop.toLowerCase()) {
+        case "rule":
+          if (!suffix) router.rule = value;
+          break;
+        case "entrypoints":
+          if (!suffix) router.entrypoints = value;
+          break;
+        // Bare `tls` can be turned off; any sub-key such as `tls.certresolver` implies https.
+        case "tls":
+          router.tls ||= suffix ? true : value.trim().toLowerCase() !== "false";
+          break;
+      }
+      routers.set(name, router);
+    }
+
+    const urls = new Set<string>();
+    for (const name of [...routers.keys()].sort()) {
+      const { rule, entrypoints, tls } = routers.get(name)!;
+      if (!rule) continue;
+      const secure = tls || /(^|,)\s*(websecure|https)\s*(,|$)/i.test(entrypoints ?? "");
+      const path = rule.match(/\bPath(?:Prefix)?\(`([^`]+)`\)/)?.[1] ?? "";
+      for (const [, hosts] of rule.matchAll(/\bHost\(([^)]*)\)/g)) {
+        for (const [, host] of hosts.matchAll(/`([^`]+)`/g)) {
+          urls.add(`${secure ? "https" : "http"}://${host}${path === "/" ? "" : path}`);
+        }
+      }
+    }
+
+    return [...urls];
+  }
+
   set name(name: string) {
     this._name = name;
   }

--- a/docs/guide/container-links.md
+++ b/docs/guide/container-links.md
@@ -34,7 +34,19 @@ Dozzle does not check that the URL resolves, and it does not rewrite it per host
 
 Dozzle knows which ports a container publishes, but a published port is not the same as a reachable URL. Reverse proxies, custom paths, TLS, and split networks all make the guess wrong often enough to be annoying. The label keeps it explicit: Dozzle only shows the link you wrote down.
 
-For containers that publish a port and have no label yet, Dozzle shows a faint link icon in the container list and on the container page. It opens a snippet you can copy into your compose file, prefilled with the published port. Dismissing it hides the hint everywhere.
+For containers with no label yet, Dozzle shows a faint link icon next to the name on the container page. It opens a snippet you can copy into your compose file, prefilled with a guess. Dismissing it hides the hint everywhere.
+
+The guess comes from two places. Traefik router labels are read first, because a router rule names an address that really does reach the container from a browser:
+
+```yaml
+labels:
+  - traefik.http.routers.grafana.rule=Host(`grafana.example.com`)
+  - traefik.http.routers.grafana.tls=true
+```
+
+Path prefixes are appended, the scheme follows the router's TLS settings and entrypoints, and `traefik.enable=false` turns the whole thing off. Failing that, Dozzle falls back to a published host port paired with the hostname you are viewing Dozzle on. Both are only ever prefilled into the snippet. Neither becomes a link until you write it into `dev.dozzle.url` yourself.
+
+Containers behind a reverse proxy publish no host port at all, so the Traefik labels are usually the only signal there is. If you use a different proxy, the hint stays hidden and you add the label by hand.
 
 ## Related labels
 

--- a/docs/guide/container-links.md
+++ b/docs/guide/container-links.md
@@ -48,6 +48,24 @@ Path prefixes are appended, the scheme follows the router's TLS settings and ent
 
 Containers behind a reverse proxy publish no host port at all, so the Traefik labels are usually the only signal there is. If you use a different proxy, the hint stays hidden and you add the label by hand.
 
+## Swarm
+
+In Swarm, `deploy.labels` sets labels on the service and the top-level `labels` key sets them on the container. Traefik's swarm provider reads service labels, so that is where everyone puts them:
+
+```yaml
+services:
+  ui:
+    image: my/ui
+    deploy:
+      labels:
+        - traefik.http.routers.ui.rule=Host(`app.example.com`)
+        - dev.dozzle.url=https://app.example.com
+```
+
+Dozzle reads service labels back onto each task container, so `dev.dozzle.url` and the Traefik hint both work from `deploy.labels`. The same goes for `dev.dozzle.name`, `dev.dozzle.group` and `dev.dozzle.icon`. A label set on the container itself wins over the service's.
+
+Listing services is a manager-only API. In a multi-node swarm the agents on worker nodes cannot read service labels, so containers scheduled there see only their own.
+
 ## Related labels
 
 - [`dev.dozzle.name`](/guide/container-names) sets a custom display name

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -43,13 +43,15 @@ type DockerCLI interface {
 	ContainerRemove(ctx context.Context, containerID string, options client.ContainerRemoveOptions) (client.ContainerRemoveResult, error)
 	ContainerCreate(ctx context.Context, options client.ContainerCreateOptions) (client.ContainerCreateResult, error)
 	ServiceInspect(ctx context.Context, serviceID string, opts client.ServiceInspectOptions) (client.ServiceInspectResult, error)
+	ServiceList(ctx context.Context, options client.ServiceListOptions) (client.ServiceListResult, error)
 	ServiceUpdate(ctx context.Context, serviceID string, options client.ServiceUpdateOptions) (client.ServiceUpdateResult, error)
 }
 
 type DockerClient struct {
-	cli  DockerCLI
-	host container.Host
-	info system.Info
+	cli           DockerCLI
+	host          container.Host
+	info          system.Info
+	serviceLabels serviceLabelCache
 }
 
 func NewClient(cli DockerCLI, host container.Host) *DockerClient {
@@ -167,7 +169,9 @@ func detectRuntime(cli DockerCLI, info system.Info) string {
 func (d *DockerClient) FindContainer(ctx context.Context, id string) (container.Container, error) {
 	log.Debug().Str("id", id).Msg("Finding container")
 	if result, err := d.cli.ContainerInspect(ctx, id, client.ContainerInspectOptions{}); err == nil {
-		return newContainerFromJSON(result.Container, d.host.ID), nil
+		c := newContainerFromJSON(result.Container, d.host.ID)
+		d.mergeServiceLabels(ctx, &c)
+		return c, nil
 	} else {
 		return container.Container{}, err
 	}
@@ -340,6 +344,12 @@ func (d *DockerClient) ListContainers(ctx context.Context, labels container.Cont
 	for _, c := range list.Items {
 		containers = append(containers, newContainer(c, d.host.ID))
 	}
+
+	refs := make([]*container.Container, len(containers))
+	for i := range containers {
+		refs[i] = &containers[i]
+	}
+	d.mergeServiceLabels(ctx, refs...)
 
 	sort.Slice(containers, func(i, j int) bool {
 		return strings.ToLower(containers[i].Name) < strings.ToLower(containers[j].Name)

--- a/internal/docker/client_test.go
+++ b/internal/docker/client_test.go
@@ -74,7 +74,7 @@ func (m *mockedProxy) ContainerRestart(ctx context.Context, containerID string, 
 func Test_dockerClient_ListContainers_null(t *testing.T) {
 	proxy := new(mockedProxy)
 	proxy.On("ContainerList", mock.Anything, mock.Anything).Return(nil, nil)
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 
 	list, err := client.ListContainers(context.Background(), container.ContainerLabels{})
 	assert.Empty(t, list, "list should be empty")
@@ -86,7 +86,7 @@ func Test_dockerClient_ListContainers_null(t *testing.T) {
 func Test_dockerClient_ListContainers_error(t *testing.T) {
 	proxy := new(mockedProxy)
 	proxy.On("ContainerList", mock.Anything, mock.Anything).Return(nil, errors.New("test"))
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 
 	list, err := client.ListContainers(context.Background(), container.ContainerLabels{})
 	assert.Nil(t, list, "list should be nil")
@@ -109,7 +109,7 @@ func Test_dockerClient_ListContainers_happy(t *testing.T) {
 
 	proxy := new(mockedProxy)
 	proxy.On("ContainerList", mock.Anything, mock.Anything).Return(containers, nil)
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 
 	list, err := client.ListContainers(context.Background(), container.ContainerLabels{})
 	require.NoError(t, err, "error should not return an error.")
@@ -143,7 +143,7 @@ func Test_dockerClient_ContainerLogs_happy(t *testing.T) {
 		Since:      "2020-12-31T23:59:59.95Z"}
 	proxy.On("ContainerLogs", mock.Anything, id, options).Return(reader, nil)
 
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 	logReader, _ := client.ContainerLogs(context.Background(), id, since, container.STDALL)
 
 	actual, _ := io.ReadAll(logReader)
@@ -157,7 +157,7 @@ func Test_dockerClient_ContainerLogs_error(t *testing.T) {
 
 	proxy.On("ContainerLogs", mock.Anything, id, mock.Anything).Return(nil, errors.New("test"))
 
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 
 	reader, err := client.ContainerLogs(context.Background(), id, time.Time{}, container.STDALL)
 
@@ -179,7 +179,7 @@ func Test_dockerClient_FindContainer_happy(t *testing.T) {
 	}
 	proxy.On("ContainerInspect", mock.Anything, "abcdefghijkl").Return(json, nil)
 
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 
 	container, err := client.FindContainer(context.Background(), "abcdefghijkl")
 	require.NoError(t, err, "error should not be thrown")
@@ -192,7 +192,7 @@ func Test_dockerClient_FindContainer_happy(t *testing.T) {
 func Test_dockerClient_FindContainer_error(t *testing.T) {
 	proxy := new(mockedProxy)
 	proxy.On("ContainerInspect", mock.Anything, "not_valid").Return(docker.InspectResponse{}, errors.New("not found"))
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 
 	_, err := client.FindContainer(context.Background(), "not_valid")
 	require.Error(t, err, "error should be thrown")
@@ -202,7 +202,7 @@ func Test_dockerClient_FindContainer_error(t *testing.T) {
 
 func Test_dockerClient_ContainerActions_happy(t *testing.T) {
 	proxy := new(mockedProxy)
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 
 	state := &docker.State{Status: "running", StartedAt: time.Now().Format(time.RFC3339Nano)}
 	json := docker.InspectResponse{ID: "abcdefghijkl", State: state, HostConfig: &docker.HostConfig{}, Config: &docker.Config{Tty: false}}
@@ -230,7 +230,7 @@ func Test_dockerClient_ContainerActions_happy(t *testing.T) {
 func Test_dockerClient_ContainerActions_error(t *testing.T) {
 
 	proxy := new(mockedProxy)
-	client := &DockerClient{proxy, container.Host{ID: "localhost"}, system.Info{}}
+	client := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
 	proxy.On("ContainerInspect", mock.Anything, "random-id").Return(docker.InspectResponse{}, errors.New("not found"))
 	proxy.On("ContainerStart", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("test"))
 	proxy.On("ContainerStop", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("test"))

--- a/internal/docker/service_labels.go
+++ b/internal/docker/service_labels.go
@@ -1,0 +1,110 @@
+package docker
+
+import (
+	"context"
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/amir20/dozzle/internal/container"
+	"github.com/moby/moby/client"
+	"github.com/rs/zerolog/log"
+)
+
+// Swarm writes a compose file's `deploy.labels` onto the *service*, never onto the task
+// containers, so inspecting a task never sees them. That is where the ecosystem puts its
+// labels: traefik's swarm provider reads service labels and its docs tell you to use
+// `deploy.labels`, so a swarm user writes `dev.dozzle.url` there too. Without merging
+// them back onto the container every `dev.dozzle.*` label is silently ignored on swarm.
+//
+// Listing services is manager-only. Agents on worker nodes skip this and their containers
+// keep only their own labels.
+
+// Service labels change on `docker service update` and nothing else, so a short window
+// turns one API call per container into one per refresh.
+const serviceLabelTTL = 30 * time.Second
+
+type serviceLabelCache struct {
+	mu      sync.Mutex
+	labels  map[string]map[string]string
+	fetched time.Time
+}
+
+// all returns the labels of every swarm service keyed by service id, refreshing when
+// stale. A failed refresh keeps whatever is already cached rather than dropping labels
+// out of the UI on a transient error.
+func (s *serviceLabelCache) all(ctx context.Context, cli DockerCLI) map[string]map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Keyed off the attempt, not the result, so a node that cannot list services backs off
+	// for a window instead of retrying on every container.
+	if !s.fetched.IsZero() && time.Since(s.fetched) < serviceLabelTTL {
+		return s.labels
+	}
+
+	result, err := cli.ServiceList(ctx, client.ServiceListOptions{})
+	if err != nil {
+		log.Debug().Err(err).Msg("could not list swarm services for labels")
+		s.fetched = time.Now()
+		return s.labels
+	}
+
+	labels := make(map[string]map[string]string, len(result.Items))
+	for _, service := range result.Items {
+		if len(service.Spec.Labels) > 0 {
+			labels[service.ID] = service.Spec.Labels
+		}
+	}
+
+	s.labels = labels
+	s.fetched = time.Now()
+	return s.labels
+}
+
+// mergeServiceLabels folds each swarm service's labels into its task containers. A label
+// set on the container itself is the more specific of the two and always wins.
+func (d *DockerClient) mergeServiceLabels(ctx context.Context, containers ...*container.Container) {
+	if !d.info.Swarm.ControlAvailable {
+		return
+	}
+
+	var byService map[string]map[string]string
+	fetched := false
+
+	for _, c := range containers {
+		serviceID := c.Labels["com.docker.swarm.service.id"]
+		if serviceID == "" {
+			continue
+		}
+		if !fetched {
+			byService = d.serviceLabels.all(ctx, d.cli)
+			fetched = true
+		}
+
+		serviceLabels := byService[serviceID]
+		if len(serviceLabels) == 0 {
+			continue
+		}
+
+		// Copy on write. The container's label map came straight off the API response and
+		// is shared with whatever else holds that container.
+		merged := make(map[string]string, len(serviceLabels)+len(c.Labels))
+		maps.Copy(merged, serviceLabels)
+		maps.Copy(merged, c.Labels)
+		c.Labels = merged
+
+		// Name and group are derived from labels at construction, before this ran. Redo
+		// that derivation on the merged set, using the same precedence.
+		if name := merged["dev.dozzle.name"]; name != "" {
+			c.Name = name
+		} else if name := coolifyName(merged); name != "" {
+			c.Name = name
+		}
+		if group := merged["dev.dozzle.group"]; group != "" {
+			c.Group = group
+		} else if group := merged["coolify.projectName"]; group != "" {
+			c.Group = group
+		}
+	}
+}

--- a/internal/docker/service_labels_test.go
+++ b/internal/docker/service_labels_test.go
@@ -1,0 +1,151 @@
+package docker
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"testing"
+
+	"github.com/amir20/dozzle/internal/container"
+	"github.com/moby/moby/api/types/swarm"
+	"github.com/moby/moby/api/types/system"
+	"github.com/moby/moby/client"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func (m *mockedProxy) ServiceList(ctx context.Context, options client.ServiceListOptions) (client.ServiceListResult, error) {
+	args := m.Called(ctx, options)
+	services, ok := args.Get(0).([]swarm.Service)
+	if !ok && args.Get(0) != nil {
+		panic("services is not of type []swarm.Service")
+	}
+	return client.ServiceListResult{Items: services}, args.Error(1)
+}
+
+func service(id string, labels map[string]string) swarm.Service {
+	return swarm.Service{ID: id, Spec: swarm.ServiceSpec{Annotations: swarm.Annotations{Labels: labels}}}
+}
+
+func managerClient(proxy *mockedProxy) *DockerClient {
+	return &DockerClient{
+		cli:  proxy,
+		host: container.Host{ID: "localhost"},
+		info: system.Info{Swarm: swarm.Info{ControlAvailable: true}},
+	}
+}
+
+func task(serviceID string, labels map[string]string) *container.Container {
+	all := map[string]string{"com.docker.swarm.service.id": serviceID}
+	maps.Copy(all, labels)
+	return &container.Container{ID: "abc", Name: "svc.1", Labels: all}
+}
+
+func Test_mergeServiceLabels_merges_deploy_labels(t *testing.T) {
+	proxy := new(mockedProxy)
+	proxy.On("ServiceList", mock.Anything, mock.Anything).Return([]swarm.Service{
+		service("svc1", map[string]string{
+			"traefik.http.routers.ui.rule": "Host(`cloud.example.com`)",
+			"dev.dozzle.url":               "https://cloud.example.com",
+		}),
+	}, nil)
+
+	c := task("svc1", nil)
+	managerClient(proxy).mergeServiceLabels(context.Background(), c)
+
+	assert.Equal(t, "Host(`cloud.example.com`)", c.Labels["traefik.http.routers.ui.rule"])
+	assert.Equal(t, "https://cloud.example.com", c.Labels["dev.dozzle.url"])
+	proxy.AssertExpectations(t)
+}
+
+func Test_mergeServiceLabels_container_label_wins(t *testing.T) {
+	proxy := new(mockedProxy)
+	proxy.On("ServiceList", mock.Anything, mock.Anything).Return([]swarm.Service{
+		service("svc1", map[string]string{"dev.dozzle.url": "https://service.example.com"}),
+	}, nil)
+
+	c := task("svc1", map[string]string{"dev.dozzle.url": "https://container.example.com"})
+	managerClient(proxy).mergeServiceLabels(context.Background(), c)
+
+	assert.Equal(t, "https://container.example.com", c.Labels["dev.dozzle.url"])
+}
+
+func Test_mergeServiceLabels_redoes_name_and_group(t *testing.T) {
+	proxy := new(mockedProxy)
+	proxy.On("ServiceList", mock.Anything, mock.Anything).Return([]swarm.Service{
+		service("svc1", map[string]string{"dev.dozzle.name": "Cloud UI", "dev.dozzle.group": "cloud"}),
+	}, nil)
+
+	c := task("svc1", nil)
+	managerClient(proxy).mergeServiceLabels(context.Background(), c)
+
+	assert.Equal(t, "Cloud UI", c.Name)
+	assert.Equal(t, "cloud", c.Group)
+}
+
+func Test_mergeServiceLabels_leaves_unmatched_containers_alone(t *testing.T) {
+	proxy := new(mockedProxy)
+	proxy.On("ServiceList", mock.Anything, mock.Anything).Return([]swarm.Service{
+		service("other", map[string]string{"dev.dozzle.url": "https://other.example.com"}),
+	}, nil)
+
+	c := task("svc1", nil)
+	managerClient(proxy).mergeServiceLabels(context.Background(), c)
+
+	assert.NotContains(t, c.Labels, "dev.dozzle.url")
+	assert.Equal(t, "svc.1", c.Name)
+}
+
+func Test_mergeServiceLabels_skips_plain_containers(t *testing.T) {
+	proxy := new(mockedProxy)
+
+	c := &container.Container{ID: "abc", Name: "plain", Labels: map[string]string{}}
+	managerClient(proxy).mergeServiceLabels(context.Background(), c)
+
+	// No swarm task in the batch, so the manager never gets asked for services.
+	proxy.AssertNotCalled(t, "ServiceList", mock.Anything, mock.Anything)
+}
+
+func Test_mergeServiceLabels_skips_workers(t *testing.T) {
+	proxy := new(mockedProxy)
+	d := &DockerClient{cli: proxy, host: container.Host{ID: "localhost"}, info: system.Info{}}
+
+	c := task("svc1", nil)
+	d.mergeServiceLabels(context.Background(), c)
+
+	// Listing services is manager-only; a worker must not even try.
+	proxy.AssertNotCalled(t, "ServiceList", mock.Anything, mock.Anything)
+	assert.Len(t, c.Labels, 1)
+}
+
+func Test_mergeServiceLabels_lists_once_for_a_batch(t *testing.T) {
+	proxy := new(mockedProxy)
+	proxy.On("ServiceList", mock.Anything, mock.Anything).Return([]swarm.Service{
+		service("svc1", map[string]string{"dev.dozzle.group": "cloud"}),
+	}, nil).Once()
+
+	d := managerClient(proxy)
+	first, second := task("svc1", nil), task("svc1", nil)
+	d.mergeServiceLabels(context.Background(), first, second)
+	// A second pass inside the TTL is served from the cache.
+	d.mergeServiceLabels(context.Background(), task("svc1", nil))
+
+	assert.Equal(t, "cloud", first.Group)
+	assert.Equal(t, "cloud", second.Group)
+	proxy.AssertExpectations(t)
+}
+
+func Test_mergeServiceLabels_survives_a_list_error(t *testing.T) {
+	proxy := new(mockedProxy)
+	proxy.On("ServiceList", mock.Anything, mock.Anything).Return(nil, errors.New("permission denied")).Once()
+
+	d := managerClient(proxy)
+	c := task("svc1", nil)
+	require.NotPanics(t, func() { d.mergeServiceLabels(context.Background(), c) })
+
+	assert.Len(t, c.Labels, 1)
+	// The failure is cached for a window so every container does not retry.
+	d.mergeServiceLabels(context.Background(), task("svc1", nil))
+	proxy.AssertExpectations(t)
+}


### PR DESCRIPTION
The `dev.dozzle.url` hint only showed up on containers publishing a host port. Behind a reverse proxy nothing is published, so the hint stayed hidden on exactly the setups where the label is most useful, and the port guess (`http://<browser host>:<port>`) would have been wrong there anyway.

Traefik already knows the answer, it's sitting in labels nobody was reading.

## What changed

`Container.traefikUrls` reads `traefik.http.routers.<name>.rule`:

- every `` Host(`a`, `b`) `` in the rule, across all routers, deduped
- `Path` / `PathPrefix` appended, bare `/` dropped
- https when `tls` is set, any `tls.*` sub-key exists, or an entrypoint is `websecure` / `https`
- explicit `tls=false` stays http
- `traefik.enable=false` skips the container
- `HostRegexp` ignored, there's nothing concrete to suggest

`ContainerLinkHint` now gates on having any suggestion rather than `ports.length > 0`. Traefik URLs come first, published ports remain the fallback.

## What didn't change

`dev.dozzle.url` is still the only source of truth. The hint requires `!container.url`, so setting the label hides it. Derived URLs only prefill the copy snippet and are never rendered as a link.

## Notes

Other proxies (Caddy, nginx-proxy) aren't covered. Traefik was the case in front of me and its labels are unambiguous. Easy to add more later behind the same getter.

12 new tests in `Container.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NXnDCJUfarF75FwMPNZCat
