### PR TITLE
fix(ui): stop truncating container names that fit

### DIFF
--- a/assets/components/ContainerViewer/ContainerTitle.vue
+++ b/assets/components/ContainerViewer/ContainerTitle.vue
@@ -6,8 +6,13 @@
       <carbon:star class="swap-off" />
     </label>
     <div class="inline-flex min-w-0 items-center text-sm">
-      <div class="breadcrumbs min-w-0 overflow-x-visible p-0 font-mono">
-        <ul>
+      <!-- daisyUI insets breadcrumbs with a -0.25rem margin plus a matching
+           0.25rem list padding. That pair is not accounted for in the intrinsic
+           width, so the truncating name below always came up 4px short and
+           ellipsized even with the whole row free. Zeroing both keeps the text
+           at the same x and gives it back those 4px. -->
+      <div class="breadcrumbs ms-0 min-w-0 overflow-x-visible p-0 font-mono">
+        <ul class="ps-0">
           <li v-if="config.hosts.length > 1" class="font-thin max-md:hidden">
             {{ container.hostLabel }}
           </li>


### PR DESCRIPTION
Container names ellipsize a few characters early even when the title row has plenty of free space. `profilarr` renders as `profila...`.


## Cause

daisyUI insets breadcrumbs with a `-0.25rem` margin on the wrapper and a matching `0.25rem` padding on the list. That pair cancels out for positioning but isn't accounted for in the intrinsic width, so the name's box lands exactly 4px short of its text and `truncate` kicks in.

Measured in Chromium on a 1400px row:

```
title     w=1248.0                      <- space was never the problem
crumbs    w=  75.6  margin-left: -4px   <- daisyUI
ul        w=  75.6  padding-left:  4px  <- daisyUI
li        w=  71.6
name      w=  71.6  needs 76px          -> truncated
```

## Fix

Zero both on this one component. Text stays at the same x (40px before and after), the name gets its 4px back:

```
BEFORE {"textX":40,"nameW":71.6,"needs":76,"truncated":true}
AFTER  {"textX":40,"nameW":75.6,"needs":76,"truncated":false}
```

`HostMenu` and `K8sMenu` also use `.breadcrumbs` but have no truncating child, so they're untouched.

## Testing

Typecheck, build and the frontend tests pass. Verified by measuring the rendered layout in Chromium before and after. Not clicked through in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gf2MCaEmVCX6V1JporBTaQ
