### PR TITLE
fix(auth): sign sessions with a persisted random secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ tmp
 .claude/settings.local.json
 .claude/worktrees/
 .playwright-mcp/
+e2e/data/session_secret

--- a/internal/auth/oauth_oidc_test.go
+++ b/internal/auth/oauth_oidc_test.go
@@ -104,7 +104,7 @@ func oidcAuth(t *testing.T, p IdentityProvider) *oauthAuthContext {
 		byGithub: map[string]*User{},
 	}
 
-	return NewOAuthAuth(NewSimpleAuth(db, 0), "", p)
+	return NewOAuthAuth(NewSimpleAuth(db, 0, testSecret), "", p)
 }
 
 // startOIDCLogin drives LoginHandler with a real Host so the callback URL is
@@ -170,7 +170,7 @@ func TestOIDCCallbackURLCarriesBase(t *testing.T) {
 	p, _, _ := testOIDCProvider(t, oidcOptions{})
 	user := &User{Username: "amir", Email: "amir@example.com"}
 	db := UserDatabase{Users: map[string]*User{"amir": user}, byEmail: map[string]*User{"amir@example.com": user}}
-	a := NewOAuthAuth(NewSimpleAuth(db, 0), "/dozzle", p)
+	a := NewOAuthAuth(NewSimpleAuth(db, 0, testSecret), "/dozzle", p)
 
 	_, _, redirectURI := startOIDCLogin(t, a, true)
 	require.Equal(t, "https://dozzle.example.com/dozzle/api/auth/callback", redirectURI)
@@ -278,7 +278,7 @@ func TestGithubAndOIDCCoexist(t *testing.T) {
 		byEmail:  map[string]*User{"amir@example.com": user},
 		byGithub: map[string]*User{"amir20": user},
 	}
-	a := NewOAuthAuth(NewSimpleAuth(db, 0), "", github, oidc)
+	a := NewOAuthAuth(NewSimpleAuth(db, 0, testSecret), "", github, oidc)
 
 	providers := a.Providers()
 	require.Len(t, providers, 2)

--- a/internal/auth/oauth_test.go
+++ b/internal/auth/oauth_test.go
@@ -75,7 +75,7 @@ func testAuth(t *testing.T, githubLogin string, provider IdentityProvider) *oaut
 		db.byGithub[normalizeGithub(githubLogin)] = user
 	}
 
-	return NewOAuthAuth(NewSimpleAuth(db, 0), "", provider)
+	return NewOAuthAuth(NewSimpleAuth(db, 0, testSecret), "", provider)
 }
 
 // startLogin runs LoginHandler and returns the state cookie plus the state value
@@ -344,7 +344,7 @@ func TestProvidersDescribeLoginButtons(t *testing.T) {
 // With a base path the login URL has to carry it, because the login page uses
 // the value verbatim.
 func TestProvidersLoginURLCarriesBase(t *testing.T) {
-	a := NewOAuthAuth(NewSimpleAuth(UserDatabase{Users: map[string]*User{}}, 0), "/dozzle", testGithubProvider(t, "amir20"))
+	a := NewOAuthAuth(NewSimpleAuth(UserDatabase{Users: map[string]*User{}}, 0, testSecret), "/dozzle", testGithubProvider(t, "amir20"))
 
 	require.Equal(t, "/dozzle/api/auth/login?provider=github", a.Providers()[0].LoginURL)
 }

--- a/internal/auth/secret.go
+++ b/internal/auth/secret.go
@@ -1,0 +1,97 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+// SessionSecretFile is the name of the file the signing secret is persisted to,
+// alongside users.yml.
+const SessionSecretFile = "session_secret"
+
+const sessionSecretSize = 32
+
+// SessionSecret returns the random key session tokens are signed with, reading
+// it from dir and creating it on first run.
+//
+// The signing key used to be derived from users.yml alone. That was fine while
+// every user had a bcrypt hash, which carries its own salt, but an account can
+// now be proven by OAuth instead and carry no password at all. In a deployment
+// where nobody has one, every input to that digest is public — a role name, an
+// email address, a GitHub login — so anyone who can guess them can derive the
+// key and mint a session for any user. This file is what puts real entropy back
+// in front of that.
+//
+// It fails soft. A read-only or unwritable /data is a real deployment (people
+// mount users.yml read-only), and refusing to boot over it would break upgrades
+// for installs that are not even at risk. An ephemeral secret is still
+// unguessable; it only costs sessions on restart, which is why it warns.
+func SessionSecret(dir string) []byte {
+	path := filepath.Join(dir, SessionSecretFile)
+
+	if secret, err := readSessionSecret(path); err == nil {
+		return secret
+	} else if !errors.Is(err, os.ErrNotExist) {
+		log.Warn().Err(err).Str("path", path).Msg("Could not read the session secret; generating a new one")
+	}
+
+	secret := make([]byte, sessionSecretSize)
+	if _, err := rand.Read(secret); err != nil {
+		// crypto/rand failing means the process has no usable entropy source.
+		// Continuing would sign sessions with zeros.
+		log.Fatal().Err(err).Msg("Could not generate a session secret")
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(secret) + "\n"
+
+	// O_EXCL rather than a plain create: replicas sharing the same volume race
+	// here on first boot, and the loser has to adopt the winner's secret instead
+	// of overwriting it and invalidating the other's sessions.
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			if existing, readErr := readSessionSecret(path); readErr == nil {
+				return existing
+			}
+		}
+
+		log.Warn().Err(err).Str("path", path).Msg("Could not persist the session secret; sessions will not survive a restart")
+		return secret
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(encoded); err != nil {
+		log.Warn().Err(err).Str("path", path).Msg("Could not write the session secret; sessions will not survive a restart")
+		return secret
+	}
+
+	log.Info().Str("path", path).Msg("Generated a new session secret")
+
+	return secret
+}
+
+func readSessionSecret(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	secret, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(data)))
+	if err != nil {
+		return nil, err
+	}
+
+	// A truncated or half-written file is worse than no file: it would sign
+	// every session with a key that has almost no entropy.
+	if len(secret) < sessionSecretSize {
+		return nil, errors.New("session secret is too short")
+	}
+
+	return secret, nil
+}

--- a/internal/auth/secret_test.go
+++ b/internal/auth/secret_test.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-chi/jwtauth/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionSecretPersistsAcrossRestarts(t *testing.T) {
+	dir := t.TempDir()
+
+	first := SessionSecret(dir)
+	require.Len(t, first, sessionSecretSize)
+
+	assert.Equal(t, first, SessionSecret(dir), "a second start should reuse the persisted secret")
+}
+
+func TestSessionSecretIsUniquePerInstall(t *testing.T) {
+	assert.NotEqual(t, SessionSecret(t.TempDir()), SessionSecret(t.TempDir()))
+}
+
+func TestSessionSecretFileIsNotWorldReadable(t *testing.T) {
+	dir := t.TempDir()
+	SessionSecret(dir)
+
+	info, err := os.Stat(filepath.Join(dir, SessionSecretFile))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+}
+
+// A truncated file would otherwise be decoded into a near-empty key, which is
+// the failure the persisted secret exists to prevent.
+func TestSessionSecretRejectsATruncatedFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, SessionSecretFile)
+	require.NoError(t, os.WriteFile(path, []byte("dHJ1bmNhdGVk\n"), 0600))
+
+	_, err := readSessionSecret(path)
+	assert.Error(t, err)
+}
+
+// An unwritable directory is a real deployment. Booting has to keep working, and
+// the secret still has to be random rather than fall back to the user digest.
+func TestSessionSecretFallsBackToAnEphemeralSecret(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "read-only")
+	require.NoError(t, os.Mkdir(dir, 0500))
+
+	secret := SessionSecret(dir)
+	require.Len(t, secret, sessionSecretSize)
+	assert.NotEqual(t, secret, SessionSecret(dir), "an unpersisted secret is regenerated per start")
+}
+
+// The signing key used to be a digest over users.yml alone. Every input to it is
+// public once an account is OAuth-only and carries no bcrypt hash, so anyone who
+// could guess a user's email and GitHub login could derive the key and mint a
+// session for them. See GHSA and internal/auth/secret.go.
+func TestSigningKeyIsNotDerivableFromUsersFile(t *testing.T) {
+	yml := `
+users:
+  admin:
+    email: admin@example.com
+    name: Admin
+    github: someadmin
+`
+	path := filepath.Join(t.TempDir(), "users.yml")
+	require.NoError(t, os.WriteFile(path, []byte(yml), 0600))
+
+	db, err := ReadUsersFromFile(path)
+	require.NoError(t, err)
+
+	a := NewSimpleAuth(db, 0, SessionSecret(t.TempDir()))
+
+	// Everything an attacker can see: no password, the default role, the email
+	// and the GitHub login straight out of users.yml.
+	h := sha256.New()
+	h.Write([]byte(""))
+	h.Write([]byte("all"))
+	h.Write([]byte("admin@example.com"))
+	h.Write([]byte("someadmin"))
+
+	_, forged, err := jwtauth.New("HS256", h.Sum(nil), nil).Encode(map[string]any{"username": "admin"})
+	require.NoError(t, err)
+
+	var resolved *User
+	handler := a.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resolved = UserFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.AddCookie(&http.Cookie{Name: "jwt", Value: forged})
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Nil(t, resolved, "a token signed with a key guessed from users.yml must not authenticate")
+}

