### PR TITLE
feat(logs): detect OpenTelemetry severityText/severityNumber fields

### DIFF
--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -1,8 +1,10 @@
 package container
 
 import (
+	"math"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -66,7 +68,8 @@ var klogPrefix = regexp.MustCompile(`^([EWIDFTV])\d{4} \d{2}:\d{2}:\d{2}\.\d{6}`
 var timestampRegex = regexp.MustCompile(`^(?:\d{4}[-/]\d{2}[-/]\d{2}(?:[T ](?:\d{2}:\d{2}:\d{2}(?:[.,]\d+)?Z?|\d{2}:\d{2}(?:AM|PM)))?\s+)`)
 
 // JSON keys to check for log level (in priority order).
-var levelKeys = []string{"@l", "level", "log.level", "severity"}
+// severityText/severityNumber are the OpenTelemetry Log Data Model fields.
+var levelKeys = []string{"@l", "level", "log.level", "severity", "severityText", "severityNumber"}
 
 // Pino's default numeric levels. JSON numbers decode to float64.
 var pinoLevels = map[float64]string{
@@ -76,6 +79,29 @@ var pinoLevels = map[float64]string{
 	40: "warn",
 	50: "error",
 	60: "fatal",
+}
+
+// otelSeverityLevel maps an OpenTelemetry severityNumber to a canonical level.
+// Ranges per https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+func otelSeverityLevel(n float64) string {
+	if n != math.Trunc(n) {
+		return ""
+	}
+	switch {
+	case n >= 1 && n <= 4:
+		return "trace"
+	case n >= 5 && n <= 8:
+		return "debug"
+	case n >= 9 && n <= 12:
+		return "info"
+	case n >= 13 && n <= 16:
+		return "warn"
+	case n >= 17 && n <= 20:
+		return "error"
+	case n >= 21 && n <= 24:
+		return "fatal"
+	}
+	return ""
 }
 
 func init() {
@@ -129,9 +155,16 @@ func guessLogLevel(logEvent *LogEvent) string {
 				if s, ok := v.(string); ok {
 					return normalizeLogLevel(s)
 				}
-				if n, ok := v.(float64); ok && key == "level" {
-					if level, ok := pinoLevels[n]; ok {
-						return level
+				if n, ok := v.(float64); ok {
+					switch key {
+					case "level":
+						if level, ok := pinoLevels[n]; ok {
+							return level
+						}
+					case "severityNumber":
+						if level := otelSeverityLevel(n); level != "" {
+							return level
+						}
 					}
 				}
 			}
@@ -143,6 +176,15 @@ func guessLogLevel(logEvent *LogEvent) string {
 		}
 		for _, key := range levelKeys {
 			if v, ok := value.Get(key); ok {
+				if key == "severityNumber" {
+					// logfmt-style string maps carry the OTel number as a string.
+					if n, err := strconv.Atoi(v); err == nil {
+						if level := otelSeverityLevel(float64(n)); level != "" {
+							return level
+						}
+					}
+					continue
+				}
 				return normalizeLogLevel(v)
 			}
 		}

--- a/internal/container/level_guesser_test.go
+++ b/internal/container/level_guesser_test.go
@@ -48,6 +48,57 @@ func TestGuessPinoLogLevel(t *testing.T) {
 	}
 }
 
+func TestGuessOtelLogLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// severityText follows the OpenTelemetry Log Data Model.
+		{`{"severityText":"TRACE","body":"trace message"}`, "trace"},
+		{`{"severityText":"DEBUG","body":"debug message"}`, "debug"},
+		{`{"severityText":"INFO","body":"info message"}`, "info"},
+		{`{"severityText":"WARN","body":"warn message"}`, "warn"},
+		{`{"severityText":"ERROR","body":"error message"}`, "error"},
+		{`{"severityText":"FATAL","body":"fatal message"}`, "fatal"},
+		{`{"severityText":"information","body":"lower case"}`, "info"},
+		{`{"severityText":"bogus","body":"not a level"}`, "unknown"},
+		// severityNumber ranges per the OTel spec.
+		{`{"severityNumber":1}`, "trace"},
+		{`{"severityNumber":4}`, "trace"},
+		{`{"severityNumber":5}`, "debug"},
+		{`{"severityNumber":8}`, "debug"},
+		{`{"severityNumber":9}`, "info"},
+		{`{"severityNumber":12}`, "info"},
+		{`{"severityNumber":13}`, "warn"},
+		{`{"severityNumber":16}`, "warn"},
+		{`{"severityNumber":17}`, "error"},
+		{`{"severityNumber":20}`, "error"},
+		{`{"severityNumber":21}`, "fatal"},
+		{`{"severityNumber":24}`, "fatal"},
+		{`{"severityNumber":0}`, "unknown"},
+		{`{"severityNumber":25}`, "unknown"},
+		{`{"severityNumber":-5}`, "unknown"},
+		{`{"severityNumber":9.5}`, "unknown"},
+		{`{"severityNumber":"17"}`, "unknown"},
+		// Existing keys keep their priority over the OTel fields.
+		{`{"level":30,"severityText":"ERROR"}`, "info"},
+		{`{"level":50,"severityNumber":9}`, "error"},
+		{`{"severity":"warn","severityText":"ERROR"}`, "warn"},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			// Exercise the same JSON decoding path as container logs.
+			event := createEvent("2026-09-05T00:00:00Z "+test.input, STDOUT)
+			if event.Type != LogTypeComplex {
+				t.Fatalf("Expected JSON log event, got %v", event.Type)
+			}
+			if actual := guessLogLevel(event); actual != test.expected {
+				t.Errorf("Expected %s, got %s", test.expected, actual)
+			}
+		})
+	}
+}
+
 func TestGuessLogLevel(t *testing.T) {
 	var nilOrderedMap *orderedmap.OrderedMap[string, any]
 	tests := []struct {
@@ -116,6 +167,21 @@ func TestGuessLogLevel(t *testing.T) {
 				orderedmap.Pair[string, any]{Key: "severity", Value: "info"},
 			),
 		), "info"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, string]{Key: "severityText", Value: "ERROR"},
+			),
+		), "error"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, string]{Key: "severityNumber", Value: "17"},
+			),
+		), "error"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, string]{Key: "severityNumber", Value: "not-a-number"},
+			),
+		), "unknown"},
 		{orderedmap.New[string, string](
 			orderedmap.WithInitialData(
 				orderedmap.Pair[string, string]{Key: "key", Value: "value"},


### PR DESCRIPTION
Fixes #5045

JSON logs following the [OpenTelemetry Log Data Model](https://opentelemetry.io/docs/specs/otel/logs/data-model/) carry their level in `severityText` / `severityNumber`, which Dozzle doesn't recognize, so they show up as `unknown` and can't be filtered or colored by level.

This PR adds both keys to `levelKeys` (lowest priority, so existing keys win):

- `severityText` goes through the existing `normalizeLogLevel` (`WARN`, `Information`, etc. all work).
- `severityNumber` is mapped per the [OTel spec ranges](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber) (1–4 trace, 5–8 debug, 9–12 info, 13–16 warn, 17–20 error, 21–24 fatal); non-integer/out-of-range values stay `unknown`. String values (logfmt) are parsed with `strconv.Atoi`.

Tests: added `TestGuessOtelLogLevel` covering all severity texts, range boundaries, invalid values, and key priority. `go test ./internal/container/` passes.
