### PR TITLE
fix(logs): stop merged log stream from deadlocking the container store

### DIFF
--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -207,7 +207,8 @@ func sendLogs(stream pb.AgentService_StreamLogsClient, events chan<- *container.
 			continue
 		}
 
-		events <- &container.LogEvent{
+		select {
+		case events <- &container.LogEvent{
 			Id:          resp.Event.Id,
 			ContainerID: resp.Event.ContainerId,
 			Message:     message,
@@ -216,6 +217,9 @@ func sendLogs(stream pb.AgentService_StreamLogsClient, events chan<- *container.
 			Level:       resp.Event.Level,
 			Stream:      resp.Event.Stream,
 			RawMessage:  resp.Event.RawMessage,
+		}:
+		case <-stream.Context().Done():
+			return stream.Context().Err()
 		}
 	}
 }
@@ -304,7 +308,11 @@ func (c *Client) StreamEvents(ctx context.Context, events chan<- container.Conta
 			c := container.FromProto(resp.Event.Container)
 			evt.Container = &c
 		}
-		events <- evt
+		select {
+		case events <- evt:
+		case <-stream.Context().Done():
+			return stream.Context().Err()
+		}
 	}
 }
 

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -272,7 +272,8 @@ func (c *Client) StreamStats(ctx context.Context, stats chan<- container.Contain
 			return rpcErrToErr(err)
 		}
 
