### PR TITLE
fix(ui): tint the notification bell with the log level

### DIFF
--- a/assets/components/LogViewer/ComplexLogItem.vue
+++ b/assets/components/LogViewer/ComplexLogItem.vue
@@ -23,7 +23,7 @@
     </ul>
   </DefineTemplate>
   <LogItem :logEntry>
-    <LogLevel class="flex select-none" :level="logEntry.level" />
+    <LogLevel class="flex select-none" :level="logEntry.level" :event="logEntry.matchedEvent" />
     <div @click="containers.length > 0 && showDrawer(LogDetails, { entry: logEntry })" class="cursor-pointer">
       <ReuseTemplate :data="validValues" />
     </div>

--- a/assets/components/LogViewer/GroupedLogItem.vue
+++ b/assets/components/LogViewer/GroupedLogItem.vue
@@ -2,7 +2,12 @@
   <LogItem :logEntry>
     <div class="flex flex-col">
       <div v-for="(msg, index) in logEntry.message" :key="index" class="flex items-start gap-x-2">
-        <LogLevel class="flex select-none" :level="logEntry.level" :position="getPosition(index)" />
+        <LogLevel
+          class="flex select-none"
+          :level="logEntry.level"
+          :position="getPosition(index)"
+          :event="index === 0 ? logEntry.matchedEvent : undefined"
+        />
         <div
           class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre"
           v-html="colorize(msg)"

--- a/assets/components/LogViewer/LogItem.vue
+++ b/assets/components/LogViewer/LogItem.vue
@@ -17,18 +17,6 @@
       <LogDate v-if="showTimestamp" :date="logEntry.date" class="shrink-0 select-none" />
     </div>
 
-    <!-- Cloud matched a notification on this exact line. Badged here rather
-         than inserted as its own row: the event IS this line, so a separate
-         marker would duplicate it — and during a storm would put one between
-         every pair of lines. -->
-    <span
-      v-if="logEntry.matchedEvent"
-      class="event-badge shrink-0 select-none"
-      :title="logEntry.matchedEvent.suppressed ? $t('label.event-suppressed-hint') : $t('label.event-sent-hint')"
-    >
-      <mdi:bell-off v-if="logEntry.matchedEvent.suppressed" class="size-3.5" />
-      <mdi:bell-alert v-else class="size-3.5" />
-    </span>
     <slot />
   </div>
 </template>
@@ -46,16 +34,3 @@ const { hosts } = useHosts();
 const container = currentContainer(toRef(() => logEntry.containerID));
 const host = computed(() => hosts.value[container.value.host]);
 </script>
-
-<style scoped>
-@reference "@/main.css";
-/* Quiet by default: a badge on every line of a storm must not out-shout the
-   logs. The delivered one keeps the alert colour because it marks the moment
-   something was actually sent. */
-.event-badge {
-  @apply mt-0.5 opacity-45 transition-opacity;
-}
-.event-badge:hover {
-  @apply opacity-100;
-}
-</style>

--- a/assets/components/LogViewer/LogLevel.vue
+++ b/assets/components/LogViewer/LogLevel.vue
@@ -1,5 +1,18 @@
 <template>
+  <!-- A matched notification takes over the level marker instead of adding a
+       second icon beside it: the bell is tinted with the level colour, so one
+       glyph still says both "this line fired" and what level it was. -->
+  <span
+    v-if="event"
+    class="event-badge mt-1 flex w-2.5 flex-none justify-center"
+    :data-event-level="level"
+    :title="event.suppressed ? $t('label.event-suppressed-hint') : $t('label.event-sent-hint')"
+  >
+    <mdi:bell-off v-if="event.suppressed" class="size-3.5 shrink-0" />
+    <mdi:bell-alert v-else class="size-3.5 shrink-0" />
+  </span>
   <div
+    v-else
     :data-level="level"
     :data-position="position"
     class="mt-1.5 size-2.5 flex-none rounded-lg"
@@ -7,15 +20,17 @@
   ></div>
 </template>
 <script lang="ts" setup>
-import { Position, Level } from "@/models/LogEntry";
+import { Position, Level, type MatchedEvent } from "@/models/LogEntry";
 
 const {
   level,
   position,
+  event,
   showUnknown = false,
 } = defineProps<{
   level?: Level;
   position?: Position;
+  event?: MatchedEvent;
   showUnknown?: boolean;
 }>();
 </script>
