### PR TITLE
feat(ui): redesign the homepage dashboard

### DIFF
--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -42,6 +42,7 @@ declare module 'vue' {
     CloudEventLogItem: typeof import('./components/LogViewer/CloudEventLogItem.vue')['default']
     CloudPopover: typeof import('./components/CloudPopover.vue')['default']
     CloudSettingsCard: typeof import('./components/CloudSettingsCard.vue')['default']
+    CollapsibleSection: typeof import('./components/common/CollapsibleSection.vue')['default']
     ComplexLogItem: typeof import('./components/LogViewer/ComplexLogItem.vue')['default']
     ContainerActionsToolbar: typeof import('./components/ContainerViewer/ContainerActionsToolbar.vue')['default']
     ContainerDropdown: typeof import('./components/ContainerDropdown.vue')['default']

--- a/assets/components/ContainerTable.vue
+++ b/assets/components/ContainerTable.vue
@@ -1,8 +1,11 @@
 <template>
-  <div class="flex flex-col gap-4">
-    <div class="flex flex-row">
-      <div v-if="Object.keys(hosts).length > 1" class="flex-1">
-        <div role="tablist" class="tabs-boxed tabs block" v-if="Object.keys(hosts).length < 4">
+  <div class="rounded-box border-base-content/10 bg-base-100 overflow-hidden border">
+    <div
+      class="border-base-content/10 flex flex-row items-center gap-3 border-b px-3 py-2"
+      v-if="Object.keys(hosts).length > 1 || isMobile"
+    >
+      <div v-if="Object.keys(hosts).length > 1" class="min-w-0 flex-1">
+        <div role="tablist" class="tabs-boxed tabs tabs-xs block" v-if="Object.keys(hosts).length < 4">
           <input
             type="radio"
             name="host"
@@ -26,7 +29,7 @@
         </div>
 
         <DropdownMenu
-          class="btn-sm"
+          class="btn-xs md:btn-sm"
           v-model="selectedHost"
           :options="[
             { label: 'Show All', value: null },
@@ -35,16 +38,7 @@
           v-else
         />
       </div>
-      <div class="flex flex-1 items-center justify-end gap-2">
-        <div v-show="ready && containers.length > pageSizes[0]">
-          {{ $t("label.per-page") }}
-
-          <DropdownMenu
-            class="dropdown-left btn-xs md:btn-sm"
-            v-model="perPage"
-            :options="pageSizes.map((i) => ({ label: i.toLocaleString(), value: i }))"
-          />
-        </div>
+      <div class="text-base-content/50 flex flex-1 items-center justify-end gap-2 text-xs">
         <div class="flex items-center gap-1 md:hidden">
           {{ $t("label.sort-by") }}
           <DropdownMenu class="dropdown-left btn-xs" v-model="mobileSortField" :options="sortOptions" />
@@ -56,26 +50,10 @@
             <mdi:arrow-up :class="direction > 0 ? '' : 'rotate-180'" />
           </button>
         </div>
-        <div class="join max-md:hidden">
-          <button
-            class="icon-btn btn join-item btn-xs md:btn-sm"
-            :class="statMode === 'chart' ? 'btn-active' : 'btn-ghost'"
-            @click="statMode = 'chart'"
-          >
-            <mdi:chart-bar />
-          </button>
-          <button
-            class="icon-btn btn join-item btn-xs md:btn-sm"
-            :class="statMode === 'progress' ? 'btn-active' : 'btn-ghost'"
-            @click="statMode = 'progress'"
-          >
-            <mdi:poll class="scale-x-[-1] rotate-90" />
-          </button>
-        </div>
       </div>
     </div>
-    <div class="rounded-box border-base-content/10 overflow-x-auto border">
-      <table class="table-md md:table-lg table-zebra table">
+    <div class="overflow-x-auto">
+      <table class="table-md table">
         <thead class="max-md:hidden">
           <tr :data-direction="direction > 0 ? 'asc' : 'desc'">
             <th
@@ -85,7 +63,7 @@
               :class="[value.customClass, { 'selected-sort': key === sortField }]"
               v-show="isVisible(key)"
             >
-              <a class="inline-flex cursor-pointer gap-2 text-sm uppercase">
+              <a class="inline-flex cursor-pointer gap-1.5 text-xs font-medium tracking-wide uppercase">
                 <span>{{ $t(isMobile && value.mobileLabel ? value.mobileLabel : value.label) }}</span>
                 <span class="h-4" data-icon>
                   <mdi:arrow-up />
@@ -94,7 +72,7 @@
             </th>
           </tr>
         </thead>
-        <tbody class="bg-base-300/30">
+        <tbody>
           <template v-if="!ready">
             <tr v-for="i in skeletonRows" :key="`skeleton-${i}`" role="status" class="animate-pulse">
               <td v-if="isVisible('name')" class="max-w-80 max-md:max-w-none">
@@ -134,7 +112,7 @@
               showAppIcons,
               dismissedLinkHint,
             ]"
