### PR TITLE
perf(ui): stop refetching dispatchers per alert card

### DIFF
--- a/assets/components/Notification/AlertCard.vue
+++ b/assets/components/Notification/AlertCard.vue
@@ -158,8 +158,9 @@
 import type { Dispatcher, NotificationRule } from "@/types/notifications";
 import AlertForm from "./AlertForm.vue";
 
-const { alert, onUpdated, highlight } = defineProps<{
+const { alert, dispatchers, onUpdated, highlight } = defineProps<{
   alert: NotificationRule;
+  dispatchers: Dispatcher[];
   onUpdated?: () => void;
   highlight?: boolean;
 }>();
@@ -184,12 +185,6 @@ const { showToast } = useToast();
 const showDrawer = useDrawer();
 const isDeleting = ref(false);
 const confirmingDelete = ref(false);
-const dispatchers = ref<Dispatcher[]>([]);
-
-onMounted(async () => {
-  const res = await fetch(withBase("/api/notifications/dispatchers"));
-  dispatchers.value = await res.json();
-});
 
 async function changeDispatcher(id: number) {
   await fetch(withBase(`/api/notifications/rules/${alert.id}`), {

--- a/assets/pages/notifications.vue
+++ b/assets/pages/notifications.vue
@@ -80,6 +80,7 @@
             v-for="alert in filteredAlerts"
             :key="alert.id"
             :alert="alert"
+            :dispatchers="dispatchers"
             :on-updated="fetchAlerts"
             :highlight="alert.id === highlightId"
           />


### PR DESCRIPTION
The notifications page was hitting `/api/notifications/dispatchers` once per alert card. `AlertCard` fetched the full dispatcher list in its own `onMounted` just to populate the reassign dropdown, on top of the page's own fetch.

The page already loads that list, so it gets passed down as a prop now. Page load goes from 2 + N fetches to 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhrMXaEoBbMLT9ynpYwfGu