### PR TITLE
feat: Redesign the live log indicator bar

### DIFF
--- a/assets/components/LogViewer/EventSource.spec.ts
+++ b/assets/components/LogViewer/EventSource.spec.ts
@@ -10,6 +10,7 @@ import { createI18n } from "vue-i18n";
 import { createRouter, createWebHistory } from "vue-router";
 import { default as Component } from "./EventSource.vue";
 import SearchStatus from "./SearchStatus.vue";
+import IndeterminateBar from "@/components/common/IndeterminateBar.vue";
 import LogViewer from "@/components/LogViewer/LogViewer.vue";
 import { Container } from "@/models/Container";
 import { Level } from "@/models/LogEntry";
@@ -171,6 +172,23 @@ describe("<ContainerEventSource />", () => {
     // @ts-ignore
     const [message, _] = wrapper.vm.messages;
     expect(message).toMatchSnapshot();
+  });
+
+  describe("live bar", () => {
+    test("lights up on an incoming batch and dims once the stream goes quiet", async () => {
+      const wrapper = createLogEventSource();
+      sources[sourceUrl].emitOpen();
+      sources[sourceUrl].emitMessage({
+        data: `{"ts":1560336942459, "m":"This is a message.", "id":1, "rm": "This is a message.", "c": "abc"}`,
+      });
+
+      // Past the 250ms buffer debounce, so the batch has flushed into messages.
+      await vi.advanceTimersByTimeAsync(300);
+      expect(wrapper.findComponent(IndeterminateBar).props("intensity")).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(2100);
+      expect(wrapper.findComponent(IndeterminateBar).props("intensity")).toBe(0);
+    });
   });
 
   describe("search status", () => {

--- a/assets/components/LogViewer/EventSource.vue
+++ b/assets/components/LogViewer/EventSource.vue
@@ -11,7 +11,7 @@
     {{ $t("label.no-logs") }}
   </div>
   <slot :messages="messages" v-else></slot>
-  <IndeterminateBar :color v-if="!historical" />
+  <IndeterminateBar :color :intensity="streaming ? 1 : 0" v-if="!historical" />
 </template>
 
 <script lang="ts" setup generic="T">
@@ -37,6 +37,12 @@ const color = computed(() => {
   if (opened.value) return "primary";
   return "error";
 });
+
+// The bar reflects real throughput. `messages` is a shallow ref replaced once
+// per buffer flush, so every arriving batch relights it and it fades back after
+// a couple of seconds of quiet instead of implying logs are still pouring in.
+const streaming = refAutoReset(false, 2000);
+watch(messages, () => (streaming.value = true));
 
 const noLogs = computed(() => messages.value.length === 0);
 const waitingForMoreLog = refAutoReset(false, 3000);

--- a/assets/components/LogViewer/SearchStatus.vue
+++ b/assets/components/LogViewer/SearchStatus.vue
@@ -8,7 +8,9 @@
       <span>{{
         status.scannedTo ? $t("label.search-status.searching-to", { time }) : $t("label.search-status.searching")
       }}</span>
-      <IndeterminateBar color="primary" class="ml-auto" />
+      <div class="ml-auto w-1/2">
+        <IndeterminateBar color="primary" />
+      </div>
     </template>
     <span v-else-if="state === 'empty'">{{ $t("label.search-status.empty") }}</span>
     <span v-else-if="state === 'capped'" class="tabular-nums">

--- a/assets/components/common/IndeterminateBar.vue
+++ b/assets/components/common/IndeterminateBar.vue
@@ -1,33 +1,89 @@
 <template>
-  <div class="animate-background h-1 w-1/2 bg-radial to-transparent to-75%" :class="colorClass"></div>
+  <div
+    class="indeterminate-bar"
+    :style="{ '--bar-color': `var(--color-${color})`, opacity: dimming }"
+    role="presentation"
+  >
+    <div class="indeterminate-bar__comet"></div>
+  </div>
 </template>
 <script setup lang="ts">
-const { color = "primary" } = defineProps<{ color: "primary" | "error" | "secondary" }>();
+const { color = "primary", intensity = 1 } = defineProps<{
+  color: "primary" | "error" | "secondary";
+  /** 0 = idle (nothing is arriving), 1 = busy. Fades the whole strip rather
+   * than changing its speed, so the sweep never jumps mid-flight. */
+  intensity?: number;
+}>();
 
-const colorClass = computed(() => {
-  switch (color) {
-    case "primary":
-      return "from-primary";
-    case "error":
-      return "from-error";
-    case "secondary":
-      return "from-secondary";
-  }
-});
+const dimming = computed(() => 0.35 + 0.65 * Math.min(Math.max(intensity, 0), 1));
 </script>
 
 <style scoped>
-.animate-background {
-  animation: gradient-animation 3s ease-out infinite;
+/* A dim rail is always drawn so the strip reads as a track the light travels
+ * along, instead of a loose glow floating over the background. */
+.indeterminate-bar {
+  position: relative;
+  height: 0.25rem;
+  overflow: hidden;
+  background: color-mix(in oklab, var(--bar-color) 12%, transparent);
+  /* Slow enough that a burst of logs reads as the strip lighting up and easing
+   * back down, not as a flicker. */
+  transition: opacity 900ms ease-out;
 }
 
-@keyframes gradient-animation {
-  0%,
-  100% {
-    transform: translateX(0%);
+/* The comet is a third of the track wide with the bright core near its leading
+ * edge and a long tail, so it reads as one object moving in one direction. */
+.indeterminate-bar__comet {
+  position: absolute;
+  inset-block: 0;
+  left: 0;
+  width: 33.333%;
+  background: linear-gradient(
+    to right,
+    transparent 0%,
+    color-mix(in oklab, var(--bar-color) 25%, transparent) 45%,
+    color-mix(in oklab, var(--bar-color) 70%, transparent) 78%,
+    var(--bar-color) 88%,
+    color-mix(in oklab, var(--bar-color) 55%, transparent) 96%,
+    transparent 100%
+  );
+  will-change: transform;
+  /* Travels off both edges (-105% and 320% of its own width) so it never turns
+   * around on screen. The easing is nearly all spent off the right edge, which
+   * keeps the speed even across the view and leaves a short beat between
+   * passes rather than a hard restart. */
+  animation: comet 2.2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes comet {
+  from {
+    transform: translateX(-105%);
   }
-  50% {
-    transform: translateX(100%);
+  to {
+    transform: translateX(320%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .indeterminate-bar {
+    transition: none;
+  }
+
+  .indeterminate-bar__comet {
+    width: 100%;
+    transform: none;
+    background: linear-gradient(to right, transparent, var(--bar-color), transparent);
+    animation: comet-breathe 3s ease-in-out infinite;
+  }
+
+  @keyframes comet-breathe {
+    0%,
+    100% {
+      opacity: 0.35;
+    }
+    50% {
+      opacity: 1;
+    }
   }
 }
 </style>


### PR DESCRIPTION
The bar at the bottom of a live log view ping-ponged a radial glow with `ease-out` on both halves, so it decelerated into each edge and then snapped back to full speed. With no track behind it, the glow read as a smudge floating over the background.

## What changed

A comet on a rail. A dim always-drawn track, and a one-third-width gradient with a bright leading edge and a long tail that enters and exits off screen, so it never turns around in view. 2.2s per pass with a short beat between passes.

The strip also reflects real throughput now. `messages` is a shallow ref replaced once per buffer flush, so every arriving batch lights it to full, and it eases back to a dim idle state after two seconds of quiet. An idle container reads faint instead of implying logs are still pouring in. It's binary live/idle, not a gradient, so a trickle looks the same as a firehose. A real throughput score needs a permanent per-stream interval, which didn't seem worth it.

Color still means connection state (primary open, secondary connecting, error closed).

Also:

- `prefers-reduced-motion` fallback: no sweep, a centered gradient breathing over 3s.
- The bar is clipped inside its track, so it no longer slides out of the search status row.
- Color moved to a `--bar-color` var, dropping the class-mapping computed.

Height and layout are unchanged, still 4px at the end of the log list.

## Testing

New test in `EventSource.spec.ts` covers lighting up on a batch and dimming after quiet. Typecheck and the LogViewer specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JRuvfwsSHstjWcJbjvGi4n