-            class="hover:bg-base-100/80!"
+            class="hover:bg-base-200/60"
           >
             <td v-if="isVisible('name')" class="max-w-80 max-md:max-w-none">
               <div class="flex items-center gap-2 max-md:items-start">
@@ -147,7 +125,7 @@
                 <div class="min-w-0 flex-1">
                   <div class="flex items-baseline gap-2">
                     <router-link
-                      class="min-w-0 flex-1 truncate"
+                      class="min-w-0 flex-1 truncate font-medium"
                       :to="{ name: '/container/[id]', params: { id: container.id } }"
                       :title="container.name"
                     >
@@ -181,9 +159,14 @@
                 </div>
               </div>
             </td>
-            <td v-if="isVisible('host')">{{ container.hostLabel }}</td>
-            <td v-if="isVisible('state')">{{ container.health ?? container.state }}</td>
-            <td v-if="isVisible('created')">
+            <td v-if="isVisible('host')" class="text-base-content/70">{{ container.hostLabel }}</td>
+            <td v-if="isVisible('state')">
+              <span class="inline-flex items-center gap-1.5">
+                <span class="size-1.5 shrink-0 rounded-full" :class="statusDot(container)"></span>
+                {{ container.health ?? container.state }}
+              </span>
+            </td>
+            <td v-if="isVisible('created')" class="text-base-content/70">
               <RelativeTime :date="container.created" />
             </td>
             <td v-if="isVisible('cpu')">
@@ -196,10 +179,22 @@
         </tbody>
       </table>
     </div>
-    <div class="p-4 text-center">
-      <nav class="join" v-if="ready && isPaginated && totalPages <= 15">
+    <div
+      class="border-base-content/10 flex flex-row flex-wrap items-center gap-3 border-t px-3 py-2"
+      v-if="ready && (isPaginated || containers.length > pageSizes[0])"
+    >
+      <div class="text-base-content/50 flex items-center gap-1 text-xs" v-show="containers.length > pageSizes[0]">
+        {{ $t("label.per-page") }}
+
+        <DropdownMenu
+          class="btn-xs"
+          v-model="perPage"
+          :options="pageSizes.map((i) => ({ label: i.toLocaleString(), value: i }))"
+        />
+      </div>
+      <nav class="join ml-auto" v-if="isPaginated && totalPages <= 15">
         <input
-          class="btn btn-square join-item"
+          class="btn btn-square btn-sm join-item"
           type="radio"
           v-model="currentPage"
           :aria-label="`${i}`"
@@ -208,8 +203,8 @@
         />
       </nav>
       <DropdownMenu
-        v-else-if="ready && isPaginated"
-        class="btn-sm"
+        v-else-if="isPaginated"
+        class="dropdown-left btn-xs ml-auto"
         v-model="currentPage"
         :options="Array.from({ length: totalPages }, (_, i) => ({ label: `${i + 1}`, value: i + 1 }))"
       />
@@ -283,10 +278,11 @@ const { containers } = defineProps<{
   containers: Container[];
 }>();
 
+const statMode = defineModel<"chart" | "progress">("statMode", { default: "chart" });
+
 const { ready } = storeToRefs(useContainerStore());
 type keys = keyof typeof fields;
 
