### PR TITLE
fix(web): link every stylesheet the entry chunk depends on

### DIFF
--- a/internal/web/index.go
+++ b/internal/web/index.go
@@ -105,11 +105,15 @@ func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
 		config["profile"] = struct{}{}
 	}
 
+	manifest := h.readManifest()
+	entryJS, styles := entryAssets(manifest, "assets/main.ts")
+
 	data := map[string]any{
-		"Config":   config,
-		"Dev":      h.config.Dev,
-		"Manifest": h.readManifest(),
-		"Base":     base,
+		"Config": config,
+		"Dev":    h.config.Dev,
+		"Entry":  entryJS,
+		"Styles": styles,
+		"Base":   base,
 	}
 	file, err := h.content.Open("index.html")
 	if err != nil {
@@ -139,6 +143,59 @@ func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Could not execute index.html")
 	}
+}
+
+// entryAssets resolves the entry chunk's script and every stylesheet it depends on.
+// Vite splits scoped component CSS into its own chunk, and a chunk statically imported by
+// the entry gets no <link> of its own, so linking only the entry's `css` left those
+// stylesheets to whichever lazy page happened to import them. Deep linking to a page that
+// didn't (a container view) then rendered shared components unstyled until the user
+// navigated somewhere that pulled the chunk in.
+func entryAssets(manifest map[string]any, entry string) (string, []string) {
+	chunk, ok := manifest[entry].(map[string]any)
+	if !ok {
+		return "", nil
+	}
+
+	file, _ := chunk["file"].(string)
+
+	seen := make(map[string]bool)
+	styles := make([]string, 0, 4)
+	var collect func(key string)
+	collect = func(key string) {
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+
+		chunk, ok := manifest[key].(map[string]any)
+		if !ok {
+			return
+		}
+
+		// Imports first, matching the order Vite itself emits, so the entry's stylesheet
+		// (Tailwind's) keeps the last word in the cascade.
+		if imports, ok := chunk["imports"].([]any); ok {
+			for _, i := range imports {
+				if name, ok := i.(string); ok {
+					collect(name)
+				}
+			}
+		}
+
+		if css, ok := chunk["css"].([]any); ok {
+			for _, c := range css {
+				name, ok := c.(string)
+				if ok && !seen[name] {
+					seen[name] = true
+					styles = append(styles, name)
+				}
+			}
+		}
+	}
+	collect(entry)
+
+	return file, styles
 }
 
 func (h *handler) readManifest() map[string]any {

--- a/internal/web/index_test.go
+++ b/internal/web/index_test.go
@@ -1,0 +1,48 @@
+package web
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEntryAssets(t *testing.T) {
+	var manifest map[string]any
+	err := json.Unmarshal([]byte(`{
+		"assets/main.ts": {
+			"file": "assets/main-abc.js",
+			"css": ["assets/main-abc.css"],
+			"imports": ["_ContainerIcon-def.js", "_shared-ghi.js"],
+			"dynamicImports": ["assets/pages/index.vue"]
+		},
+		"_ContainerIcon-def.js": {
+			"file": "assets/ContainerIcon-def.js",
+			"css": ["assets/ContainerIcon-def.css"],
+			"imports": ["_shared-ghi.js"]
+		},
+		"_shared-ghi.js": {
+			"file": "assets/shared-ghi.js",
+			"css": ["assets/shared-ghi.css"]
+		},
+		"assets/pages/index.vue": {
+			"file": "assets/index-jkl.js",
+			"css": ["assets/pages-jkl.css"]
+		}
+	}`), &manifest)
+	assert.NoError(t, err)
+
+	entry, styles := entryAssets(manifest, "assets/main.ts")
+
+	assert.Equal(t, "assets/main-abc.js", entry)
+	// Statically imported chunks first, entry's own stylesheet last. Lazy page CSS is left
+	// to the preload helper.
+	assert.Equal(t, []string{"assets/shared-ghi.css", "assets/ContainerIcon-def.css", "assets/main-abc.css"}, styles)
+}
+
+func TestEntryAssetsMissingEntry(t *testing.T) {
+	entry, styles := entryAssets(map[string]any{}, "assets/main.ts")
+
+	assert.Empty(t, entry)
+	assert.Empty(t, styles)
+}

--- a/public/index.html
+++ b/public/index.html
@@ -14,10 +14,10 @@
     {{- if .Dev}}
     <script type="module" src="http://localhost:5173/@vite/client"></script>
     <script type="module" src="http://localhost:5173/assets/main.ts"></script>
-    {{- else }} {{ $js := index .Manifest "assets/main.ts" "file" }} {{ $css := index .Manifest "assets/main.ts" "css"
-    }}
-    <link rel="stylesheet" href="{{ .Base }}/{{ index $css 0}}" />
-    <script type="module" src="{{ .Base }}/{{ $js }}"></script>
+    {{- else }} {{- range .Styles }}
+    <link rel="stylesheet" href="{{ $.Base }}/{{ . }}" />
+    {{- end }}
+    <script type="module" src="{{ .Base }}/{{ .Entry }}"></script>
     {{- end }}
     <meta name="description" content="A log viewer for containers" />
     <meta name="robots" content="noindex" />


### PR DESCRIPTION
Sidebar container icons sometimes render with no status dot and no health color. Only happens when you land directly on a container page; visiting the home page fixes it for the rest of the session.

Vite splits scoped component CSS into its own chunk, and a chunk statically imported by the entry gets no link tag of its own. `public/index.html` linked only `manifest["assets/main.ts"].css[0]`, so six stylesheets loaded only as a side effect of lazily importing a page that happened to pull them in:

```
ContainerIcon, ContainerTitle, LogEntry, JsonFormatted, ViewerWithSource, memory
```

`ContainerIcon-*.css` came in through `pages/index.vue`. Deep link to `/container/[id]` and it never loads, so `.status-badge` has no positioning (0x0, invisible) and `[data-status]` colors are gone (healthy check turns white instead of green).

`entryAssets()` walks the manifest's static import graph from the entry and collects every css dep, imports-first so Tailwind's `main.css` stays last in the cascade (same order Vite emits itself).

Not reproducible under `make dev`, which sets `DEV=true` and lets the Vite dev server inject CSS through JS. Needs a production build (`make preview`).

Verified against a real built manifest: all 7 stylesheets emit, `main-*.css` last. Test covers ordering, dedupe, and an empty manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELDFzgXjbbndrvY7FhCPAJ