### PR TITLE
fix(logs): support Pino numeric log levels

### DIFF
--- a/internal/container/event_generator_test.go
+++ b/internal/container/event_generator_test.go
@@ -13,6 +13,27 @@ import (
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
+func TestEventGenerator_Pino(t *testing.T) {
+	const message = `{"level":30,"time":1788571152988,"pid":1,"hostname":"example","msg":"Service started"}`
+	for _, stream := range []StdType{STDOUT, STDERR} {
+		t.Run(stream.String(), func(t *testing.T) {
+			g := NewEventGenerator(context.Background(), makeFakeReader("2026-09-05T00:00:00Z "+message, stream), Container{})
+			event := <-g.Events
+
+			require.NotNil(t, event)
+			assert.Equal(t, "info", event.Level)
+			assert.Equal(t, LogTypeComplex, event.Type)
+			assert.Equal(t, stream.String(), event.Stream)
+			assert.Equal(t, message, event.RawMessage)
+			data, ok := event.Message.(*orderedmap.OrderedMap[string, any])
+			require.True(t, ok)
+			level, ok := data.Get("level")
+			require.True(t, ok)
+			assert.Equal(t, float64(30), level)
+		})
+	}
+}
+
 func TestEventGenerator_Events_tty(t *testing.T) {
 	input := "example input"
 

--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -68,6 +68,16 @@ var timestampRegex = regexp.MustCompile(`^(?:\d{4}[-/]\d{2}[-/]\d{2}(?:[T ](?:\d
 // JSON keys to check for log level (in priority order).
 var levelKeys = []string{"@l", "level", "log.level", "severity"}
 
+// Pino's default numeric levels. JSON numbers decode to float64.
+var pinoLevels = map[float64]string{
+	10: "trace",
+	20: "debug",
+	30: "info",
+	40: "warn",
+	50: "error",
+	60: "fatal",
+}
+
 func init() {
 	SupportedLogLevels = make(map[string]struct{}, len(logLevels)+1)
 	var aliases []string
@@ -118,6 +128,11 @@ func guessLogLevel(logEvent *LogEvent) string {
 			if v, ok := value.Get(key); ok {
 				if s, ok := v.(string); ok {
 					return normalizeLogLevel(s)
+				}
+				if n, ok := v.(float64); ok && key == "level" {
+					if level, ok := pinoLevels[n]; ok {
+						return level
+					}
 				}
 			}
 		}

--- a/internal/container/level_guesser_test.go
+++ b/internal/container/level_guesser_test.go
@@ -7,6 +7,47 @@ import (
 	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
+func TestGuessPinoLogLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{`{"level":10,"msg":"trace message"}`, "trace"},
+		{`{"level":20,"msg":"debug message"}`, "debug"},
+		{`{"level":30,"time":1788571152988,"pid":1,"hostname":"example","msg":"Service started"}`, "info"},
+		{`{"level":40,"msg":"warning message"}`, "warn"},
+		{`{"level":50,"msg":"error message"}`, "error"},
+		{`{"level":60,"msg":"fatal message"}`, "fatal"},
+		{`{"level":30.0}`, "info"},
+		{`{"level":35}`, "unknown"},
+		{`{"level":30.5}`, "unknown"},
+		{`{"level":0}`, "unknown"},
+		{`{"level":-10}`, "unknown"},
+		{`{"level":70}`, "unknown"},
+		{`{"level":null}`, "unknown"},
+		{`{"level":true}`, "unknown"},
+		{`{"level":"30"}`, "unknown"},
+		{`{"severity":30}`, "unknown"},
+		{`{"@l":30}`, "unknown"},
+		{`{"log.level":30}`, "unknown"},
+		{`{"@l":"error","level":30}`, "error"},
+		{`{"level":30,"severity":"error"}`, "info"},
+		{`{"level":35,"severity":"warn"}`, "warn"},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			// Exercise the same JSON decoding path as container logs.
+			event := createEvent("2026-09-05T00:00:00Z "+test.input, STDOUT)
+			if event.Type != LogTypeComplex {
+				t.Fatalf("Expected JSON log event, got %v", event.Type)
+			}
+			if actual := guessLogLevel(event); actual != test.expected {
+				t.Errorf("Expected %s, got %s", test.expected, actual)
+			}
+		})
+	}
+}
+
 func TestGuessLogLevel(t *testing.T) {
 	var nilOrderedMap *orderedmap.OrderedMap[string, any]
 	tests := []struct {


### PR DESCRIPTION
Valid Pino JSON logs such as `{"level":30,"msg":"Service started"}` are currently classified as `unknown` because structured level detection only accepts strings. Recognize Pino's six default numeric levels (10 through 60), so these entries receive the appropriate level for display and filtering.

Apply the mapping only to the JSON `level` field. Other numeric severity fields may use different scales. Preserve existing string handling, key priority, and fallback for unsupported values; custom numeric levels remain unsupported. The original JSON is preserved.

Tests cover all six levels, fractional and unsupported values, field priority, and event generation from both stdout and stderr, including preservation of the numeric field and raw message.

Validation: `make test-ci` passed with Go 1.27.1 in Docker (full Go suite with coverage and race detection). Formatting and `git diff --check` passed.

Related: #3341 and the closed, unmerged #4940. This change is limited to numeric Pino levels in valid JSON.