-const statMode = useStorage<"chart" | "progress">("DOZZLE_TABLE_STAT_MODE", "chart");
 const perPage = useStorage("DOZZLE_TABLE_PAGE_SIZE", 15);
 const pageSizes = [15, 30, 50, 100];
 
@@ -329,6 +325,13 @@ const mobileSortField = computed({
   },
 });
 
+function statusDot(container: Container) {
+  if (container.health === "unhealthy") return "bg-error";
+  if (container.health === "starting") return "bg-warning";
+  if (container.state === "running") return "bg-success";
+  return "bg-base-content/30";
+}
+
 function sort(field: keys) {
   if (sortField.value === field) {
     direction.value *= -1;
@@ -353,14 +356,24 @@ function isVisible(field: keys) {
   }
 }
 
+thead tr {
+  @apply bg-base-200/40;
+}
+
 th {
-  @apply border-base-200 border-b-2;
+  @apply text-base-content/50 border-base-content/10 border-b;
   &.selected-sort {
-    font-weight: bold;
-    @apply border-primary;
+    @apply text-base-content/80;
     [data-icon] {
       display: inline-block;
     }
+  }
+}
+
+tbody tr {
+  @apply transition-colors;
+  &:not(:last-child) {
+    @apply border-base-content/[0.06] border-b;
   }
 }
 

--- a/assets/components/HostCard.vue
+++ b/assets/components/HostCard.vue
@@ -1,63 +1,63 @@
 <template>
-  <div class="card bg-base-100">
-    <div class="card-body flex gap-3 max-md:p-4">
-      <div class="flex flex-row items-center gap-3 overflow-hidden">
-        <div class="flex min-w-0 items-center gap-2 text-lg font-semibold tracking-tight md:text-xl">
-          <HostIcon :type="host.type" class="text-base-content/80 flex-none" />
-          <div class="truncate">{{ host.name }}</div>
+  <div
+    class="border-base-content/10 bg-base-100 hover:border-base-content/20 rounded-box flex flex-col gap-4 border p-4 transition-colors lg:flex-row lg:items-center lg:gap-6 lg:px-5"
+  >
+    <div class="flex min-w-0 flex-col gap-1 lg:shrink-0">
+      <div class="flex min-w-0 items-center gap-2">
+        <span class="bg-base-content/5 text-base-content/70 flex-none rounded-md p-1.5">
+          <HostIcon :type="host.type" class="size-4" />
+        </span>
+        <div class="truncate text-lg font-semibold tracking-tight">{{ host.name }}</div>
 
-          <span class="badge badge-error badge-xs gap-1 p-2 font-normal" v-if="!host.available">
-            <carbon:warning />
-            offline
-          </span>
-          <span
-            class="badge badge-success badge-xs gap-1 p-2 font-normal"
-            :class="{ 'badge-warning': config.version != host.agentVersion }"
-            v-else-if="host.type == 'agent'"
-            title="Dozzle Agent"
-          >
-            {{ host.agentVersion }}
-          </span>
-        </div>
-
-        <ul
-          class="text-base-content/60 ml-auto flex shrink-0 flex-row flex-wrap items-center gap-x-3 text-xs tabular-nums md:text-sm"
+        <span class="badge badge-error badge-xs gap-1 p-2 font-normal" v-if="!host.available">
+          <carbon:warning />
+          offline
+        </span>
+        <span
+          class="badge badge-success badge-xs gap-1 p-2 font-normal"
+          :class="{ 'badge-warning': config.version != host.agentVersion }"
+          v-else-if="host.type == 'agent'"
+          title="Dozzle Agent"
         >
-          <li class="flex items-center gap-1.5">
-            <octicon:container-24 class="size-3.5" />
-            {{ $t("label.container", hostContainers.length) }}
-          </li>
-          <li class="flex items-center gap-1.5" :title="runtimeLabel">
-            <simple-icons:podman v-if="host.runtime === 'podman'" class="size-3.5" />
-            <mdi:docker v-else class="size-3.5" />
-            {{ host.dockerVersion }}
-          </li>
-        </ul>
+          {{ host.agentVersion }}
+        </span>
       </div>
 
-      <div class="grid grid-cols-2 gap-2 md:gap-3" v-if="stats">
-        <MetricCard
-          :icon="PhCpu"
-          :value="stats.weighted.movingAverage.totalCPU"
-          :chartData="cpuHistory"
-          container-class="bg-primary/10"
-          text-class="text-primary"
-          bar-class="bg-primary"
-          :formatValue="(value) => `${value.toFixed(1)}%`"
-          :label="`${host.nCPU} CPU`"
-        />
+      <ul class="text-base-content/50 flex flex-row flex-wrap items-center gap-x-3 gap-y-1 text-xs tabular-nums">
+        <li class="flex items-center gap-1.5">
+          <octicon:container-24 class="size-3.5" />
+          {{ $t("label.container", hostContainers.length) }}
+        </li>
+        <li class="flex items-center gap-1.5" :title="runtimeLabel">
+          <simple-icons:podman v-if="host.runtime === 'podman'" class="size-3.5" />
+          <mdi:docker v-else class="size-3.5" />
+          {{ host.dockerVersion }}
+        </li>
+      </ul>
+    </div>
 
-        <MetricCard
-          :icon="PhMemory"
-          :value="stats.weighted.movingAverage.totalMemUsage"
-          :chartData="memHistory"
-          container-class="bg-secondary/10"
-          text-class="text-secondary"
-          bar-class="bg-secondary"
-          :formatValue="(value) => formatBytes(value, { decimals: 1 })"
-          :label="formatBytes(host.memTotal, { decimals: 1 })"
-        />
-      </div>
+    <div class="grid grid-cols-2 gap-3 lg:flex-1" v-if="stats">
+      <MetricCard
+        :icon="PhCpu"
+        label="CPU"
+        :capacity="$t('label.core', host.nCPU ?? 0)"
+        :value="stats.weighted.movingAverage.totalCPU"
+        :chartData="cpuHistory"
+        text-class="text-primary"
+        bar-class="bg-primary"
+        :formatValue="(value) => `${value.toFixed(1)}%`"
+      />
+
+      <MetricCard
+        :icon="PhMemory"
+        label="Memory"
+        :capacity="formatBytes(host.memTotal, { decimals: 1 })"
+        :value="stats.weighted.movingAverage.totalMemUsage"
+        :chartData="memHistory"
+        text-class="text-secondary"
+        bar-class="bg-secondary"
+        :formatValue="(value) => formatBytes(value, { decimals: 1 })"
+      />
     </div>
   </div>
 </template>

--- a/assets/components/HostList.vue
+++ b/assets/components/HostList.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul class="grid gap-4 md:grid-cols-[repeat(auto-fill,minmax(480px,1fr))]">
+  <ul class="grid gap-3 md:grid-cols-[repeat(auto-fit,minmax(min(100%,30rem),1fr))]">
     <li v-for="host in hosts" :key="host.id">
       <HostCard :host="host" />
     </li>

--- a/assets/components/MetricCard.vue
+++ b/assets/components/MetricCard.vue
@@ -1,14 +1,19 @@
 <template>
-  <div class="rounded-lg p-2 md:p-3" :class="containerClass">
-    <div class="mb-2 flex items-center gap-1.5 text-sm font-medium" :class="textClass">
-      <component :is="icon" class="text-lg" />
-      <span>{{ label }}</span>
+  <div class="border-base-content/10 bg-base-200/40 rounded-lg border px-3 py-2.5">
+    <div class="flex items-center gap-2">
+      <div class="flex min-w-0 items-center gap-1.5 text-xs font-medium" :class="textClass">
+        <component :is="icon" class="size-3.5 shrink-0" />
+        <span class="truncate">{{ label }}</span>
+      </div>
+      <span class="text-base-content/40 ml-auto shrink-0 text-xs tabular-nums">{{ capacity }}</span>
     </div>
-    <div class="mb-1.5 text-lg font-semibold tabular-nums">{{ formattedValue }}</div>
-    <div class="text-base-content/60 mb-1 text-xs tabular-nums max-md:hidden">
-      avg {{ formatValue(average) }} • pk {{ formatValue(peak) }}
+
+    <div class="mt-0.5 text-xl leading-tight font-semibold tabular-nums">{{ formattedValue }}</div>
+    <div class="text-base-content/50 mt-0.5 truncate text-[0.6875rem] tabular-nums">
+      avg {{ formatValue(average) }} · pk {{ formatValue(peak) }}
     </div>
-    <BarChart class="h-8" :chart-data="chartData" :bar-class="barClass" />
+
+    <BarChart class="mt-2 h-7" :chart-data="chartData" :bar-class="barClass" />
   </div>
 </template>
 
@@ -18,19 +23,19 @@ import type { BarDataPoint } from "@/components/BarChart.vue";
 
 const {
   label,
+  capacity,
   icon,
   value,
   chartData,
-  containerClass = "",
   textClass = "",
   barClass = "",
   formatValue = (v: number) => v.toString(),
 } = defineProps<{
   label: string;
+  capacity: string;
   icon: Component;
   value: string | number;
   chartData: BarDataPoint[];
-  containerClass?: string;
   textClass?: string;
   barClass?: string;
   formatValue?: (value: number) => string;

--- a/assets/components/common/CollapsibleSection.vue
+++ b/assets/components/common/CollapsibleSection.vue
@@ -1,0 +1,60 @@
+<template>
+  <section>
+    <div class="mb-3 flex min-h-8 items-center gap-3">
+      <button
+        class="icon-btn text-base-content/60 hover:text-base-content -ml-1 flex items-center gap-2 rounded-md px-1 py-0.5 transition-colors"
+        :aria-expanded="!collapsed"
+        @click="collapsed = !collapsed"
+      >
+        <mdi:chevron-down class="size-4 transition-transform" :class="{ '-rotate-90': collapsed }" />
+        <h2 class="text-xs font-semibold tracking-[0.08em] uppercase">{{ title }}</h2>
+        <span
+          v-if="count !== undefined"
+          class="bg-base-content/10 text-base-content/70 rounded-full px-1.5 py-px text-[0.6875rem] font-semibold tabular-nums"
+        >
+          {{ count.toLocaleString() }}
+        </span>
+      </button>
+      <div class="ml-auto flex items-center gap-2">
+        <slot name="actions"></slot>
+      </div>
+    </div>
+    <Transition name="collapse">
+      <div v-show="!collapsed">
+        <slot></slot>
+      </div>
+    </Transition>
+  </section>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title: string;
+  count?: number;
+}>();
+
+const collapsed = defineModel<boolean>({ default: false });
+</script>
+
+<style scoped>
+.collapse-enter-active,
+.collapse-leave-active {
+  transition:
+    opacity 200ms cubic-bezier(0.22, 1, 0.36, 1),
+    max-height 240ms cubic-bezier(0.22, 1, 0.36, 1);
+  overflow: hidden;
+}
+
+.collapse-enter-from,
+.collapse-leave-to {
+  opacity: 0;
+  max-height: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .collapse-enter-active,
+  .collapse-leave-active {
+    transition: none;
+  }
+}
+</style>

--- a/assets/pages/index.vue
+++ b/assets/pages/index.vue
@@ -1,30 +1,36 @@
 <template>
   <PageWithLinks>
-    <section>
-      <div class="mb-4 flex items-center justify-between">
-        <h2 class="text-lg font-semibold">{{ $t("label.host-count", { count: Object.keys(hosts).length }) }}</h2>
-        <button @click="hostsCollapsed = !hostsCollapsed" class="icon-btn btn btn-ghost btn-sm">
-          <mdi:chevron-down :class="{ 'rotate-180': !hostsCollapsed }" class="transition-transform" />
-        </button>
-      </div>
-      <Transition name="collapse">
-        <HostList v-show="!hostsCollapsed" />
-      </Transition>
-    </section>
+    <CollapsibleSection v-model="hostsCollapsed" :title="$t('label.hosts')" :count="Object.keys(hosts).length">
+      <HostList />
+    </CollapsibleSection>
 
-    <section>
-      <div class="mb-4 flex items-center justify-between">
-        <h2 class="text-lg font-semibold">
-          {{ $t("label.container", { count: dashboardContainers.length }) }}
-        </h2>
-        <button @click="containersCollapsed = !containersCollapsed" class="icon-btn btn btn-ghost btn-sm">
-          <mdi:chevron-down :class="{ 'rotate-180': !containersCollapsed }" class="transition-transform" />
-        </button>
-      </div>
-      <Transition name="collapse">
-        <ContainerTable v-show="!containersCollapsed" :containers="dashboardContainers" />
-      </Transition>
-    </section>
+    <CollapsibleSection
+      v-model="containersCollapsed"
+      :title="$t('label.containers')"
+      :count="dashboardContainers.length"
+    >
+      <template #actions>
+        <div class="join max-md:hidden">
+          <button
+            class="icon-btn btn join-item btn-xs"
+            :class="statMode === 'chart' ? 'btn-active' : 'btn-ghost'"
+            :aria-pressed="statMode === 'chart'"
+            @click="statMode = 'chart'"
+          >
+            <mdi:chart-bar />
+          </button>
+          <button
+            class="icon-btn btn join-item btn-xs"
+            :class="statMode === 'progress' ? 'btn-active' : 'btn-ghost'"
+            :aria-pressed="statMode === 'progress'"
+            @click="statMode = 'progress'"
+          >
+            <mdi:poll class="scale-x-[-1] rotate-90" />
+          </button>
+        </div>
+      </template>
+      <ContainerTable :containers="dashboardContainers" v-model:stat-mode="statMode" />
+    </CollapsibleSection>
   </PageWithLinks>
 </template>
 
@@ -44,6 +50,7 @@ const dashboardContainers = computed(() =>
   containers.value.filter((c) => (showAllContainers.value ? c.state !== "deleted" : c.state === "running")),
 );
 
+const statMode = useStorage<"chart" | "progress">("DOZZLE_TABLE_STAT_MODE", "chart");
 const hostsCollapsed = useStorage("DOZZLE_HOSTS_COLLAPSED", false);
 const containersCollapsed = useStorage("DOZZLE_CONTAINERS_COLLAPSED", false);
 
@@ -53,30 +60,3 @@ watchEffect(() => {
   }
 });
 </script>
