### PR TITLE
fix(docker): skip pnpm version switch during offline install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm fetch --ignore-scripts
 
 # Copy package.json and install dependencies
+# corepack already pins pnpm, so skip pnpm's own version switch. It would try to
+# resolve the packageManager field from the registry, which fails with --offline.
 COPY package.json ./
-RUN pnpm install --offline --ignore-scripts
+RUN pnpm install --offline --ignore-scripts --pm-on-fail=ignore
 
 # Copy assets and translations to build
 COPY vite.config.ts tsconfig.json .prettierrc.cjs .npmrc ./


### PR DESCRIPTION
Master's container build has been failing since the pnpm 12 bump (#5017):

```
Error: ERR_PNPM_BAD_CONFIG_DEP
  × resolve package manager dependencies
  ╰─▶ Failed to resolve config dependency pnpm@12.3.4 ... registry.npmjs.org/pnpm.jsonl
```

pnpm 12 resolves the `packageManager` pin on every install, even under corepack. The image runs `pnpm fetch` before `package.json` is copied, so nothing put `pnpm@12.3.4` in the metadata mirror, and the later `pnpm install --offline` can't resolve it.

Passing `--pm-on-fail=ignore` skips that resolution. corepack already pins the version inside the build, so nothing is lost.

Kept it on the install command instead of setting `pmOnFail: ignore` in pnpm-workspace.yaml. The workspace setting also fixes the build, but it turns off the version switch everywhere, so local pnpm silently falls back to whatever is installed (I hit 11.12.0 while testing).

Verified with `docker build --target node` on both linux/arm64 and linux/amd64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MXzKbiS2qCHAb9s6y222CS