--- a/internal/auth/simple.go
+++ b/internal/auth/simple.go
@@ -25,7 +25,14 @@ type simpleAuthContext struct {
 
 var ErrInvalidCredentials = errors.New("invalid credentials")
 
-func NewSimpleAuth(userDatabase UserDatabase, ttl time.Duration) *simpleAuthContext {
+// NewSimpleAuth builds the simple auth context. secret is the persisted random
+// key from SessionSecret; it is what the signing key's entropy comes from.
+func NewSimpleAuth(userDatabase UserDatabase, ttl time.Duration, secret []byte) *simpleAuthContext {
+	// The users are hashed on top of the secret rather than instead of it. On
+	// their own they are not secret at all: an OAuth-only account has no password
+	// hash, leaving a digest over a role name, an email and a GitHub login that
+	// anyone who can guess them can reproduce and sign tokens with.
+	//
 	// Hash the users in a stable order. Ranging over the map directly makes the
 	// digest depend on Go's randomized map iteration order, so any users.yml with
 	// more than one user derives a different signing key on every start and
@@ -35,6 +42,7 @@ func NewSimpleAuth(userDatabase UserDatabase, ttl time.Duration) *simpleAuthCont
 	// password is: repointing a user at a different GitHub login has to rotate
 	// sessions, or the sessions minted under the old link outlive it.
 	h := sha256.New()
+	h.Write(secret)
 	for _, username := range slices.Sorted(maps.Keys(userDatabase.Users)) {
 		user := userDatabase.Users[username]
 		h.Write([]byte(user.Password))

--- a/internal/auth/simple_test.go
+++ b/internal/auth/simple_test.go
@@ -10,6 +10,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testSecret stands in for the persisted secret from SessionSecret. It is fixed
+// so the "stable across restarts" tests below still compare two contexts built
+// from the same inputs.
+var testSecret = []byte("test-session-secret")
+
 // The JWT signing key is derived from the users in users.yml so that a token
 // stays valid across restarts and is only invalidated when a password or role
 // actually changes. Deriving it by ranging over the user map made the digest
@@ -25,12 +30,12 @@ func TestSimpleAuthSigningKeyIsStableAcrossRestarts(t *testing.T) {
 		},
 	}
 
-	_, token, err := NewSimpleAuth(users, 0).tokenAuth.Encode(map[string]any{"username": "alice"})
+	_, token, err := NewSimpleAuth(users, 0, testSecret).tokenAuth.Encode(map[string]any{"username": "alice"})
 	require.NoError(t, err)
 
 	// Each iteration stands in for a Dozzle restart against an unchanged users.yml.
 	for i := range 50 {
-		if _, err := NewSimpleAuth(users, 0).tokenAuth.Decode(token); err != nil {
+		if _, err := NewSimpleAuth(users, 0, testSecret).tokenAuth.Decode(token); err != nil {
 			t.Fatalf("token issued before restart %d was rejected: %v", i+1, err)
 		}
 	}
@@ -45,11 +50,11 @@ func TestSimpleAuthSigningKeyChangesWhenCredentialsChange(t *testing.T) {
 		},
 	}
 
-	_, token, err := NewSimpleAuth(users, 0).tokenAuth.Encode(map[string]any{"username": "alice"})
+	_, token, err := NewSimpleAuth(users, 0, testSecret).tokenAuth.Encode(map[string]any{"username": "alice"})
 	require.NoError(t, err)
 
 	users.Users["bob"].RolesConfigured = "shell,actions"
-	_, err = NewSimpleAuth(users, 0).tokenAuth.Decode(token)
+	_, err = NewSimpleAuth(users, 0, testSecret).tokenAuth.Decode(token)
 	require.Error(t, err)
 }
 
@@ -81,7 +86,7 @@ func TestSimpleAuthUsesCurrentRolesNotTheTokensRoles(t *testing.T) {
 		},
 	}
 
-	a := NewSimpleAuth(users, 0)
+	a := NewSimpleAuth(users, 0, testSecret)
 
 	// A session minted back when All did not include Cloud.
 	stale := All &^ Cloud
@@ -103,7 +108,7 @@ func TestSimpleAuthAppliesRevokedRolesToExistingSessions(t *testing.T) {
 		},
 	}
 