-<style scoped>
-:deep(tr td) {
-  padding-top: 1em;
-  padding-bottom: 1em;
-}
-
-.collapse-enter-active,
-.collapse-leave-active {
-  transition:
-    opacity 200ms cubic-bezier(0.22, 1, 0.36, 1),
-    max-height 240ms cubic-bezier(0.22, 1, 0.36, 1);
-  overflow: hidden;
-}
-
-.collapse-enter-from,
-.collapse-leave-to {
-  opacity: 0;
-  max-height: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .collapse-enter-active,
-  .collapse-leave-active {
-    transition: none;
-  }
-}
-</style>

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -66,10 +66,11 @@ label:
   container-name: Container Navn
   status: Status
   created: Lavet
-  avg-cpu: Gns. CPU (%)
-  avg-mem: Gns. MEM (%)
+  avg-cpu: Gns. CPU
+  avg-mem: Gns. hukommelse
   name: Navn
   cpu: CPU
+  core: Ingen kerner | 1 kerne | {count} kerner
   mem: MEM
   pinned: Fastgjort
   per-page: Rækker per side

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -66,10 +66,11 @@ label:
   container-name: Container Name
   status: Status
   created: Erstellt
-  avg-cpu: Avg. CPU (%)
-  avg-mem: Avg. MEM (%)
+  avg-cpu: Ø CPU
+  avg-mem: Ø Speicher
   name: Name
   cpu: CPU
