### PR TITLE
feat(ui): make the same-name container dropdown readable

### DIFF
--- a/assets/components/ContainerViewer/ContainerTitle.vue
+++ b/assets/components/ContainerViewer/ContainerTitle.vue
@@ -23,26 +23,38 @@
             <div v-else>
               <div class="dropdown">
                 <button tabindex="0" role="button" class="btn btn-xs md:btn-sm">
-                  {{ container.name }} <carbon:caret-down />
+                  {{ container.name }}
+                  <span class="badge badge-xs badge-neutral font-sans">{{ sameNameContainers.length }}</span>
+                  <carbon:caret-down />
                 </button>
                 <ul
                   tabindex="0"
-                  class="dropdown-content menu rounded-box bg-base-100 border-base-content/20 border shadow-sm"
+                  class="dropdown-content menu rounded-box bg-base-100 border-base-content/20 z-10 w-max border p-1 shadow-sm"
                 >
-                  <li v-for="other in otherContainers">
-                    <router-link :to="{ name: '/container/[id]', params: { id: other.id } }">
+                  <li class="menu-title px-2 py-1 text-xs">
+                    {{ $t("label.container", sameNameContainers.length) }}
+                  </li>
+                  <li v-for="other in sameNameContainers" :key="other.id">
+                    <router-link
+                      :to="{ name: '/container/[id]', params: { id: other.id } }"
+                      active-class="menu-active"
+                      class="grid grid-cols-[auto_1fr_auto] items-center gap-x-3"
+                      :title="other.isSwarm ? other.swarmId : other.name"
+                    >
                       <div
                         class="status data-[state=exited]:status-error data-[state=running]:status-success data-[state=paused]:status-warning"
                         :data-state="other.state"
                       ></div>
-                      <div v-if="other.isSwarm">{{ other.swarmId }}</div>
-                      <div v-else>{{ other.name }}</div>
-                      <div v-if="other.hostLabel !== container.hostLabel" class="text-base-content/50 text-xs">
-                        {{ other.hostLabel }}
+                      <div class="flex flex-col leading-tight">
+                        <span class="font-mono text-xs">{{ other.id.slice(0, 12) }}</span>
+                        <span v-if="showHost" class="text-base-content/50 font-sans text-[11px]">
+                          {{ other.hostLabel }}
+                        </span>
                       </div>
-                      <div v-if="other.state === 'running'">running</div>
-                      <div v-else-if="other.state === 'paused'">paused</div>
-                      <RelativeTime :date="other.finishedAt" class="text-base-content/70 text-xs" v-else />
+                      <div class="flex flex-col text-right font-sans leading-tight">
+                        <span class="text-xs">{{ other.state }}</span>
+                        <RelativeTime :date="timestampOf(other)" class="text-base-content/50 text-[11px]" />
+                      </div>
                     </router-link>
                   </li>
                 </ul>
@@ -106,11 +118,26 @@ const pinned = computed({
 const store = useContainerStore();
 const { containers: allContainers } = storeToRefs(store);
 
-const otherContainers = computed(() =>
+const sameNameContainers = computed(() =>
   allContainers.value
-    .filter((c) => c.name === container.name && c.id !== container.id && c.customGroup === container.customGroup)
+    .filter((c) => c.name === container.name && c.customGroup === container.customGroup)
     .sort((a, b) => +b.created - +a.created),
 );
+
+const otherContainers = computed(() => sameNameContainers.value.filter((c) => c.id !== container.id));
+
+// Same-name containers are usually the same service restarted, so the host only tells them
+// apart when they actually differ.
+const showHost = computed(() => new Set(sameNameContainers.value.map((c) => c.hostLabel)).size > 1);
+
+// Docker leaves startedAt/finishedAt at the zero time when a container never ran or is still
+// running, which renders as "2027 years ago". Fall back to the one timestamp always set.
+const isSet = (date: Date) => date.getFullYear() > 1;
+
+function timestampOf(c: Container) {
+  const date = c.state === "running" || c.state === "paused" ? c.startedAt : c.finishedAt;
+  return isSet(date) ? date : c.created;
+}
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
Swarm replicas share a task name, so the dropdown for same-name containers listed raw swarm task ids and rendered zero-value `finishedAt` as "2,027 years ago".

- show the short container id (12 chars) instead of the swarm task id, task id moved to the tooltip
- fall back to `created` when `startedAt`/`finishedAt` is the zero time
- include the current container in the list, marked with `menu-active`
- running/paused rows show started time; state and time right-aligned in a 3 column grid
- host label only when the containers actually span hosts
- count badge on the trigger plus a `label.container` menu title (existing key, no new strings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U37nFXXPzxh2pRkCwxd8d9