-	a := NewSimpleAuth(users, 0)
+	a := NewSimpleAuth(users, 0, testSecret)
 	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "alice", "roles": float64(All)})
 	require.NoError(t, err)
 
@@ -122,7 +127,7 @@ func TestSimpleAuthRejectsTokenForUnknownUser(t *testing.T) {
 		},
 	}
 
-	a := NewSimpleAuth(users, 0)
+	a := NewSimpleAuth(users, 0, testSecret)
 	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "mallory", "roles": float64(All)})
 	require.NoError(t, err)
 
@@ -139,7 +144,7 @@ func TestSimpleAuthResolvesTokenWithNoRolesClaim(t *testing.T) {
 		},
 	}
 
-	a := NewSimpleAuth(users, 0)
+	a := NewSimpleAuth(users, 0, testSecret)
 	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "alice"})
 	require.NoError(t, err)
 
@@ -156,7 +161,7 @@ func TestSimpleAuthWithoutTokenHasNoUser(t *testing.T) {
 		},
 	}
 
-	require.Nil(t, serveWithAuth(t, NewSimpleAuth(users, 0), ""))
+	require.Nil(t, serveWithAuth(t, NewSimpleAuth(users, 0, testSecret), ""))
 }
 
 // The container filter comes from users.yml as well, parsed into labels when the
@@ -174,7 +179,7 @@ users:
 	users, err := ReadUsersFromFile(path)
 	require.NoError(t, err)
 
-	a := NewSimpleAuth(users, 0)
+	a := NewSimpleAuth(users, 0, testSecret)
 	_, token, err := a.tokenAuth.Encode(map[string]any{"username": "alice", "filter": "name=stale"})
 	require.NoError(t, err)
 

--- a/internal/auth/users_test.go
+++ b/internal/auth/users_test.go
@@ -173,7 +173,7 @@ func TestSigningKeyCoversLinkedAccounts(t *testing.T) {
 	tokenFor := func(github, email string) string {
 		user := &User{Username: "amir", Email: email, Github: github, RolesConfigured: "all"}
 		db := UserDatabase{Users: map[string]*User{"amir": user}}
-		token, err := NewSimpleAuth(db, 0).issueToken(*user)
+		token, err := NewSimpleAuth(db, 0, testSecret).issueToken(*user)
 		require.NoError(t, err)
 		return token
 	}

--- a/internal/web/auth_simple_test.go
+++ b/internal/web/auth_simple_test.go
@@ -19,6 +19,10 @@ import (
 	"github.com/spf13/afero"
 )
 
+// testSecret stands in for the persisted secret from auth.SessionSecret, fixed so
+// the snapshotted responses stay stable.
+var testSecret = []byte("test-session-secret")
+
 func Test_createRoutes_simple_redirect(t *testing.T) {
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "index.html", []byte("index page"), 0644), "WriteFile should have no error.")
@@ -33,7 +37,7 @@ func Test_createRoutes_simple_redirect(t *testing.T) {
 						Password: "$2a$10$4Tvzu0ms9shlv4B8pIfqI.TM9CoqsamsAznP91A1NGuwg/68SGS1m",
 					},
 				},
