### PR TITLE
fix(events): stop containers from getting stuck after a restart

### DIFF
--- a/assets/stores/container.ts
+++ b/assets/stores/container.ts
@@ -181,15 +181,7 @@ export const useContainerStore = defineStore("container", () => {
       return container;
     });
 
-    // The payload is the complete list for every host it mentions (a start/rename refresh
-    // covers a single host, the initial connect covers all of them). Anything missing from
-    // a host that is present is gone for good, so drop it instead of keeping a tombstone
-    // that never leaves the store.
-    const hostsInPayload = new Set(containersPayload.map((c) => c.host));
-    const idsInPayload = new Set(containersPayload.map((c) => c.id));
-    const retained = containers.value.filter((c) => !hostsInPayload.has(c.host) || idsInPayload.has(c.id));
-
-    containers.value = [...retained, ...mapped];
+    containers.value = [...containers.value, ...mapped];
   };
 
   const currentContainer = (id: Ref<string>) => computed(() => allContainersById.value[id.value]);

--- a/assets/stores/container.ts
+++ b/assets/stores/container.ts
@@ -131,6 +131,10 @@ export const useContainerStore = defineStore("container", () => {
         errorTimer = null;
       }
       removeToast("events-stream");
+      // EventSource reconnects on its own without going through connect(), and the server
+      // replays the full list on every connect. Reset ready so the replay isn't mistaken
+      // for containers that just started and flagged as new.
+      ready.value = false;
       if (containers.value.length > 0) {
         containers.value = [];
       }
@@ -177,7 +181,15 @@ export const useContainerStore = defineStore("container", () => {
       return container;
     });
 
-    containers.value = [...containers.value, ...mapped];
+    // The payload is the complete list for every host it mentions (a start/rename refresh
+    // covers a single host, the initial connect covers all of them). Anything missing from
+    // a host that is present is gone for good, so drop it instead of keeping a tombstone
+    // that never leaves the store.
+    const hostsInPayload = new Set(containersPayload.map((c) => c.host));
+    const idsInPayload = new Set(containersPayload.map((c) => c.id));
+    const retained = containers.value.filter((c) => !hostsInPayload.has(c.host) || idsInPayload.has(c.id));
+
+    containers.value = [...retained, ...mapped];
   };
 
   const currentContainer = (id: Ref<string>) => computed(() => allContainersById.value[id.value]);

--- a/internal/container/container_store.go
+++ b/internal/container/container_store.go
@@ -301,6 +301,47 @@ func (s *ContainerStore) SubscribeNewContainers(ctx context.Context, containers 
 	}()
 }
 
+// addContainer records a newly created or started container and notifies subscribers.
+//
+// FindContainer can fail transiently (the daemon is busy right after a compose recreate,
+// or the inspect times out). Nothing re-adds the container afterwards, so it would stay
+// missing from the store until the next reconnect and the UI would never update it again.
+// Fall back to the list entry in that case: it is not FullyLoaded, so the next
+// FindContainer fills in the rest.
+func (s *ContainerStore) addContainer(id string, timeout time.Duration) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	list, err := s.client.ListContainers(ctx, s.labels)
+	if err != nil {
+		log.Warn().Err(err).Str("id", id).Msg("failed to list containers while adding container")
+		return
+	}
+
+	// make sure the container is in the list of containers when using filter
+	listed, valid := lo.Find(list, func(item Container) bool {
+		return item.ID == id
+	})
+	if !valid {
+		return
+	}
+
+	found, err := s.client.FindContainer(ctx, id)
+	if err != nil {
+		log.Warn().Err(err).Str("id", id).Msg("failed to inspect container, falling back to list entry")
+		found = listed
+	}
+
+	s.containers.Store(found.ID, &found)
+	s.newContainerSubscribers.Range(func(c context.Context, containers chan<- Container) bool {
+		select {
+		case containers <- found:
+		case <-c.Done():
+		}
+		return true
+	})
+}
+
 func (s *ContainerStore) init() {
 	stats := make(chan ContainerStat)
 	s.statsCollector.Subscribe(s.ctx, stats)
@@ -315,52 +356,10 @@ func (s *ContainerStore) init() {
 			log.Trace().Str("event", event.Name).Str("id", event.ActorID).Msg("received container event")
 			switch event.Name {
 			case "create":
-				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-
-				if container, err := s.client.FindContainer(ctx, event.ActorID); err == nil {
-					list, _ := s.client.ListContainers(ctx, s.labels)
-
-					// make sure the container is in the list of containers when using filter
-					valid := lo.ContainsBy(list, func(item Container) bool {
-						return item.ID == container.ID
-					})
-
-					if valid {
-						s.containers.Store(container.ID, &container)
-						s.newContainerSubscribers.Range(func(c context.Context, containers chan<- Container) bool {
-							select {
-							case containers <- container:
-							case <-c.Done():
-							}
-							return true
-						})
-					}
-				}
-				cancel()
+				s.addContainer(event.ActorID, 3*time.Second)
 
 			case "start":
-				ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-
-				if container, err := s.client.FindContainer(ctx, event.ActorID); err == nil {
-					list, _ := s.client.ListContainers(ctx, s.labels)
-
-					// make sure the container is in the list of containers when using filter
-					valid := lo.ContainsBy(list, func(item Container) bool {
-						return item.ID == container.ID
-					})
-
-					if valid {
-						s.containers.Store(container.ID, &container)
-						s.newContainerSubscribers.Range(func(c context.Context, containers chan<- Container) bool {
-							select {
-							case containers <- container:
-							case <-c.Done():
-							}
-							return true
-						})
-					}
-				}
-				cancel()
+				s.addContainer(event.ActorID, defaultTimeout)
 			case "destroy":
 				log.Debug().Str("id", event.ActorID).Msg("container destroyed")
 				s.containers.Delete(event.ActorID)

--- a/internal/container/container_store_test.go
+++ b/internal/container/container_store_test.go
@@ -193,6 +193,54 @@ func TestContainerStore_rename(t *testing.T) {
 	})
 }
 
+// TestContainerStore_start_inspect_failure covers a container that starts while
+// FindContainer is failing (a busy daemon right after a compose recreate). Nothing
+// re-adds it later, so before the list-entry fallback it stayed missing from the store
+// for the life of the connection and the UI never saw it update again.
+func TestContainerStore_start_inspect_failure(t *testing.T) {
+	client := new(mockedClient)
+
+	existing := Container{ID: "1234", Name: "test", State: "running", Stats: utils.NewRingBuffer[ContainerStat](300)}
+	started := Container{ID: "5678", Name: "restarted", State: "running", Stats: utils.NewRingBuffer[ContainerStat](300)}
+
+	// the initial store hydration only sees the pre-existing container
+	client.On("ListContainers", mock.Anything, mock.Anything).Return([]Container{existing}, nil).Once()
+	// by the time the start event lands, docker lists both
+	client.On("ListContainers", mock.Anything, mock.Anything).Return([]Container{existing, started}, nil)
+
+	client.On("FindContainer", mock.Anything, "1234").Return(existing, nil)
+	// inspect fails for the container that just started
+	client.On("FindContainer", mock.Anything, "5678").Return(Container{}, assert.AnError)
+
+	client.On("Host").Return(Host{ID: "localhost"})
+
+	ready := make(chan struct{})
+	client.On("ContainerEvents", mock.Anything, mock.AnythingOfType("chan<- container.ContainerEvent")).Return(nil).
+		Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+			events := args.Get(1).(chan<- ContainerEvent)
+			<-ready
+			events <- ContainerEvent{Name: "start", ActorID: "5678", Host: "localhost"}
+			<-ctx.Done()
+		})
+
+	store := NewContainerStore(t.Context(), client, &fakeStatsCollector{}, ContainerLabels{})
+
+	events := make(chan ContainerEvent)
+	store.SubscribeEvents(t.Context(), events)
+	close(ready)
+	<-events
+
+	containers, err := store.ListContainers(ContainerLabels{})
+	assert.NoError(t, err)
+
+	ids := make([]string, 0, len(containers))
+	for _, c := range containers {
+		ids = append(ids, c.ID)
+	}
+	assert.ElementsMatch(t, []string{"1234", "5678"}, ids, "started container should fall back to its list entry when inspect fails")
+}
+
 type fakeStatsCollector struct{}
 
 func (f *fakeStatsCollector) Subscribe(_ context.Context, _ chan<- ContainerStat) {}

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/amir20/dozzle/internal/analytics"
 	"github.com/amir20/dozzle/internal/auth"
