### PR TITLE
fix(logs): fall back to severityNumber when severityText is not a level

### DIFF
--- a/internal/container/level_guesser.go
+++ b/internal/container/level_guesser.go
@@ -104,6 +104,36 @@ func otelSeverityLevel(n float64) string {
 	return ""
 }
 
+// otelSeverityNumber reads an OTel severityNumber, which arrives as a JSON
+// number from JSON logs and as a string from logfmt-style maps (some JSON
+// emitters quote it too). Returns "" when it is not a usable severity.
+func otelSeverityNumber(v any) string {
+	switch n := v.(type) {
+	case float64:
+		return otelSeverityLevel(n)
+	case string:
+		if i, err := strconv.Atoi(strings.TrimSpace(n)); err == nil {
+			return otelSeverityLevel(float64(i))
+		}
+	}
+	return ""
+}
+
+// otelSeverityText normalizes an OTel severityText. On top of the usual aliases
+// it understands the spec's own short names for sub-levels, which append 1-4 to
+// the base name: TRACE2, INFO3, WARN4. Returns "unknown" for anything else so
+// the caller can fall back to severityNumber.
+func otelSeverityText(s string) string {
+	if level := normalizeLogLevel(s); level != "unknown" {
+		return level
+	}
+	s = StripANSI(s)
+	if n := len(s); n > 1 && s[n-1] >= '1' && s[n-1] <= '4' {
+		return normalizeLogLevel(s[:n-1])
+	}
+	return "unknown"
+}
+
 func init() {
 	SupportedLogLevels = make(map[string]struct{}, len(logLevels)+1)
 	var aliases []string
@@ -151,20 +181,30 @@ func guessLogLevel(logEvent *LogEvent) string {
 			return "unknown"
 		}
 		for _, key := range levelKeys {
-			if v, ok := value.Get(key); ok {
+			v, ok := value.Get(key)
+			if !ok {
+				continue
+			}
+			switch key {
+			case "severityText":
+				// severityText is free-form, so a value we cannot map falls
+				// through to severityNumber instead of ending the search.
+				if s, ok := v.(string); ok {
+					if level := otelSeverityText(s); level != "unknown" {
+						return level
+					}
+				}
+			case "severityNumber":
+				if level := otelSeverityNumber(v); level != "" {
+					return level
+				}
+			default:
 				if s, ok := v.(string); ok {
 					return normalizeLogLevel(s)
 				}
-				if n, ok := v.(float64); ok {
-					switch key {
-					case "level":
-						if level, ok := pinoLevels[n]; ok {
-							return level
-						}
-					case "severityNumber":
-						if level := otelSeverityLevel(n); level != "" {
-							return level
-						}
+				if n, ok := v.(float64); ok && key == "level" {
+					if level, ok := pinoLevels[n]; ok {
+						return level
 					}
 				}
 			}
@@ -175,16 +215,20 @@ func guessLogLevel(logEvent *LogEvent) string {
 			return "unknown"
 		}
 		for _, key := range levelKeys {
-			if v, ok := value.Get(key); ok {
-				if key == "severityNumber" {
-					// logfmt-style string maps carry the OTel number as a string.
-					if n, err := strconv.Atoi(v); err == nil {
-						if level := otelSeverityLevel(float64(n)); level != "" {
-							return level
-						}
-					}
-					continue
+			v, ok := value.Get(key)
+			if !ok {
+				continue
+			}
+			switch key {
+			case "severityText":
+				if level := otelSeverityText(v); level != "unknown" {
+					return level
 				}
+			case "severityNumber":
+				if level := otelSeverityNumber(v); level != "" {
+					return level
+				}
+			default:
 				return normalizeLogLevel(v)
 			}
 		}

--- a/internal/container/level_guesser_test.go
+++ b/internal/container/level_guesser_test.go
@@ -62,6 +62,20 @@ func TestGuessOtelLogLevel(t *testing.T) {
 		{`{"severityText":"FATAL","body":"fatal message"}`, "fatal"},
 		{`{"severityText":"information","body":"lower case"}`, "info"},
 		{`{"severityText":"bogus","body":"not a level"}`, "unknown"},
+		// OTel short names for sub-levels append 1-4 to the base name.
+		{`{"severityText":"TRACE2"}`, "trace"},
+		{`{"severityText":"DEBUG3"}`, "debug"},
+		{`{"severityText":"INFO4"}`, "info"},
+		{`{"severityText":"WARN2"}`, "warn"},
+		{`{"severityText":"ERROR3"}`, "error"},
+		{`{"severityText":"FATAL4"}`, "fatal"},
+		{`{"severityText":"INFO5"}`, "unknown"},
+		// A severityText we cannot map falls back to severityNumber.
+		{`{"severityText":"WARN2","severityNumber":14}`, "warn"},
+		{`{"severityText":"Notice","severityNumber":9}`, "info"},
+		{`{"severityText":"","severityNumber":17}`, "error"},
+		{`{"severityText":"bogus","severityNumber":0}`, "unknown"},
+		{`{"severityText":42,"severityNumber":21}`, "fatal"},
 		// severityNumber ranges per the OTel spec.
 		{`{"severityNumber":1}`, "trace"},
 		{`{"severityNumber":4}`, "trace"},
@@ -79,7 +93,9 @@ func TestGuessOtelLogLevel(t *testing.T) {
 		{`{"severityNumber":25}`, "unknown"},
 		{`{"severityNumber":-5}`, "unknown"},
 		{`{"severityNumber":9.5}`, "unknown"},
-		{`{"severityNumber":"17"}`, "unknown"},
+		{`{"severityNumber":"17"}`, "error"},
+		{`{"severityNumber":"nope"}`, "unknown"},
+		{`{"severityNumber":true}`, "unknown"},
 		// Existing keys keep their priority over the OTel fields.
 		{`{"level":30,"severityText":"ERROR"}`, "info"},
 		{`{"level":50,"severityNumber":9}`, "error"},
@@ -182,6 +198,17 @@ func TestGuessLogLevel(t *testing.T) {
 				orderedmap.Pair[string, string]{Key: "severityNumber", Value: "not-a-number"},
 			),
 		), "unknown"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, string]{Key: "severityText", Value: "WARN2"},
+			),
+		), "warn"},
+		{orderedmap.New[string, string](
+			orderedmap.WithInitialData(
+				orderedmap.Pair[string, string]{Key: "severityText", Value: "Notice"},
+				orderedmap.Pair[string, string]{Key: "severityNumber", Value: "9"},
+			),
+		), "info"},
 		{orderedmap.New[string, string](
 			orderedmap.WithInitialData(
 				orderedmap.Pair[string, string]{Key: "key", Value: "value"},


### PR DESCRIPTION
Follow up to #5046.

`severityText` is free-form in the OTel data model, but the JSON path returned on it unconditionally, so an unmapped value short-circuited the key loop and `severityNumber` never got a chance. That includes the spec's own short names for sub-levels (`TRACE2`, `INFO3`, `WARN2`, ...), which aren't aliases, so `{"severityText":"WARN2","severityNumber":14}` came back as unknown.

Changes:

* `severityText` strips the trailing 1-4 of an OTel short name, so `WARN2` resolves to warn.
* Anything still unmapped (`Notice`, `""`, a non-string value) falls through to `severityNumber` instead of ending the search.
* `severityNumber` given as a string is now read in the JSON path too. logfmt already did this, so `severityNumber=17` and `{"severityNumber":"17"}` disagreed.

Both map branches share `otelSeverityText` / `otelSeverityNumber` now. Existing key priority is unchanged (`@l`, `level`, `log.level`, `severity` still win).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDzWy59qvAqMUDTG5rbZTy