-			}, time.Second*100),
+			}, time.Second*100, testSecret),
 		},
 	})
 	req, err := http.NewRequest("GET", "/", nil)
@@ -58,7 +62,7 @@ func Test_createRoutes_simple_valid_token(t *testing.T) {
 						Password: "$2a$10$4Tvzu0ms9shlv4B8pIfqI.TM9CoqsamsAznP91A1NGuwg/68SGS1m",
 					},
 				},
-			}, time.Second*100),
+			}, time.Second*100, testSecret),
 		},
 	})
 
@@ -103,7 +107,7 @@ func Test_createRoutes_simple_bad_password(t *testing.T) {
 						Password: "$2a$10$4Tvzu0ms9shlv4B8pIfqI.TM9CoqsamsAznP91A1NGuwg/68SGS1m",
 					},
 				},
-			}, time.Second*100),
+			}, time.Second*100, testSecret),
 		},
 	})
 
@@ -146,7 +150,7 @@ func Test_createRoutes_simple_cloud_callback_requires_auth(t *testing.T) {
 						Password: "$2a$10$4Tvzu0ms9shlv4B8pIfqI.TM9CoqsamsAznP91A1NGuwg/68SGS1m",
 					},
 				},
-			}, time.Second*100),
+			}, time.Second*100, testSecret),
 		},
 	})
 

--- a/main.go
+++ b/main.go
@@ -292,7 +292,10 @@ func createServer(args cli.Args, hostService web.HostService, cloudHooks web.Clo
 				log.Fatal().Err(err).Msg("Could not parse auth ttl")
 			}
 		}
-		simpleAuth := auth.NewSimpleAuth(db, ttl)
+		// Sits next to users.yml so it lands on the same volume operators already
+		// persist, and so a multi-replica setup sharing that volume signs with the
+		// same key.
+		simpleAuth := auth.NewSimpleAuth(db, ttl, auth.SessionSecret(filepath.Dir(userFilePath)))
 		authorizer = simpleAuth
 
 		if providers := oauthProviders(args); len(providers) > 0 {


### PR DESCRIPTION
The JWT signing key is a sha256 over `users.yml`: password hash, roles, and since #5043 the linked email and github login. That was fine while every user had a bcrypt hash, since the hash carries its own salt.

OAuth login made passwords optional. The OIDC docs show a user with only an email:

```yaml
users:
  admin:
    email: me@email.net
    name: Admin
    # password is optional once the account is linked
```

When no user has a password, every input to the digest is public. Roles default to `all`, the email and github login are right there in the file. Anyone who can guess them derives the key and signs a token for any user. `executeTemplate` also reports `passwordLogin: false` to unauthenticated callers, so an instance in that state is easy to spot from outside.

Confirmed against the current code, a token forged from a guessed key authenticates as `admin` with full roles.

## Fix

Read a random 32 byte secret from `data/session_secret`, created on first run at `0600`, and hash it before the per-user digest. Rotate-on-credential-change is unchanged.

- `O_EXCL` on create, so replicas sharing a volume adopt one secret instead of overwriting each other
- a short or truncated file is rejected rather than decoded into a near empty key
- an unwritable `/data` warns and uses an ephemeral secret. Mounting `users.yml` read only is a real setup, and refusing to boot would break upgrades for installs that are not at risk. Sessions just don't survive a restart there.

## Tests

`secret_test.go` covers persistence, uniqueness per install, file mode, truncation, and the read only fallback. `TestSigningKeyIsNotDerivableFromUsersFile` rebuilds the attacker's key from the public fields and asserts the forged token is rejected. It fails on master.

## Upgrade note

Everyone is logged out once. `data/session_secret` needs to persist alongside `users.yml`, which it already does for anyone mounting `/data` as a volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYpffXQMYL6bHQ5VU3mFs5