+  core: Keine Kerne | 1 Kern | {count} Kerne
   mem: MEM
   pinned: Angepinnt
   per-page: Zeilen pro Seite

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -66,10 +66,11 @@ label:
   container-name: Container Name
   status: Status
   created: Created
-  avg-cpu: Avg. CPU (%)
-  avg-mem: Avg. MEM (%)
+  avg-cpu: Avg. CPU
+  avg-mem: Avg. Memory
   name: Name
   cpu: CPU
+  core: No cores | 1 core | {count} cores
   mem: MEM
   pinned: Pinned
   per-page: Rows per page

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -66,10 +66,11 @@ label:
   container-name: Nombre del contenedor
   status: Estado
   created: Creado
-  avg-cpu: Promedio de CPU (%)
-  avg-mem: Promedio de MEM (%)
+  avg-cpu: Promedio de CPU
+  avg-mem: Promedio de memoria
   name: Nombre
   cpu: CPU
+  core: Sin núcleos | 1 núcleo | {count} núcleos
   mem: MEM
   pinned: Fijado
   per-page: Filas por página

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -66,10 +66,11 @@ label:
   container-name: Nom du conteneur
   status: Status
   created: Créé
-  avg-cpu: Moyenne CPU (%)
-  avg-mem: Moyenne MEM (%)
+  avg-cpu: Moyenne CPU
+  avg-mem: Moyenne mémoire
   name: Nom
   cpu: CPU
