### PR TITLE
perf(ui): prefetch route chunks once the app is idle

### DIFF
--- a/assets/main.ts
+++ b/assets/main.ts
@@ -3,9 +3,12 @@ import { createApp, App as VueApp } from "vue";
 import App from "./App.vue";
 
 const app = createApp(App);
-Object.values(import.meta.glob<{ install: (app: VueApp) => void }>("./modules/*.ts", { eager: true })).forEach((i) =>
-  i.install?.(app),
-);
+// Specs live next to the modules they cover, and an eager glob would drag vitest into the entry chunk.
+Object.values(
+  import.meta.glob<{ install: (app: VueApp) => void }>(["./modules/*.ts", "!./modules/*.spec.ts"], {
+    eager: true,
+  }),
+).forEach((i) => i.install?.(app));
 app.mount("#app");
 
 if ("serviceWorker" in navigator) {

--- a/assets/modules/router.spec.ts
+++ b/assets/modules/router.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, test, vi } from "vitest";
+import { createRouter, createMemoryHistory } from "vue-router";
+import { prefetchRoutes } from "./router";
+
+const page = () => ({ template: "<div/>" });
+
+describe("prefetchRoutes", () => {
+  test("imports every lazily loaded page", async () => {
+    const home = vi.fn().mockResolvedValue(page());
+    const settings = vi.fn().mockResolvedValue(page());
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/", component: home },
+        { path: "/settings", component: settings },
+      ],
+    });
+
+    await prefetchRoutes(router);
+
+    expect(home).toHaveBeenCalledOnce();
+    expect(settings).toHaveBeenCalledOnce();
+  });
+
+  test("leaves eagerly bundled pages alone and survives a failed chunk", async () => {
+    const broken = vi.fn().mockRejectedValue(new Error("Failed to fetch dynamically imported module"));
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [
+        { path: "/", component: page() },
+        { path: "/broken", component: broken },
+      ],
+    });
+
+    await expect(prefetchRoutes(router)).resolves.toBeDefined();
+    expect(broken).toHaveBeenCalledOnce();
+  });
+});

--- a/assets/modules/router.ts
+++ b/assets/modules/router.ts
@@ -1,5 +1,5 @@
 import { type App } from "vue";
-import { createRouter, createWebHistory } from "vue-router";
+import { createRouter, createWebHistory, type Router } from "vue-router";
 import { routes } from "vue-router/auto-routes";
 import { setupLayouts } from "virtual:generated-layouts";
 
@@ -13,14 +13,57 @@ export const router = createRouter({
 const isStaleChunkError = (error: unknown) =>
   error instanceof Error && /dynamically imported module|Importing a module script failed/i.test(error.message);
 
+// Every page chunk together is ~50 KB brotli, a quarter of the entry chunk, but importing one
+// cold still blocks the navigation long enough to read as lag. Warming them once the app is idle
+// makes every later navigation resolve straight from the module cache, on mobile too.
+export const prefetchRoutes = (router: Router) => {
+  const loaders = router
+    .getRoutes()
+    .map((route) => route.components?.default)
+    .filter((component): component is () => Promise<unknown> => typeof component === "function");
+
+  return Promise.all(loaders.map((load) => load().catch(() => {})));
+};
+
+const whenIdle = (callback: () => void) =>
+  "requestIdleCallback" in window ? requestIdleCallback(callback, { timeout: 2_000 }) : setTimeout(callback, 500);
+
 export const install = (app: App) => {
-  window.addEventListener("vite:preloadError", () => window.location.reload());
+  let prefetching = false;
+  let navigating = false;
+
+  router.beforeEach(() => {
+    navigating = true;
+  });
+  router.afterEach(() => {
+    navigating = false;
+  });
+
+  window.addEventListener("vite:preloadError", (event) => {
+    // A background prefetch that fails offline must not yank the page out from under someone
+    // reading logs. Cancelling swallows the error, which the prefetch ignores anyway; a real
+    // navigation still reloads.
+    if (prefetching && !navigating) {
+      event.preventDefault();
+      return;
+    }
+    window.location.reload();
+  });
 
   router.onError((error, to) => {
+    navigating = false;
     if (isStaleChunkError(error)) {
       window.location.href = router.resolve(to).href;
     }
   });
 
   app.use(router);
+
+  // Save-Data means the browser is asking us not to spend bytes speculatively.
+  if (!(navigator as Navigator & { connection?: { saveData?: boolean } }).connection?.saveData) {
+    whenIdle(() => {
+      prefetching = true;
+      prefetchRoutes(router).finally(() => (prefetching = false));
+    });
+  }
 };


### PR DESCRIPTION
Pages are code split, so the first visit to a route pays a cold dynamic import before vue-router will even start the navigation. Nothing happens on click for the duration, which reads as lag.

The chunks are tiny. Measured on a production build (brotli, incremental cost beyond the entry graph):

| | brotli | files |
|---|---|---|
| entry graph | 211 KB | 45 |
| biggest page (`index.vue`) | 19.7 KB | 8 |
| typical page (`container/[id].vue`) | 2.6 KB | 5 |
| all 17 pages combined | 49.6 KB | 33 |

So this is round trips and module eval, not bandwidth. Warming every route on `requestIdleCallback` after mount costs less than a quarter of the entry chunk, once, and makes every later navigation resolve straight from the module cache. Works on mobile, unlike hover prefetch, and needs no spinner.

`sw.go` already caches hashed assets, so the 49.6 KB is paid once per version rather than per page load. Save-Data opts out.

## Changes

- `assets/modules/router.ts`: `prefetchRoutes()` walks `router.getRoutes()` and invokes each lazy component loader on idle, ignoring failures.
- A background prefetch failing (offline, blip) no longer triggers the stale-chunk `window.location.reload()`, which would otherwise yank the page out from under someone reading logs. The handler cancels the `vite:preloadError` only while a prefetch is in flight and no navigation is pending, so real navigations still reload.
- `assets/main.ts`: exclude specs from the eager `import.meta.glob("./modules/*.ts")`. Adding `router.spec.ts` next to `router.ts` matched that glob and pulled vitest into the entry chunk, taking it from 87 KB to 345 KB. Latent footgun for any future spec in that directory.

## Verification

- Entry chunk 87.19 KB → 87.62 KB, code splitting unchanged (entry graph 211.4 → 211.5 KB br, pages still 33 lazy files / 49.6 KB br).
- `pnpm typecheck` clean, `pnpm test` 281 passing across 31 files (includes 2 new specs for `prefetchRoutes`).

## Tradeoff

Prefetching evaluates the page modules, not just downloads them. SFC top-level code is only component definition today, so that is free, but a page doing real work at module scope would start doing it at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTvT9A4ZpB6R66vdkyQNwa

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTvT9A4ZpB6R66vdkyQNwa)_