### PR TITLE
perf(ui): stop duplicating the cloud config and status requests

### DIFF
--- a/assets/components/CloudPopover.vue
+++ b/assets/components/CloudPopover.vue
@@ -124,8 +124,15 @@ const cloudUrl = __CLOUD_URL__;
 const callbackUrl = `${window.location.origin}${withBase("/")}`;
 const cloudLinkUrl = `${cloudUrl}/link?appUrl=${encodeURIComponent(callbackUrl)}&from=cloud`;
 
-const { cloudConfig, cloudStatus, cloudStatusError, isLoadingCloudStatus, fetchCloudConfig, fetchCloudStatus } =
-  useCloudConfig();
+const {
+  cloudConfig,
+  cloudStatus,
+  cloudStatusError,
+  isLoadingCloudStatus,
+  initialLoad,
+  fetchCloudStatus,
+  ensureCloudStatus,
+} = useCloudConfig();
 
 const welcomeModal = ref<{ open: () => void }>();
 const cloudWelcomeShown = useProfileStorage("cloudWelcomeShown", false);
@@ -136,17 +143,12 @@ const usagePercent = computed(() => {
 });
 
 function onOpen() {
-  if (cloudConfig.value?.linked && !cloudStatus.value && !isLoadingCloudStatus.value) {
-    fetchCloudStatus();
-  }
+  ensureCloudStatus();
 }
 
 onMounted(async () => {
-  await fetchCloudConfig();
-
-  if (cloudConfig.value?.linked) {
-    fetchCloudStatus();
-  }
+  await initialLoad;
+  ensureCloudStatus();
 
   // Handle successful OAuth return — show welcome modal
   if (window.location.hash === "#cloudLinked" && !cloudWelcomeShown.value) {

--- a/assets/composable/cloudConfig.ts
+++ b/assets/composable/cloudConfig.ts
@@ -29,8 +29,7 @@ async function fetchCloudConfig() {
 // shared `cloudConfig` ref — no per-component fetch.
 const initialLoad = fetchCloudConfig();
 
-async function fetchCloudStatus() {
-  if (!config.enableCloud || !cloudConfig.value?.linked) return;
+async function loadCloudStatus() {
   isLoadingCloudStatus.value = true;
   cloudStatusError.value = false;
   try {
@@ -47,13 +46,19 @@ async function fetchCloudStatus() {
   }
 }
 
-// Dedupes concurrent/repeat status fetches so several components (nav popover,
-// pro badge) can ask for the status without each firing its own request.
+// Several components (nav popover, pro badge, settings card) can ask for the
+// status at once on the same page, so callers that overlap share one request.
 let pendingStatus: Promise<void> | null = null;
-async function ensureCloudStatus() {
-  if (!config.enableCloud || !cloudConfig.value?.linked || cloudStatus.value) return;
-  pendingStatus ??= fetchCloudStatus().finally(() => (pendingStatus = null));
+async function fetchCloudStatus() {
+  if (!config.enableCloud || !cloudConfig.value?.linked) return;
+  pendingStatus ??= loadCloudStatus().finally(() => (pendingStatus = null));
   return pendingStatus;
+}
+
+// For consumers that only need a status, not a fresh one.
+async function ensureCloudStatus() {
+  if (cloudStatus.value) return;
+  return fetchCloudStatus();
 }
 
 const isPro = computed(() => cloudStatus.value?.plan.name.toLowerCase() === "pro");


### PR DESCRIPTION
Follow up to #5028, same kind of thing.

`CloudPopover` called `fetchCloudConfig()` on mount even though `cloudConfig.ts` already fires it at module import (the comment there says "no per-component fetch"), so `/api/cloud/config` went out twice on every page load.

It also called `fetchCloudStatus()` directly, which skipped the `ensureCloudStatus` dedupe. `ProBadge` and `CloudSettingsCard` mount on the same page and ask for the status too, so `/api/cloud/status` could fire two or three times concurrently on the settings page.

Moved the in-flight dedupe into `fetchCloudStatus` itself, so any overlapping callers share one request. `ensureCloudStatus` stays the cache-aware wrapper for consumers that just need a status. Callers that want a fresh one (settings card on mount, both retry buttons) keep working as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VhrMXaEoBbMLT9ynpYwfGu