### PR TITLE
perf(ci): persist the Go build cache across container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,10 @@ dist
 .git
 e2e
 docs
+
+# Restored into the workspace by the Go cache restore/injection steps in
+# dev.yml. Without these the build context would carry a few hundred MB of
+# module and compiler cache on every build.
+go-build-cache
+go-mod-cache
+scratch

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,6 +23,7 @@ jobs:
     if: ${{ !github.event.repository.fork && !github.event.pull_request.head.repo.fork && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == 'amir20/dozzle') }}
     steps:
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Login to DockerHub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -60,6 +61,42 @@ jobs:
         run: |
           echo "${{ secrets.TTL_KEY }}" > shared_key.pem
           echo "${{ secrets.TTL_CERT }}" > shared_cert.pem
+      # BuildKit cache mounts live in the builder's local state and cache-to:gha
+      # does not export them. Every run got a fresh builder, so /go/pkg/mod and
+      # /root/.cache/go-build started empty and the whole dependency tree was
+      # recompiled from scratch for both platforms, ~135s of a 3m30s build. Note
+      # `go mod download` looks CACHED in the log while leaving its mount empty,
+      # so the modules were re-fetched inside `go build` too.
+      #
+      # Both mounts default to id=<target>, so the amd64 and arm64 builds share
+      # one copy and a single injection reaches both. That is safe for Go (GOCACHE
+      # keys entries by GOOS/GOARCH, the module cache is just source) and would
+      # not be for apt/apk, which is why those need id=...-${TARGETARCH}.
+      - name: Restore Go caches
+        id: go-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            go-build-cache
+            go-mod-cache
+          # Keyed on go.sum with no run-unique suffix so a hit skips the save.
+          # Dependencies are the expensive part and they only move when go.sum
+          # does; recompiling dozzle's own packages each run costs a few seconds.
+          # A per-SHA key would instead upload the whole cache on every build.
+          key: go-docker-${{ hashFiles('go.sum') }}
+          restore-keys: go-docker-
+      - name: Inject Go caches into the builder
+        uses: reproducible-containers/buildkit-cache-dance@5422eac04292c961a382e0f584ea0f03ad9da723 # v3.4.0
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-map: |
+            {
+              "go-build-cache": "/root/.cache/go-build",
+              "go-mod-cache": "/go/pkg/mod"
+            }
+          # On a hit the mounts would be written back unchanged, so skip the
+          # extraction post-step that tars them back out of the builder.
+          skip-extraction: ${{ steps.go-cache.outputs.cache-hit == 'true' }}
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:


### PR DESCRIPTION
The container build spends most of its time recompiling dependencies it already compiled on the previous run.

Step timings from a recent master build ([run 34037072315](https://github.com/amir20/dozzle/actions/runs/34037072315)), `Build and push` = 3m29s:

| phase | time |
| --- | --- |
| import gha cache manifest + node stage layers | ~15s |
| `pnpm build` | ~16s |
| **`go build` amd64 + arm64** | **135s** |
| export image + push | 11s |
| export to GHA cache (`mode=max`) | 32s |

The cache mounts for `/go/pkg/mod` and `/root/.cache/go-build` live in the builder's local state, and `cache-to: type=gha` does not export them. Every run gets a fresh builder, so both mounts start empty and the full dependency tree gets compiled from scratch for both platforms.

`go mod download` hides part of this. Its layer reports CACHED, so the RUN is skipped, but the mount it would have populated is still empty and the modules get re-fetched inside `go build`.

Locally, a warm rebuild of the same cross-compiled binary is 0.3s, and about 10-15s with a real source change under `internal/`.

## What this does

`actions/cache` restores the two caches, `buildkit-cache-dance` injects them into the mounts before the build. `actions/cache` is registered first so the post steps run in the right order: extraction, then save.

The key is `go.sum` alone with no per-SHA suffix, so a hit skips the save. Dependencies are the expensive part and they only move when `go.sum` does. Recompiling dozzle's own packages every run costs a few seconds. A per-SHA key would upload the whole cache on every build instead.

Both mounts default to `id=<target>`, so the amd64 and arm64 builds share one copy and a single injection reaches both. That works for Go, since GOCACHE keys its entries by GOOS/GOARCH and the module cache is only source. Caches like apt or apk would need `id=...-${TARGETARCH}` here.

`.dockerignore` has to exclude the restored dirs. They land in the workspace, which is the build context, so without that every build ships a few hundred MB of cache to the builder and gives back what it saves.

No Dockerfile change. Putting the module cache in a real layer instead would work, but `cache-to: mode=max` then has to export a ~500MB layer, so the dance covers it more cheaply.

## Checking it worked

The first run here will be slower. It has nothing to restore and pays the extract and upload. Measure from the second run. `go build` should land around 25s against 135s today.

If the extract and upload turn out to cost more than they save, the fallback is building the binaries on the runner with `setup-go` and copying them in, which is cheaper to restore but forks the build path from `make docker`.

`deploy.yml` and the `int-test` bake in `_tests.yml` have the same cold-cache problem. Left for a follow-up, `int-test` is the one most worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXCVQHYhvmrVt4n2xaujqr
