### PR TITLE
ci: run pnpm dedupe on renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
   ],
   "rangeStrategy": "bump",
   "minimumReleaseAge": "24 hours",
+  "postUpdateOptions": ["pnpmDedupe"],
   "ignoreDeps": [],
   "packageRules": [
     {


### PR DESCRIPTION
Renovate bumps the direct dependency in package.json but leaves transitive resolutions pointing at the old version, so the lockfile ends up with two copies of a package. That happened twice with `@codemirror/state` (6.7.2/6.7.3, then 6.7.3/6.7.4) and both times typecheck failed because `@codemirror/view` handed back an `EditorState` from the other copy.

`pnpmDedupe` makes renovate run `pnpm dedupe` after the install, so the branch it pushes is already collapsed to one version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wn6uUowfcabiiN1872dJ4s