+  core: Aucun cœur | 1 cœur | {count} cœurs
   mem: MEM
   pinned: Epinglé
   per-page: Colonnes par page

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -67,10 +67,11 @@ label:
   container-name: Nama Kontainer
   status: Status
   created: Dibuat
-  avg-cpu: Rata-rata CPU (%)
-  avg-mem: Rata-rata MEM (%)
+  avg-cpu: Rata-rata CPU
+  avg-mem: Rata-rata memori
   name: Nama
   cpu: CPU
+  core: Tidak ada inti | 1 inti | {count} inti
   mem: MEM
   pinned: Disematkan
   per-page: Baris per halaman

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -66,10 +66,11 @@ label:
   container-name: Nome Container
   status: Stato
   created: Creato
-  avg-cpu: CPU (%)
-  avg-mem: MEM (%)
+  avg-cpu: CPU
+  avg-mem: Memoria
   name: Nome
   cpu: CPU
+  core: Nessun core | 1 core | {count} core
   mem: MEM
   pinned: Fissato
   per-page: Righe per pagina

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -66,10 +66,11 @@ label:
   container-name: 컨테이너 이름
   status: 상태
   created: 만든 날짜
-  avg-cpu: 평균 CPU (%)
-  avg-mem: 평균 메모리 (%)
+  avg-cpu: 평균 CPU
+  avg-mem: 평균 메모리
   name: 이름
   cpu: CPU