-		stats <- container.ContainerStat{
+		select {
+		case stats <- container.ContainerStat{
 			CPUPercent:     resp.Stat.CpuPercent,
 			MemoryPercent:  resp.Stat.MemoryPercent,
 			MemoryUsage:    resp.Stat.MemoryUsage,
@@ -281,6 +282,9 @@ func (c *Client) StreamStats(ctx context.Context, stats chan<- container.Contain
 			NetworkTxTotal: resp.Stat.NetworkTxTotal,
 			DiskReadTotal:  resp.Stat.DiskReadTotal,
 			DiskWriteTotal: resp.Stat.DiskWriteTotal,
+		}:
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }
@@ -328,7 +332,11 @@ func (c *Client) StreamNewContainers(ctx context.Context, containers chan<- cont
 			return rpcErrToErr(err)
 		}
 
-		containers <- container.FromProto(resp.Container)
+		select {
+		case containers <- container.FromProto(resp.Container):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 
@@ -454,12 +462,16 @@ func (c *Client) UpdateContainer(ctx context.Context, containerID string, progre
 			updated = true
 		}
 
-		progressCh <- container.UpdateProgress{
+		select {
+		case progressCh <- container.UpdateProgress{
 			Status:  progress.Status,
 			Layer:   progress.Layer,
 			Current: progress.Current,
 			Total:   progress.Total,
 			Error:   progress.Error,
+		}:
+		case <-ctx.Done():
+			return false, ctx.Err()
 		}
 	}
 }

--- a/internal/container/container_store.go
+++ b/internal/container/container_store.go
@@ -113,8 +113,32 @@ const (
 	sendCancelled
 )
 
-// sendBounded delivers v, waiting at most broadcastTimeout for a full channel.
-func sendBounded[T any](ctx context.Context, ch chan<- T, v T) sendResult {
+// fanoutBudget is the wait shared by one fan-out. The timeout is per fan-out
+// rather than per subscriber so that N wedged subscribers cost the loop one
+// broadcastTimeout between them, not N of them on every event. It starts on
+// first use, so a fan-out where everyone is reading allocates nothing.
+type fanoutBudget struct {
+	expired chan struct{}
+	timer   *time.Timer
+}
+
+func (b *fanoutBudget) start() <-chan struct{} {
+	if b.expired == nil {
+		b.expired = make(chan struct{})
+		b.timer = time.AfterFunc(broadcastTimeout, func() { close(b.expired) })
+	}
+	return b.expired
+}
+
+func (b *fanoutBudget) stop() {
+	if b.timer != nil {
+		b.timer.Stop()
+	}
+}
+
+// sendBounded delivers v, waiting no longer than what is left of the fan-out's
+// shared budget for a subscriber that is not reading.
+func sendBounded[T any](ctx context.Context, ch chan<- T, v T, budget *fanoutBudget) sendResult {
 	select {
 	case ch <- v:
 		return sendOK
@@ -123,14 +147,12 @@ func sendBounded[T any](ctx context.Context, ch chan<- T, v T) sendResult {
 	default:
 	}
 
-	timer := time.NewTimer(broadcastTimeout)
-	defer timer.Stop()
 	select {
 	case ch <- v:
 		return sendOK
 	case <-ctx.Done():
 		return sendCancelled
-	case <-timer.C:
+	case <-budget.start():
 		return sendDropped
 	}
 }
@@ -138,8 +160,11 @@ func sendBounded[T any](ctx context.Context, ch chan<- T, v T) sendResult {
 // broadcast fans an event out to every subscriber without letting any of them
 // stall the caller.
 func (s *ContainerStore) broadcast(event ContainerEvent) {
+	budget := &fanoutBudget{}
+	defer budget.stop()
+
 	s.subscribers.Range(func(ctx context.Context, events chan<- ContainerEvent) bool {
-		switch sendBounded(ctx, events, event) {
+		switch sendBounded(ctx, events, event, budget) {
 		case sendCancelled:
 			s.subscribers.Delete(ctx)
 		case sendDropped:
@@ -381,8 +406,11 @@ func (s *ContainerStore) addContainer(id string, timeout time.Duration) {
 	}
 
 	s.containers.Store(found.ID, &found)
+	budget := &fanoutBudget{}
+	defer budget.stop()
+
 	s.newContainerSubscribers.Range(func(c context.Context, containers chan<- Container) bool {
-		switch sendBounded(c, containers, found) {
+		switch sendBounded(c, containers, found, budget) {
 		case sendCancelled:
 			s.newContainerSubscribers.Delete(c)
 		case sendDropped:

--- a/internal/container/container_store.go
+++ b/internal/container/container_store.go
@@ -74,20 +74,12 @@ func (s *ContainerStore) applyMountStats(id string, stats map[string]MountStat) 
 		return
 	}
 
-	event := ContainerEvent{
+	s.broadcast(ContainerEvent{
 		Name:      "update",
 		Host:      updated.Host,
 		ActorID:   updated.ID,
 		Time:      time.Now(),
 		Container: updated,
-	}
-	s.subscribers.Range(func(ctx context.Context, events chan<- ContainerEvent) bool {
-		select {
-		case events <- event:
-		case <-ctx.Done():
-			s.subscribers.Delete(ctx)
-		}
-		return true
 	})
 }
 
@@ -95,6 +87,71 @@ var (
 	ErrContainerNotFound = errors.New("container not found")
 	maxFetchParallelism  = int64(30)
 )
+
+// broadcastTimeout bounds how long a fan-out waits on a subscriber that is not
+// draining its channel.
+//
+// Everything this store does runs on one goroutine: the Docker event stream,
+// stats, and the create/start handling that is the only path a container has
+// into the map. A blocking send to a subscriber puts all of that behind the
+// slowest reader, and a subscriber that stops reading entirely (a handler that
+// deadlocked, a client whose socket wedged) stops the store for as long as its
+// context stays alive. Docker does not hold events for a consumer that has
+// stopped reading, so what is lost during a stall is lost permanently — a
+// missed `start` means the container never appears until the process restarts.
+//
+// One wedged subscriber must cost its own messages, never the loop.
+const broadcastTimeout = 250 * time.Millisecond
+
+type sendResult int
+
+const (
+	sendOK sendResult = iota
+	// sendDropped: the subscriber did not read in time. Its message is gone.
+	sendDropped
+	// sendCancelled: the subscriber is finished and should be unregistered.
+	sendCancelled
+)
+
+// sendBounded delivers v, waiting at most broadcastTimeout for a full channel.
+func sendBounded[T any](ctx context.Context, ch chan<- T, v T) sendResult {
+	select {
+	case ch <- v:
+		return sendOK
+	case <-ctx.Done():
+		return sendCancelled
+	default:
+	}
+
+	timer := time.NewTimer(broadcastTimeout)
+	defer timer.Stop()
+	select {
+	case ch <- v:
+		return sendOK
+	case <-ctx.Done():
+		return sendCancelled
+	case <-timer.C:
+		return sendDropped
+	}
+}
+
+// broadcast fans an event out to every subscriber without letting any of them
+// stall the caller.
+func (s *ContainerStore) broadcast(event ContainerEvent) {
+	s.subscribers.Range(func(ctx context.Context, events chan<- ContainerEvent) bool {
+		switch sendBounded(ctx, events, event) {
+		case sendCancelled:
+			s.subscribers.Delete(ctx)
+		case sendDropped:
+			log.Warn().
+				Str("host", s.client.Host().Name).
+				Str("event", event.Name).
+				Str("id", event.ActorID).
+				Msg("subscriber is not reading container events, dropping event")
+		}
+		return true
+	})
+}
 
 func (s *ContainerStore) checkConnectivity() error {
 	if s.connected.CompareAndSwap(false, true) {
@@ -233,20 +290,11 @@ func (s *ContainerStore) FindContainer(id string, labels ContainerLabels) (Conta
 
 	if updated {
 		go func() {
-			event := ContainerEvent{
+			s.broadcast(ContainerEvent{
 				Name:      "update",
 				Host:      container.Host,
 				ActorID:   id,
 				Container: container,
-			}
-
-			s.subscribers.Range(func(c context.Context, events chan<- ContainerEvent) bool {
-				select {
-				case events <- event:
-				case <-c.Done():
-					s.subscribers.Delete(c)
-				}
-				return true
 			})
 		}()
 	}
@@ -334,9 +382,14 @@ func (s *ContainerStore) addContainer(id string, timeout time.Duration) {
 
 	s.containers.Store(found.ID, &found)
 	s.newContainerSubscribers.Range(func(c context.Context, containers chan<- Container) bool {
-		select {
-		case containers <- found:
-		case <-c.Done():
+		switch sendBounded(c, containers, found) {
+		case sendCancelled:
+			s.newContainerSubscribers.Delete(c)
+		case sendDropped:
+			log.Warn().
+				Str("host", s.client.Host().Name).
+				Str("id", found.ID).
+				Msg("subscriber is not reading new containers, dropping container")
 		}
 		return true
 	})
@@ -387,17 +440,10 @@ func (s *ContainerStore) init() {
 				})
 
 				if started {
-					s.subscribers.Range(func(ctx context.Context, events chan<- ContainerEvent) bool {
-						select {
-						case events <- ContainerEvent{
-							Name:    "start",
-							ActorID: updatedContainer.ID,
-							Host:    updatedContainer.Host,
-						}:
-						case <-ctx.Done():
-							s.subscribers.Delete(ctx)
-						}
-						return true
+					s.broadcast(ContainerEvent{
+						Name:    "start",
+						ActorID: updatedContainer.ID,
+						Host:    updatedContainer.Host,
 					})
 				}
 
@@ -464,14 +510,7 @@ func (s *ContainerStore) init() {
 					return &copy, xsync.UpdateOp
 				})
 			}
-			s.subscribers.Range(func(c context.Context, events chan<- ContainerEvent) bool {
-				select {
-				case events <- event:
-				case <-c.Done():
-					s.subscribers.Delete(c)
-				}
-				return true
-			})
+			s.broadcast(event)
 
 		case stat := <-stats:
 			if container, ok := s.containers.Load(stat.ID); ok {

--- a/internal/container/container_store_test.go
+++ b/internal/container/container_store_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/amir20/dozzle/internal/utils"
+	"github.com/puzpuzpuz/xsync/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -300,4 +301,31 @@ func TestContainerStore_wedgedSubscriberDoesNotStallStore(t *testing.T) {
 		_, hasSecond := ids["9012"]
 		return hasFirst && hasSecond
 	}, 5*time.Second, 10*time.Millisecond, "containers started behind a wedged subscriber should still reach the store")
+}
+
+// The wait belongs to the fan-out, not to each subscriber: a host that has
+// collected several wedged readers must not pay a full timeout per reader on
+// every event.
+func TestContainerStore_broadcastBudgetIsShared(t *testing.T) {
+	client := new(mockedClient)
+	client.On("Host").Return(Host{ID: "localhost"})
+
+	store := &ContainerStore{
+		client:      client,
+		subscribers: xsync.NewMap[context.Context, chan<- ContainerEvent](),
+	}
+
+	const wedged = 5
+	for range wedged {
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		store.subscribers.Store(ctx, make(chan ContainerEvent))
+	}
+
+	start := time.Now()
+	store.broadcast(ContainerEvent{Name: "start", ActorID: "1234"})
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, broadcastTimeout, "should have waited on the wedged subscribers")
+	assert.Less(t, elapsed, 2*broadcastTimeout, "should have waited once, not once per subscriber")
 }

--- a/internal/container/container_store_test.go
+++ b/internal/container/container_store_test.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/amir20/dozzle/internal/utils"
 	"github.com/stretchr/testify/assert"
@@ -246,3 +247,57 @@ type fakeStatsCollector struct{}
 func (f *fakeStatsCollector) Subscribe(_ context.Context, _ chan<- ContainerStat) {}
 func (f *fakeStatsCollector) Start(_ context.Context) bool                        { return true }
 func (f *fakeStatsCollector) Stop()                                               {}
+
+// A subscriber that stops reading must cost only its own events. The store runs
+// the Docker event stream, stats and every container add on one goroutine, so a
+// blocking fan-out lets one wedged reader freeze the host: containers that start
+// during the freeze are never added, and Docker does not replay what it sent
+// while nobody was reading.
+func TestContainerStore_wedgedSubscriberDoesNotStallStore(t *testing.T) {
+	client := new(mockedClient)
+
+	existing := Container{ID: "1234", Name: "test", State: "running", Stats: utils.NewRingBuffer[ContainerStat](300)}
+	first := Container{ID: "5678", Name: "first", State: "running", Stats: utils.NewRingBuffer[ContainerStat](300)}
+	second := Container{ID: "9012", Name: "second", State: "running", Stats: utils.NewRingBuffer[ContainerStat](300)}
+
+	client.On("ListContainers", mock.Anything, mock.Anything).Return([]Container{existing}, nil).Once()
+	client.On("ListContainers", mock.Anything, mock.Anything).Return([]Container{existing, first, second}, nil)
+	client.On("FindContainer", mock.Anything, "1234").Return(existing, nil)
+	client.On("FindContainer", mock.Anything, "5678").Return(first, nil)
+	client.On("FindContainer", mock.Anything, "9012").Return(second, nil)
+	client.On("Host").Return(Host{ID: "localhost"})
+
+	ready := make(chan struct{})
+	client.On("ContainerEvents", mock.Anything, mock.AnythingOfType("chan<- container.ContainerEvent")).Return(nil).
+		Run(func(args mock.Arguments) {
+			ctx := args.Get(0).(context.Context)
+			events := args.Get(1).(chan<- ContainerEvent)
+			<-ready
+			events <- ContainerEvent{Name: "start", ActorID: "5678", Host: "localhost"}
+			events <- ContainerEvent{Name: "start", ActorID: "9012", Host: "localhost"}
+			<-ctx.Done()
+		})
+
+	store := NewContainerStore(t.Context(), client, &fakeStatsCollector{}, ContainerLabels{})
+
+	// neither of these is ever read from: a handler that deadlocked, a client
+	// whose socket wedged. Both contexts stay alive, so nothing unregisters them.
+	store.SubscribeEvents(t.Context(), make(chan ContainerEvent))
+	store.SubscribeNewContainers(t.Context(), make(chan Container))
+
+	close(ready)
+
+	assert.Eventually(t, func() bool {
+		containers, err := store.ListContainers(ContainerLabels{})
+		if err != nil {
+			return false
+		}
+		ids := make(map[string]struct{}, len(containers))
+		for _, c := range containers {
+			ids[c.ID] = struct{}{}
+		}
+		_, hasFirst := ids["5678"]
+		_, hasSecond := ids["9012"]
+		return hasFirst && hasSecond
+	}, 5*time.Second, 10*time.Millisecond, "containers started behind a wedged subscriber should still reach the store")
+}

--- a/internal/container/event_generator.go
+++ b/internal/container/event_generator.go
@@ -270,24 +270,32 @@ func canContinueGroup(prev, next *LogEvent, groupLevel string) bool {
 }
 
 func (g *EventGenerator) consumeReader() {
+	defer g.wg.Done()
+
 	for {
 		message, streamType, readerError := g.reader.Read()
 		if message != "" {
 			logEvent := createEvent(message, streamType)
 			logEvent.ContainerID = g.containerID
 			logEvent.Level = guessLogLevel(logEvent)
-			g.buffer <- logEvent
+			// processBuffer stops draining as soon as emit sees the context end,
+			// so an unguarded send here parks this goroutine, and the reader it
+			// holds, for the life of the process once the buffer fills.
+			select {
+			case g.buffer <- logEvent:
+			case <-g.ctx.Done():
+				return
+			}
 		}
 
 		if readerError != nil {
 			if readerError != ErrBadHeader {
 				g.Errors <- readerError
 				close(g.buffer)
-				break
+				return
 			}
 		}
 	}
-	g.wg.Done()
 }
 
 func (g *EventGenerator) peek() *LogEvent {

--- a/internal/docker/client.go
+++ b/internal/docker/client.go
@@ -463,12 +463,18 @@ func (d *DockerClient) ContainerEvents(ctx context.Context, messages chan<- cont
 
 		case message := <-dockerMessages:
 			if message.Type == events.ContainerEventType && len(message.Actor.ID) > 0 {
-				messages <- container.ContainerEvent{
+				// ctx-guarded: an unguarded send outlives its consumer, and this
+				// goroutine is what tells the store its event stream has ended.
+				select {
+				case messages <- container.ContainerEvent{
 					ActorID:         message.Actor.ID[:12],
 					Name:            string(message.Action),
 					Host:            d.host.ID,
 					ActorAttributes: message.Actor.Attributes,
 					Time:            time.Now(),
+				}:
+				case <-ctx.Done():
+					return nil
 				}
 			}
 		}

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -604,12 +604,16 @@ func (k *K8sClient) ContainerEvents(ctx context.Context, ch chan<- container.Con
 				}
 
 				for _, c := range k.podToContainers(ctx, pod) {
-					ch <- container.ContainerEvent{
+					select {
+					case ch <- container.ContainerEvent{
 						Name:      name,
 						ActorID:   c.ID,
 						Host:      pod.Spec.NodeName,
 						Time:      time.Now(),
 						Container: &c,
+					}:
+					case <-ctx.Done():
+						return
 					}
 				}
 			}

--- a/internal/support/docker/docker_service.go
+++ b/internal/support/docker/docker_service.go
@@ -91,7 +91,11 @@ func (d *DockerClientService) StreamLogs(ctx context.Context, c container.Contai
 	dockerReader := docker.NewLogReader(reader, c.Tty)
 	g := container.NewEventGenerator(ctx, dockerReader, c)
 	for event := range g.Events {
-		events <- event
+		select {
+		case events <- event:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	select {

--- a/internal/support/docker/docker_service.go
+++ b/internal/support/docker/docker_service.go
@@ -160,10 +160,20 @@ func (d *DockerClientService) CheckImageUpdate(ctx context.Context, c container.
 func (d *DockerClientService) UpdateContainer(ctx context.Context, c container.Container, progressCh chan<- container.UpdateProgress) (bool, error) {
 	defer close(progressCh)
 
+	// The consumer is a request: an SSE handler that returns the moment a write
+	// to the client fails, or an agent stream that ends with its RPC. An
+	// unguarded send outlives it and parks this goroutine mid-update forever.
+	progress := func(p container.UpdateProgress) {
+		select {
+		case progressCh <- p:
+		case <-ctx.Done():
+		}
+	}
+
 	// 1. Inspect container to get full config
 	inspectResp, err := d.client.ContainerInspect(ctx, c.ID)
 	if err != nil {
-		progressCh <- container.UpdateProgress{Status: "error", Error: fmt.Sprintf("inspect failed: %v", err)}
+		progress(container.UpdateProgress{Status: "error", Error: fmt.Sprintf("inspect failed: %v", err)})
 		return false, err
 	}
 
@@ -172,7 +182,7 @@ func (d *DockerClientService) UpdateContainer(ctx context.Context, c container.C
 	// 2. Pull image with progress
 	reader, err := d.client.ImagePull(ctx, imageName)
 	if err != nil {
-		progressCh <- container.UpdateProgress{Status: "error", Error: fmt.Sprintf("pull failed: %v", err)}
+		progress(container.UpdateProgress{Status: "error", Error: fmt.Sprintf("pull failed: %v", err)})
 		return false, err
 	}
 	defer reader.Close()
@@ -183,16 +193,16 @@ func (d *DockerClientService) UpdateContainer(ctx context.Context, c container.C
 		if err := decoder.Decode(&event); err == io.EOF {
 			break
 		} else if err != nil {
-			progressCh <- container.UpdateProgress{Status: "error", Error: fmt.Sprintf("pull decode failed: %v", err)}
+			progress(container.UpdateProgress{Status: "error", Error: fmt.Sprintf("pull decode failed: %v", err)})
 			return false, err
 		}
 
-		progressCh <- container.UpdateProgress{
+		progress(container.UpdateProgress{
 			Status:  "pulling",
 			Layer:   event.ID,
 			Current: event.ProgressDetail.Current,
 			Total:   event.ProgressDetail.Total,
-		}
+		})
 	}
 
 	// 3. Compare what the tag resolves to now against what the container is
@@ -209,62 +219,62 @@ func (d *DockerClientService) UpdateContainer(ctx context.Context, c container.C
 	}
 
 	if !updated {
-		progressCh <- container.UpdateProgress{Status: "up-to-date"}
+		progress(container.UpdateProgress{Status: "up-to-date"})
 		return false, nil
 	}
 
 	// 4. Check if this is a swarm service
 	serviceName := c.Labels["com.docker.swarm.service.name"]
 	if serviceName != "" {
-		progressCh <- container.UpdateProgress{Status: "recreating"}
+		progress(container.UpdateProgress{Status: "recreating"})
 		serviceID := c.Labels["com.docker.swarm.service.id"]
 		if err := d.client.ServiceUpdate(ctx, serviceID, imageName); err != nil {
-			progressCh <- container.UpdateProgress{Status: "error", Error: fmt.Sprintf("service update failed: %v", err)}
+			progress(container.UpdateProgress{Status: "error", Error: fmt.Sprintf("service update failed: %v", err)})
 			return false, err
 		}
-		progressCh <- container.UpdateProgress{Status: "done"}
+		progress(container.UpdateProgress{Status: "done"})
 		return true, nil
 	}
 
 	// 5. Standalone container: check for self-update
 	if strings.Contains(imageName, "amir20/dozzle") {
-		progressCh <- container.UpdateProgress{Status: "error", Error: "Dozzle cannot update itself. Please restart manually."}
+		progress(container.UpdateProgress{Status: "error", Error: "Dozzle cannot update itself. Please restart manually."})
 		return false, fmt.Errorf("cannot self-update: stopping Dozzle would terminate the update process")
 	}
 
 	// 6. Standalone container: stop -> remove -> create -> start
-	progressCh <- container.UpdateProgress{Status: "recreating"}
+	progress(container.UpdateProgress{Status: "recreating"})
 
 	containerName := strings.TrimPrefix(inspectResp.Name, "/")
 
 	// Stop if running
 	if c.State == "running" {
 		if err := d.client.ContainerActions(ctx, container.Stop, c.ID); err != nil {
-			progressCh <- container.UpdateProgress{Status: "error", Error: fmt.Sprintf("stop failed: %v", err)}
+			progress(container.UpdateProgress{Status: "error", Error: fmt.Sprintf("stop failed: %v", err)})
 			return false, err
 		}
 	}
 
 	// Remove
 	if err := d.client.ContainerRemove(ctx, c.ID); err != nil {
-		progressCh <- container.UpdateProgress{Status: "error", Error: fmt.Sprintf("remove failed: %v", err)}
+		progress(container.UpdateProgress{Status: "error", Error: fmt.Sprintf("remove failed: %v", err)})
 		return false, err
 	}
 
 	// Create with same config
 	newID, err := d.client.ContainerCreate(ctx, inspectResp, containerName)
 	if err != nil {
-		progressCh <- container.UpdateProgress{Status: "error", Error: fmt.Sprintf("create failed: %v", err)}
+		progress(container.UpdateProgress{Status: "error", Error: fmt.Sprintf("create failed: %v", err)})
 		return false, err
 	}
 
 	// Start
 	if err := d.client.ContainerActions(ctx, container.Start, newID); err != nil {
-		progressCh <- container.UpdateProgress{Status: "error", Error: fmt.Sprintf("start failed: %v", err)}
+		progress(container.UpdateProgress{Status: "error", Error: fmt.Sprintf("start failed: %v", err)})
 		return false, err
 	}
 
-	progressCh <- container.UpdateProgress{Status: "done"}
+	progress(container.UpdateProgress{Status: "done"})
 	return true, nil
 }
 

--- a/internal/support/k8s/k8s_service.go
+++ b/internal/support/k8s/k8s_service.go
@@ -71,7 +71,11 @@ func (k *K8sClientService) StreamLogs(ctx context.Context, c container.Container
 	k8sReader := k8s.NewLogReader(reader)
 	g := container.NewEventGenerator(ctx, k8sReader, c)
 	for event := range g.Events {
-		events <- event
+		select {
+		case events <- event:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 
 	select {

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -515,11 +515,14 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 				if c.FinishedAt.IsZero() {
 					finishedAt = time.Now()
 				}
-				events <- &container.ContainerEvent{
+				select {
+				case events <- &container.ContainerEvent{
 					ActorID: c.ID,
 					Name:    "container-stopped",
 					Host:    c.Host,
 					Time:    finishedAt,
+				}:
+				case <-r.Context().Done():
 				}
 			} else if errors.Is(err, context.Canceled) || r.Context().Err() != nil {
 				// the client went away; a read already in flight comes back as
@@ -552,7 +555,17 @@ loop:
 			sseWriter.Message(logEvent)
 		case c := <-newContainers:
 			if _, err := h.hostService.FindContainer(c.Host, c.ID, userLabels); err == nil {
-				events <- &container.ContainerEvent{ActorID: c.ID, Name: "container-started", Host: c.Host, Time: time.Now()}
+				// Written straight to the client instead of pushed through `events`.
+				// This case runs on the same goroutine that drains `events`, so a send
+				// here waits on a reader that is this very statement: with the buffer
+				// already holding a container-stopped from streamLogs — which is what a
+				// redeploy produces — the handler deadlocks for good. It then stops
+				// draining newContainers, which backs up into the shared container store
+				// and freezes it for every client on that host.
+				event := &container.ContainerEvent{ActorID: c.ID, Name: "container-started", Host: c.Host, Time: time.Now()}
+				if err := sseWriter.Event("container-event", event); err != nil {
+					log.Error().Err(err).Msg("error encoding container event")
+				}
 				go streamLogs(c)
 			}
 

--- a/internal/web/logs_test.go
+++ b/internal/web/logs_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/url"
 	"regexp"
+	"sync/atomic"
 	"time"
 
 	"net/http"
@@ -531,4 +532,89 @@ func makeMessage(message string, stream container.StdType) []byte {
 	data = append(data, []byte(message)...)
 
 	return data
+}
+
+// The select loop is the only reader of its `events` channel, so it must never
+// be a writer to it. A container starting while a container-stopped sits in the
+// buffer used to deadlock the handler for good; it then stopped draining
+// newContainers, which backs up through the host service into the shared
+// container store and freezes it for every client on that host.
+func Test_handler_streamHostLogs_container_started_while_event_buffered(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "/api/hosts/localhost/logs/stream", nil)
+	require.NoError(t, err)
+	q := req.URL.Query()
+	q.Add("stdout", "true")
+	q.Add("stderr", "true")
+	addAllLogLevels(q)
+	req.URL.RawQuery = q.Encode()
+
+	running := container.Container{ID: "aaaa", Name: "running", Host: "localhost", State: "running"}
+	starting := container.Container{ID: "bbbb", Name: "starting", Host: "localhost", State: "running"}
+
+	var (
+		releaseStopped = make(chan struct{}) // lets the running container's stream end
+		inNewContainer = make(chan struct{}) // handler is inside the newContainers case
+		releaseLookup  = make(chan struct{}) // lets that case finish
+		startEvent     = make(chan struct{}) // docker reports the new container
+		lookups        atomic.Int32
+	)
+
+	mockedClient := new(MockedClient)
+	mockedClient.On("Host").Return(container.Host{ID: "localhost"})
+	mockedClient.On("ListContainers", mock.Anything, mock.Anything).Return([]container.Container{running}, nil).Once()
+	mockedClient.On("ListContainers", mock.Anything, mock.Anything).Return([]container.Container{running, starting}, nil)
+	mockedClient.On("FindContainer", mock.Anything, "aaaa").Return(running, nil)
+	mockedClient.On("FindContainer", mock.Anything, "bbbb").Return(starting, nil).
+		Run(func(args mock.Arguments) {
+			// first lookup is the store adding the container; the second one is the
+			// handler's, on the select loop itself
+			if lookups.Add(1) == 2 {
+				close(inNewContainer)
+				<-releaseLookup
+			}
+		})
+	mockedClient.On("ContainerLogs", mock.Anything, "aaaa", mock.Anything, container.STDALL).
+		Return(io.NopCloser(strings.NewReader("")), io.EOF).
+		Run(func(args mock.Arguments) {
+			<-releaseStopped
+		})
+	mockedClient.On("ContainerLogs", mock.Anything, "bbbb", mock.Anything, container.STDALL).
+		Return(io.NopCloser(strings.NewReader("")), io.EOF)
+	mockedClient.On("ContainerEvents", mock.Anything, mock.AnythingOfType("chan<- container.ContainerEvent")).Return(nil).
+		Run(func(args mock.Arguments) {
+			eventCtx := args.Get(0).(context.Context)
+			events := args.Get(1).(chan<- container.ContainerEvent)
+			<-startEvent
+			events <- container.ContainerEvent{Name: "start", ActorID: "bbbb", Host: "localhost"}
+			<-eventCtx.Done()
+		})
+
+	handler := createDefaultHandler(mockedClient)
+	rr := httptest.NewRecorder()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.ServeHTTP(rr, req)
+	}()
+
+	time.Sleep(300 * time.Millisecond) // handler is up and subscribed
+	close(startEvent)
+	<-inNewContainer
+	close(releaseStopped)              // container-stopped now occupies the buffer
+	time.Sleep(150 * time.Millisecond) // ...and has had time to get there
+	close(releaseLookup)
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler deadlocked when a container started while an event was buffered")
+	}
+
+	assert.Contains(t, rr.Body.String(), "container-started")
+	assert.Contains(t, rr.Body.String(), "bbbb")
 }


### PR DESCRIPTION
Production instance stopped picking up new containers. Two containers redeployed at 18:47 were still missing four hours later, with `container not found` logged twice a second the whole time. A goroutine dump from the wedged process pointed at the merged log stream handler.

## The deadlock

`streamLogsForContainers` has a select loop that is the only reader of its own `events` channel (cap 1), and one of its cases also writes to it:

```go
events := make(chan *container.ContainerEvent, 1)
...
case c := <-newContainers:
    events <- &container.ContainerEvent{...}   // waits on this same goroutine
case event := <-events:
```

The other producer is `streamLogs`, which pushes `container-stopped` when a container's log stream ends. If that slot is occupied when a container starts, the loop blocks on a channel only it can drain. A redeploy is exactly "one container stops while another starts", so it happens under normal use and nowhere else, which is why it looked random.

## Why one browser tab took the host down

```
handler loop stops draining newContainers (unbuffered)
  -> MultiHostService forwarder blocks (ctx is the request, still alive)
  -> ContainerStore.addContainer blocks broadcasting to subscribers
  -> the whole per-host store loop stops
```

That loop also drains the Docker event stream and stats. Docker does not hold events for a consumer that stopped reading, so `create` and `start` are dropped while it is stuck, and those are the only path a container has into the store. Anything that starts during the freeze is invisible until the process restarts. It also explains the 255 second stats gap in the logs and the 257 samples that flushed in one second when the browser finally disconnected.

## Changes

* `logs.go`: emit `container-started` straight to the SSE writer, which the loop already owns.
* `container_store.go`: fan out with a bounded send (250ms) instead of a blocking one. A subscriber that will not read loses that message and gets logged, instead of stopping every client on the host.
* ctx-guard the sends that leak a goroutine and its Docker stream once the consumer is gone: `StreamLogs` (docker, k8s), `ContainerEvents` (docker, k8s), agent client log and event streams. The dump had one of these parked on a send for 26 hours.

## Tests

Two regression tests, both verified to fail on master:

* `Test_handler_streamHostLogs_container_started_while_event_buffered` drives the exact ordering and times out on master.
* `TestContainerStore_wedgedSubscriberDoesNotStallStore` subscribes two readers that never read and asserts later containers still reach the store.

Full suite passes with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cuUsCNfGQWDNrw1k2mp1W