@@ -41,6 +56,26 @@ const {
 [data-position="end"] {
   border-radius: 0 0 0.375rem 0.375rem;
   margin-top: 0;
+}
+
+/* Named data-event-level, NOT data-level: the unscoped block below paints any
+   element carrying data-level with an !important background. */
+.event-badge {
+  @apply text-base-content/60 transition-colors;
+}
+.event-badge[data-event-level="debug"],
+.event-badge[data-event-level="trace"] {
+  @apply text-purple;
+}
+.event-badge[data-event-level="info"] {
+  @apply text-green;
+}
+.event-badge[data-event-level="error"],
+.event-badge[data-event-level="fatal"] {
+  @apply text-red;
+}
+.event-badge[data-event-level="warn"] {
+  @apply text-orange;
 }
 </style>
 <style>

--- a/assets/components/LogViewer/SimpleLogItem.vue
+++ b/assets/components/LogViewer/SimpleLogItem.vue
@@ -1,6 +1,6 @@
 <template>
   <LogItem :logEntry>
-    <LogLevel class="flex select-none" :level="logEntry.level" />
+    <LogLevel class="flex select-none" :level="logEntry.level" :event="logEntry.matchedEvent" />
     <div
       class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre"
       v-html="colorize(logEntry.message)"

--- a/assets/components/LogViewer/__snapshots__/EventSource.spec.ts.snap
+++ b/assets/components/LogViewer/__snapshots__/EventSource.spec.ts.snap
@@ -6,8 +6,8 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
     <div data-v-cf9ff940="" class="flex min-h-[1px] flex-1 content-center justify-center"><span class="loading loading-bars loading-md text-primary m-2" style="display: none;"></span></div>
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
-    <div data-v-1344ff3d="" data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div data-v-1344ff3d="" class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+    <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
+      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
           </svg></a>
         <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
@@ -27,18 +27,16 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
         </ul>
       </div>
       <!--v-if-->
-      <div data-v-1344ff3d="" class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
+      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
         <!--v-if-->
         <!--v-if-->
-        <div data-v-1344ff3d="" class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
+        <div class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
           <div class="inline-flex gap-2 text-blue whitespace-nowrap"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42 AM</time></div>
         </div>
       </div>
-      <!-- Cloud matched a notification on this exact line. Badged here rather
-         than inserted as its own row: the event IS this line, so a separate
-         marker would duplicate it — and during a storm would put one between
-         every pair of lines. -->
-      <!--v-if-->
+      <!-- A matched notification takes over the level marker instead of adding a
+       second icon beside it: the bell is tinted with the level colour, so one
+       glyph still says both "this line fired" and what level it was. -->
       <div data-v-e625cddd="" class="mt-1.5 size-2.5 flex-none rounded-lg flex select-none"></div>
       <div class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">foo bar</div>
     </div>
@@ -52,8 +50,8 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
     <div data-v-cf9ff940="" class="flex min-h-[1px] flex-1 content-center justify-center"><span class="loading loading-bars loading-md text-primary m-2" style="display: none;"></span></div>
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
-    <div data-v-1344ff3d="" data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div data-v-1344ff3d="" class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+    <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
+      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
           </svg></a>
         <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
@@ -73,18 +71,16 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
         </ul>
       </div>
       <!--v-if-->
-      <div data-v-1344ff3d="" class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
+      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
         <!--v-if-->
         <!--v-if-->
-        <div data-v-1344ff3d="" class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
+        <div class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
           <div class="inline-flex gap-2 text-blue whitespace-nowrap"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42</time></div>
         </div>
       </div>
-      <!-- Cloud matched a notification on this exact line. Badged here rather
-         than inserted as its own row: the event IS this line, so a separate
-         marker would duplicate it — and during a storm would put one between
-         every pair of lines. -->
-      <!--v-if-->
+      <!-- A matched notification takes over the level marker instead of adding a
+       second icon beside it: the bell is tinted with the level colour, so one
+       glyph still says both "this line fired" and what level it was. -->
       <div data-v-e625cddd="" class="mt-1.5 size-2.5 flex-none rounded-lg flex select-none"></div>
       <div class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">foo bar</div>
     </div>
@@ -98,8 +94,8 @@ exports[`<ContainerEventSource /> > render html correctly > should render messag
     <div data-v-cf9ff940="" class="flex min-h-[1px] flex-1 content-center justify-center"><span class="loading loading-bars loading-md text-primary m-2" style="display: none;"></span></div>
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
-    <div data-v-1344ff3d="" data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div data-v-1344ff3d="" class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+    <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
+      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
           </svg></a>
         <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
@@ -119,18 +115,16 @@ exports[`<ContainerEventSource /> > render html correctly > should render messag
         </ul>
       </div>
       <!--v-if-->
-      <div data-v-1344ff3d="" class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
+      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
         <!--v-if-->
         <!--v-if-->
-        <div data-v-1344ff3d="" class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
+        <div class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
           <div class="inline-flex gap-2 text-blue whitespace-nowrap"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42 AM</time></div>
         </div>
       </div>
-      <!-- Cloud matched a notification on this exact line. Badged here rather
-         than inserted as its own row: the event IS this line, so a separate
-         marker would duplicate it — and during a storm would put one between
-         every pair of lines. -->
-      <!--v-if-->
+      <!-- A matched notification takes over the level marker instead of adding a
+       second icon beside it: the bell is tinted with the level colour, so one
+       glyph still says both "this line fired" and what level it was. -->
       <div data-v-e625cddd="" class="mt-1.5 size-2.5 flex-none rounded-lg flex select-none"></div>
       <div class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">This is a message.</div>
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.3.4
+        version: 12.3.4
       pnpm:
         specifier: 12.3.4
         version: 12.3.4
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.3.4':
+    resolution: {integrity: sha512-Rq7JokWAyYF9IFfn8zofB/q2AgnZlmoMuH5fMHB2+Ta61I9aD7sNm+woZpx6iH+5vb38chdSoYRvOtSqlH72YQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.3.4:
     resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.3.4':
     optional: true
+
+  '@pnpm/exe@12.3.4':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
 
   pnpm@12.3.4:
     optionalDependencies:


### PR DESCRIPTION
A line with a matched notification carried two markers: the bell next to the timestamp and the level dot next to the message.

The bell now replaces the dot and takes the level colour, so one marker says both "this fired" and what level it was. Grouped entries keep the rail on rows after the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015H31fUrup3X2Z6TqD5g1aK