+  core: 코어 없음 | 코어 1개 | 코어 {count}개
   mem: 메모리
   pinned: 고정됨
   per-page: 페이지당 행 수

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -66,10 +66,11 @@ label:
   container-name: Containernaam
   status: Status
   created: Aangemaakt
-  avg-cpu: Gem. CPU (%)
-  avg-mem: Gem. geheugen (%)
+  avg-cpu: Gem. CPU
+  avg-mem: Gem. geheugen
   name: Naam
   cpu: CPU
+  core: Geen kernen | 1 kern | {count} kernen
   mem: MEM
   pinned: Vastgezet
   per-page: Rijen per pagina

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -66,10 +66,11 @@ label:
   container-name: Nazwa kontenera
   status: Status
   created: Utworzony
-  avg-cpu: Średnie zużycie CPU (%)
-  avg-mem: Średnie zużycie pamięci (%)
+  avg-cpu: Średnie zużycie CPU
+  avg-mem: Średnie zużycie pamięci
   name: Nazwa
   cpu: CPU
+  core: Brak rdzeni | 1 rdzeń | {count} rdzeni
   mem: MEM
   pinned: Przypięte
   per-page: Wierszy na strone

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -66,10 +66,11 @@ label:
   container-name: Nome do Container
   status: Status
   created: Criado
-  avg-cpu: Média CPU (%)
-  avg-mem: Média MEM (%)
+  avg-cpu: Média CPU
+  avg-mem: Média memória
   name: Nome
   cpu: CPU
