### PR TITLE
fix(ui): stop the alert form from jumping while previews load

### DIFF
--- a/assets/components/Notification/AlertForm.vue
+++ b/assets/components/Notification/AlertForm.vue
@@ -56,7 +56,9 @@
           :examples="containerExamples"
           :get-hints="containerHints"
         />
-        <div class="mt-1 text-sm">
+        <!-- Fixed height: this line flips between a spinner, a match count and nothing at all
+             on every keystroke, and a collapsing line shoves the rest of the form around. -->
+        <div class="mt-1 min-h-5 text-sm">
           <span v-if="isLoading && !containerResult" class="text-base-content/60">
             <span class="loading loading-spinner loading-xs align-middle"></span>
             {{ $t("notifications.alert-form.checking") }}

--- a/assets/components/Notification/EventAlertFields.vue
+++ b/assets/components/Notification/EventAlertFields.vue
@@ -35,7 +35,10 @@
       </span>
     </div>
 
-    <div v-if="samples.length" class="border-base-content/20 divide-base-content/10 divide-y rounded-lg border">
+    <div
+      v-if="samples.length"
+      class="border-base-content/20 divide-base-content/10 min-h-24 divide-y rounded-lg border"
+    >
       <div
         v-for="(sample, index) in samples"
         :key="index"
@@ -57,8 +60,8 @@
       {{ emptyStateMessage }}
     </div>
 
-    <p v-if="samples.length" class="text-base-content/50 mt-1 text-xs">
-      {{ $t("notifications.alert-form.event-preview-note") }}
+    <p class="text-base-content/50 mt-1 min-h-4 text-xs">
+      <template v-if="samples.length">{{ $t("notifications.alert-form.event-preview-note") }}</template>
     </p>
   </div>
 </template>

--- a/assets/components/Notification/ExpressionField.vue
+++ b/assets/components/Notification/ExpressionField.vue
@@ -8,7 +8,9 @@
       <div ref="editorRef" class="w-full"></div>
     </div>
 
-    <p v-if="error" class="text-error mt-1 font-mono text-xs">{{ error }}</p>
+    <!-- Always present: the error arrives a debounce after typing stops, and letting it push
+         everything below it down makes the form jump mid-edit. -->
+    <p class="text-error mt-1 min-h-4 font-mono text-xs">{{ error }}</p>
 
     <!-- Examples double as documentation: clicking one fills the editor. -->
     <div v-if="examples.length" class="mt-2 flex flex-wrap items-center gap-1.5">

--- a/assets/components/Notification/LogAlertFields.vue
+++ b/assets/components/Notification/LogAlertFields.vue
@@ -31,15 +31,16 @@
       :last-selected-item="undefined"
       class="border-base-content/20 bg-base-200/40 h-64 overflow-hidden rounded-lg border"
     />
+    <!-- Same height as the log list so results appearing and disappearing don't resize the form. -->
     <div
       v-else
-      class="border-base-content/15 bg-base-content/[0.03] text-base-content/60 flex h-24 items-center justify-center rounded-lg border border-dashed px-4 text-center text-sm"
+      class="border-base-content/15 bg-base-content/[0.03] text-base-content/60 flex h-64 items-center justify-center rounded-lg border border-dashed px-4 text-center text-sm"
     >
       {{ emptyStateMessage }}
     </div>
 
-    <p v-if="truncated" class="text-base-content/50 mt-1 text-xs">
-      {{ $t("notifications.alert-form.log-scan-note", scannedContainers) }}
+    <p class="text-base-content/50 mt-1 min-h-4 text-xs">
+      <template v-if="truncated">{{ $t("notifications.alert-form.log-scan-note", scannedContainers) }}</template>
     </p>
   </div>
 </template>

--- a/assets/components/Notification/MetricAlertFields.vue
+++ b/assets/components/Notification/MetricAlertFields.vue
@@ -44,7 +44,7 @@
       </span>
     </div>
 
-    <div v-if="samples.length" class="border-base-content/20 overflow-x-auto rounded-lg border">
+    <div v-if="samples.length" class="border-base-content/20 min-h-24 overflow-x-auto rounded-lg border">
       <table class="table-sm table">
         <thead>
           <tr>
@@ -90,8 +90,10 @@
       {{ emptyStateMessage }}
     </div>
 
-    <p v-if="samples.length" class="text-base-content/50 mt-1 text-xs">
-      {{ $t("notifications.alert-form.metric-preview-note", { duration: windowLabel }) }}
+    <p class="text-base-content/50 mt-1 min-h-4 text-xs">
+      <template v-if="samples.length">{{
+        $t("notifications.alert-form.metric-preview-note", { duration: windowLabel })
+      }}</template>
     </p>
   </div>
 </template>


### PR DESCRIPTION
Editing the log condition made the form jump on every keystroke. The container match line under step 2 collapses to zero height when `containerResult` is null, which is the case whenever the container expression is empty, so each preview request toggled the "Checking..." spinner line in and out and moved everything below it (including the step 3 heading).

Reserved space for everything that appears and disappears around a preview request:

- container match line gets `min-h-5`
- expression error line is always rendered with `min-h-4` instead of `v-if`
- log preview empty state is `h-64`, matching the log list, so results appearing don't resize the box
- log/metric/event preview notes always rendered with `min-h-4`, metric table and event sample list get `min-h-24`

Typecheck and vitest pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PdyDTZtGpXQxzp3th8YhT7