@@ -10,6 +11,13 @@ import (
 	support_web "github.com/amir20/dozzle/internal/support/web"
 	"github.com/amir20/dozzle/types"
 	"github.com/rs/zerolog/log"
+)
+
+const (
+	eventBufferSize = 64
+	statBufferSize  = 128
+	// how often a host whose container list failed to refresh is retried
+	staleHostRetryInterval = 5 * time.Second
 )
 
 func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
@@ -21,8 +29,10 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 	}
 	defer sseWriter.Close()
 
-	events := make(chan container.ContainerEvent)
-	stats := make(chan container.ContainerStat)
+	// buffered so a momentarily slow client can't stall the shared per-host store loop,
+	// which broadcasts to every subscriber with a blocking send
+	events := make(chan container.ContainerEvent, eventBufferSize)
+	stats := make(chan container.ContainerStat, statBufferSize)
 	availableHosts := make(chan container.Host)
 
 	h.hostService.SubscribeEventsAndStats(r.Context(), events, stats)
@@ -46,6 +56,22 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 			ids[c.ID] = struct{}{}
 		}
 		visibleByHost[host] = ids
+	}
+
+	// A host whose refresh failed keeps a set that is missing containers started since,
+	// and nothing else repopulates it. Without a retry those containers stay invisible for
+	// the life of this stream, so the client never sees them start, stop or update again.
+	staleHosts := make(map[string]struct{})
+	refreshHost := func(host string) ([]container.Container, bool) {
+		containers, err := h.hostService.ListContainersForHost(host, userLabels)
+		if err != nil {
+			log.Warn().Err(err).Str("host", host).Msg("failed to refresh containers, will retry")
+			staleHosts[host] = struct{}{}
+			return nil, false
+		}
+		delete(staleHosts, host)
+		setVisible(host, containers)
+		return containers, true
 	}
 	isVisible := func(host, id string) bool {
 		if host != "" {
@@ -77,6 +103,8 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 	for _, err := range errors {
 		log.Warn().Err(err).Msg("error listing containers")
 		if hostNotAvailableError, ok := err.(*docker_support.HostUnavailableError); ok {
+			// this host has no visible set at all, so retry it until it answers
+			staleHosts[hostNotAvailableError.Host.ID] = struct{}{}
 			if err := sseWriter.Event("update-host", hostNotAvailableError.Host); err != nil {
 				log.Error().Err(err).Msg("error writing event to event stream")
 			}
@@ -94,8 +122,23 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 
 	go sendBeaconEvent(h, r, len(allContainers))
 
+	// stats never repair a stale host (their payload carries no host) and a quiet host may
+	// not emit another event for a long time, so retry on a timer as well
+	retry := time.NewTicker(staleHostRetryInterval)
+	defer retry.Stop()
+
 	for {
 		select {
+		case <-retry.C:
+			for host := range staleHosts {
+				if containers, ok := refreshHost(host); ok {
+					log.Debug().Str("host", host).Int("count", len(containers)).Msg("recovered stale host")
+					if err := sseWriter.Event("containers-changed", containers); err != nil {
+						log.Error().Err(err).Msg("error writing containers to event stream")
+						return
+					}
+				}
+			}
 		case host := <-availableHosts:
 			if err := sseWriter.Event("update-host", host); err != nil {
 				log.Error().Err(err).Msg("error writing event to event stream")
@@ -114,13 +157,26 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			log.Trace().Str("event", event.Name).Str("id", event.ActorID).Msg("container event from store")
+
+			// a host left stale by an earlier failure gets repaired on its next event, so a
+			// single transient list failure can't hide containers for the rest of the stream.
+			// start/rename refresh on their own below, so skip the extra list call for those.
+			_, stale := staleHosts[event.Host]
+			if stale && event.Host != "" && event.Name != "start" && event.Name != "rename" {
+				if containers, ok := refreshHost(event.Host); ok {
+					if err := sseWriter.Event("containers-changed", containers); err != nil {
+						log.Error().Err(err).Msg("error writing containers to event stream")
+						return
+					}
+				}
+			}
+
 			switch event.Name {
 			case "start", "die", "destroy", "rename", "pause", "unpause":
 				var refreshed []container.Container
 				if event.Name == "start" || event.Name == "rename" {
-					if containers, err := h.hostService.ListContainersForHost(event.Host, userLabels); err == nil {
+					if containers, ok := refreshHost(event.Host); ok {
 						log.Debug().Str("host", event.Host).Int("count", len(containers)).Msg("updating containers for host")
-						setVisible(event.Host, containers)
 						refreshed = containers
 					}
 				}

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -16,7 +16,7 @@ import (
 const (
 	eventBufferSize = 64
 	statBufferSize  = 128
-	// how often a host whose container list failed to refresh is retried
+	// minimum gap between retries of a host whose container list failed to refresh
 	staleHostRetryInterval = 5 * time.Second
 )
 
@@ -61,17 +61,35 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 	// A host whose refresh failed keeps a set that is missing containers started since,
 	// and nothing else repopulates it. Without a retry those containers stay invisible for
 	// the life of this stream, so the client never sees them start, stop or update again.
-	staleHosts := make(map[string]struct{})
+	// Retries are driven by the host's own traffic and throttled, so a host that is down
+	// and silent is never polled and can't block this loop on every attempt.
+	staleHosts := make(map[string]time.Time) // host -> last failed attempt
 	refreshHost := func(host string) ([]container.Container, bool) {
 		containers, err := h.hostService.ListContainersForHost(host, userLabels)
 		if err != nil {
 			log.Warn().Err(err).Str("host", host).Msg("failed to refresh containers, will retry")
-			staleHosts[host] = struct{}{}
+			staleHosts[host] = time.Now()
 			return nil, false
 		}
 		delete(staleHosts, host)
 		setVisible(host, containers)
 		return containers, true
+	}
+	// retries a stale host and pushes the recovered list; false means the client is gone
+	repairHost := func(host string) bool {
+		if last, stale := staleHosts[host]; !stale || time.Since(last) < staleHostRetryInterval {
+			return true
+		}
+		containers, ok := refreshHost(host)
+		if !ok {
+			return true
+		}
+		log.Debug().Str("host", host).Int("count", len(containers)).Msg("recovered stale host")
+		if err := sseWriter.Event("containers-changed", containers); err != nil {
+			log.Error().Err(err).Msg("error writing containers to event stream")
+			return false
+		}
+		return true
 	}
 	isVisible := func(host, id string) bool {
 		if host != "" {
@@ -103,8 +121,8 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 	for _, err := range errors {
 		log.Warn().Err(err).Msg("error listing containers")
 		if hostNotAvailableError, ok := err.(*docker_support.HostUnavailableError); ok {
-			// this host has no visible set at all, so retry it until it answers
-			staleHosts[hostNotAvailableError.Host.ID] = struct{}{}
+			// this host has no visible set at all, so retry as soon as it produces traffic
+			staleHosts[hostNotAvailableError.Host.ID] = time.Time{}
 			if err := sseWriter.Event("update-host", hostNotAvailableError.Host); err != nil {
 				log.Error().Err(err).Msg("error writing event to event stream")
 			}
@@ -122,31 +140,30 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 
 	go sendBeaconEvent(h, r, len(allContainers))
 
-	// stats never repair a stale host (their payload carries no host) and a quiet host may
-	// not emit another event for a long time, so retry on a timer as well
-	retry := time.NewTicker(staleHostRetryInterval)
-	defer retry.Stop()
-
 	for {
 		select {
-		case <-retry.C:
-			for host := range staleHosts {
-				if containers, ok := refreshHost(host); ok {
-					log.Debug().Str("host", host).Int("count", len(containers)).Msg("recovered stale host")
-					if err := sseWriter.Event("containers-changed", containers); err != nil {
-						log.Error().Err(err).Msg("error writing containers to event stream")
-						return
-					}
-				}
-			}
 		case host := <-availableHosts:
+			// an agent that reconnected has no visible set yet; its first traffic fills it
+			if _, ok := visibleByHost[host.ID]; host.Available && !ok {
+				staleHosts[host.ID] = time.Time{}
+			}
 			if err := sseWriter.Event("update-host", host); err != nil {
 				log.Error().Err(err).Msg("error writing event to event stream")
 				return
 			}
 		case stat := <-stats:
 			if !isVisible("", stat.ID) {
-				continue
+				// an unknown ID may belong to a container a stale host never got to report.
+				// a just-started container produces a stat every second, so this also covers
+				// a host that is otherwise quiet
+				for host := range staleHosts {
+					if !repairHost(host) {
+						return
+					}
+				}
+				if !isVisible("", stat.ID) {
+					continue
+				}
 			}
 			if err := sseWriter.Event("container-stat", stat); err != nil {
 				log.Error().Err(err).Msg("error writing event to event stream")
@@ -158,17 +175,10 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 			}
 			log.Trace().Str("event", event.Name).Str("id", event.ActorID).Msg("container event from store")
 
-			// a host left stale by an earlier failure gets repaired on its next event, so a
-			// single transient list failure can't hide containers for the rest of the stream.
-			// start/rename refresh on their own below, so skip the extra list call for those.
-			_, stale := staleHosts[event.Host]
-			if stale && event.Host != "" && event.Name != "start" && event.Name != "rename" {
-				if containers, ok := refreshHost(event.Host); ok {
-					if err := sseWriter.Event("containers-changed", containers); err != nil {
-						log.Error().Err(err).Msg("error writing containers to event stream")
-						return
-					}
-				}
+			// start/rename refresh on their own below; anything else from a stale host is a
+			// chance to repair it
+			if event.Name != "start" && event.Name != "rename" && !repairHost(event.Host) {
+				return
 			}
 
 			switch event.Name {


### PR DESCRIPTION
Chasing down the rare "container never updates after a restart" state. A container recreated by `docker compose up -d` gets a new ID, and there were three ways that new ID could stay invisible for the entire life of an SSE connection. Once it happened, only a page refresh recovered.

### 1. A failed refresh poisoned `visibleByHost` permanently

`internal/web/events.go` gates every event, stat and update through `visibleByHost`, and the start/rename branch is the only thing that ever puts a new container ID in there:

```go
if containers, err := h.hostService.ListContainersForHost(event.Host, userLabels); err == nil {
    setVisible(event.Host, containers)  // replaces the host's whole set
}
if !isVisible(event.Host, event.ActorID) { continue }
```

One transient list failure (timeout, agent hiccup, label-filtered path hitting the Docker API) and the container is never added. Nothing else repopulates the set, so it's gated out forever.

Fix: remember hosts whose refresh failed and retry them, throttled to one attempt per 5s. Retries are driven by the host's own traffic: any event from that host, or a stat for an ID we don't recognize (a just-started container produces one every second, which covers a host that's otherwise quiet). A host that is down and silent is never polled, so a dead agent can't block the loop on every attempt. Hosts that fail the initial `ListAllContainers` start out stale, and an agent that reconnects is marked stale from the `availableHosts` channel so its first traffic fills in its set.

The label gate is unchanged, so this doesn't widen what a filtered user can see.

### 2. The store dropped containers when inspect failed

`container_store.go` only stored a started container if `FindContainer` succeeded, which is exactly what fails when the daemon is busy right after a recreate. Nothing re-added it, so it was missing from the store until the next reconnect, and the SSE layer's `setVisible` then evicted it from the visible set.

Falls back to the list entry now. It's not `FullyLoaded`, so the next `FindContainer` fills in the rest. `create` and `start` had identical bodies, so they're one helper now.

### 3. One slow client stalled every other client

The store broadcasts to subscribers with a blocking send from a single loop, and stats are drained in that same `select`. A slow SSE writer froze events *and* stats for every client on that host. Subscriber channels are buffered now to absorb bursts. This is mitigation rather than a full fix; a permanently wedged client still blocks once the buffer fills, which would need drop-and-resync semantics.

### Frontend

Reset `ready` on EventSource reconnect. The browser reconnects without going through `connect()`, and the server replays the full list on every connect, so every container was coming back flagged `isNew`.

### Testing

`TestContainerStore_start_inspect_failure` covers #2. Verified it fails against the old behavior before keeping it.

Go and frontend suites pass. `internal/agent` fails locally for both this branch and master, missing `shared_cert.pem`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSkta4vdhSWDoCECK7ENme