+  core: Sem núcleos | 1 núcleo | {count} núcleos
   mem: MEM
   pinned: Fixado
   per-page: Linhas por página

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -66,10 +66,11 @@ label:
   container-name: Имя контейнера
   status: Статус
   created: Создан
-  avg-cpu: средний процессор (%)
-  avg-mem: средняя память (%)
+  avg-cpu: Средний ЦП
+  avg-mem: Средняя память
   name: Имя
   cpu: CPU
+  core: Нет ядер | 1 ядро | {count} ядер
   mem: MEM
   pinned: Закреплено
   per-page: Строк на странице

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -53,7 +53,7 @@ label:
   or: ali
   status: Stanje
   created: Ustvarjeno
-  avg-cpu: CPE povprečje (%)
+  avg-cpu: CPE povprečje
   pinned: Pripeto
   per-page: Vrstic na stran
   sort-by: Razvrsti po
@@ -79,9 +79,10 @@ label:
   event-metric: Metrika
   event-container: Zabojnik
   services: Storitve
-  avg-mem: Povprečje spomina (%)
+  avg-mem: Povprečje spomina
   name: Ime
   cpu: CPU
+  core: Ni jeder | 1 jedro | {count} jeder
   mem: MEM
   no-logs: Zabojnik še nima dnevnika
   search-status:

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -66,10 +66,11 @@ label:
   container-name: Konteyner Adı
   status: Durum
   created: Oluşturulma
-  avg-cpu: Ort. CPU (%)
-  avg-mem: Ort. Bellek (%)
+  avg-cpu: Ort. CPU
+  avg-mem: Ort. Bellek
   name: Ad
   cpu: CPU
+  core: Çekirdek yok | 1 çekirdek | {count} çekirdek
   mem: MEM
   pinned: Sabitlenmiş
   per-page: Sayfa başına satır

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -77,10 +77,11 @@ label:
   container-name: 容器名稱
   status: 狀態
   created: 建立時間
-  avg-cpu: 平均 CPU 使用率 (%)
-  avg-mem: 平均記憶體使用率 (%)
+  avg-cpu: 平均 CPU
+  avg-mem: 平均記憶體
   name: 名稱
   cpu: CPU
+  core: 無核心 | 1 個核心 | {count} 個核心
   mem: MEM
   pinned: 已釘選
   per-page: 每頁列數

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -77,10 +77,11 @@ label:
   container-name: 容器名称
   status: 状态
   created: 创建时间
-  avg-cpu: 平均CPU (%)
-  avg-mem: 平均MEM (%)
+  avg-cpu: 平均 CPU
+  avg-mem: 平均内存
   name: 名称
   cpu: CPU
+  core: 无核心 | 1 个核心 | {count} 个核心
   mem: MEM
   pinned: 固定
   per-page: 每页行数


### PR DESCRIPTION
Redesign of the homepage dashboard. Denser and quieter, less card-in-card nesting.

**Hosts**
- Host card is now one horizontal row: name/meta block on the left, CPU and memory metrics inline on the right. Stacks on small screens.
- Icon gets a small tinted tile instead of sitting bare next to the title.
- `MetricCard` drops `containerClass` and takes a `capacity` prop, so the label reads `CPU` / `8 cores` instead of the count being jammed into the label.
- Grid uses `auto-fit` with `min(100%, 30rem)` so a single host does not stretch to a full-width card on wide screens.

**Containers**
- Table is wrapped in a bordered shell with its own header bar (host tabs, mobile sort) and footer bar (rows per page, pagination). Rows per page moved out of the top bar.
- Zebra striping replaced with row borders and a hover tint.
- State column gets a status dot (green running, red unhealthy, amber starting).
- Chart/progress toggle moved up to the section header, so `statMode` is now a `v-model` on `ContainerTable` owned by `index.vue`.

**Shared**
- New `CollapsibleSection` component holds the section header, count badge, chevron and collapse transition, used by both sections. `index.vue` loses its local copy of all of that.

New key `label.core` added to every locale. `label.avg-cpu` / `label.avg-mem` reworded to drop the `(%)` since the memory column is not a percentage.

Typecheck and `pnpm test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bP3uUxfct979KZuTQH2EQ
