### PR TITLE
feat(toolbar): group the container menu into labeled sections

### DIFF
--- a/assets/components/ContainerViewer/ContainerActionsToolbar.vue
+++ b/assets/components/ContainerViewer/ContainerActionsToolbar.vue
@@ -14,9 +14,10 @@
     </label>
     <ul
       tabindex="0"
-      class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 shadow-sm"
+      class="menu dropdown-content rounded-box bg-base-200 border-base-content/10 z-50 w-max min-w-60 border p-1.5 shadow-lg"
       @click="hideMenu"
     >
+      <li class="section" v-if="!historical || hasComplexLogs">{{ $t("toolbar.section-logs") }}</li>
       <li v-if="!historical">
         <a @click="showSearch = true">
           <mdi:magnify /> {{ $t("toolbar.search") }}
@@ -35,15 +36,16 @@
           <KeyShortcut char="f" :modifiers="['shift', 'meta']" />
         </a>
       </li>
-      <li class="line"></li>
+      <li class="section">{{ $t("toolbar.section-filters") }}</li>
       <li>
         <details>
           <summary>
-            <div class="flex w-4">
-              <carbon:circle-solid class="text-red w-2.5" v-if="streamConfig.stderr" />
-              <carbon:circle-solid class="text-blue w-2.5" v-if="streamConfig.stdout" />
+            <div class="flex w-4 items-center gap-0.5">
+              <carbon:circle-solid class="size-2" :class="streamConfig.stderr ? 'text-red' : 'opacity-20'" />
+              <carbon:circle-solid class="size-2" :class="streamConfig.stdout ? 'text-blue' : 'opacity-20'" />
             </div>
-            Streams
+            {{ $t("toolbar.streams") }}
+            <span class="value">{{ streamSummary }}</span>
           </summary>
           <ul class="menu">
             <li>
@@ -89,11 +91,12 @@
         <details class="group/details">
           <summary>
             <mdi:gauge />
-            Levels
+            {{ $t("toolbar.levels") }}
+            <span class="value group-open/details:hidden">{{ levelSummary }}</span>
             <Toggle
-              class="toggle-xs invisible group-open/details:visible"
+              class="toggle-xs hidden group-open/details:inline-flex"
               v-model="toggleAllLevels"
-              title="Toggle all levels"
+              :title="$t('toolbar.toggle-all-levels')"
             />
           </summary>
           <ul class="menu">
@@ -111,7 +114,7 @@
         </details>
       </li>
 
-      <li class="line"></li>
+      <li class="section">{{ $t("toolbar.section-export") }}</li>
       <li v-if="enableDownload">
         <a :href="downloadUrl" download>
           <octicon:download-24 />
@@ -132,8 +135,8 @@
       </li>
 
       <!-- Container Actions (Enabled via config) -->
+      <li class="section" v-if="showContainerSection">{{ $t("toolbar.section-container") }}</li>
       <template v-if="enableActions && !historical">
-        <li class="line"></li>
         <li>
           <button
             @click="stop()"
@@ -171,54 +174,7 @@
         </li>
       </template>
 
-      <!-- Manual mode never checks on its own, so the only way to reach a
-           registry is this. Automatic mode reports the last result instead. -->
-      <template v-if="imageCheckState === 'check'">
-        <li class="line"></li>
-        <li>
-          <a @click.stop="checkImageUpdate(true)">
-            <carbon:upgrade :class="{ 'animate-spin': checkingImageUpdate }" />
-            {{ checkingImageUpdate ? $t("toolbar.checking-for-updates") : $t("toolbar.check-for-updates") }}
-          </a>
-        </li>
-      </template>
-
-      <template v-if="imageCheckState === 'checking'">
-        <li class="line"></li>
-        <li class="menu-title flex-row items-center gap-1.5 py-1 text-xs">
-          <carbon:upgrade class="animate-spin" /> {{ $t("toolbar.checking-for-updates") }}
-        </li>
-      </template>
-
-      <template v-if="imageCheckState === 'none'">
-        <li class="line"></li>
-        <li class="menu-title flex-row items-center gap-1.5 py-1 text-xs">
-          <carbon:checkmark /> {{ $t("toolbar.no-updates") }}
-        </li>
-      </template>
-
-      <!-- Shown regardless of actions: an update is worth knowing about even
-           when Dozzle cannot apply it. -->
-      <template v-if="imageCheckState === 'available'">
-        <li class="line"></li>
-        <li class="menu-title text-warning flex-row items-center gap-1.5 py-1 text-xs">
-          <carbon:upgrade /> {{ $t("toolbar.update-available") }}
-        </li>
-        <li v-if="isSelfContainer">
-          <a :href="releaseNotesUrl" target="_blank" rel="noreferrer noopener">
-            <mdi:script-text-outline /> {{ $t("toolbar.view-release-notes") }}
-          </a>
-        </li>
-        <li>
-          <a @click="copyImageReference()"> <mdi:content-copy /> {{ $t("toolbar.copy-image") }} </a>
-        </li>
-        <li>
-          <a @click="dismissImageUpdate()"> <mdi:bell-off-outline /> {{ $t("toolbar.dismiss-update") }} </a>
-        </li>
-      </template>
-
       <template v-if="enableShell && !historical">
-        <li class="line"></li>
         <li>
           <a @click="showDrawer(Terminal, { container, action: 'attach' }, 'lg')">
             <ri:terminal-window-fill />
@@ -232,6 +188,53 @@
             {{ $t("toolbar.shell") }}
             <KeyShortcut char="e" :modifiers="['shift', 'meta']" />
           </a>
+        </li>
+      </template>
+
+      <!-- Manual mode never checks on its own, so the only way to reach a
+           registry is this. Automatic mode reports the last result instead. -->
+      <template v-if="imageCheckState === 'check'">
+        <li class="section">{{ $t("toolbar.section-image") }}</li>
+        <li>
+          <a @click.stop="checkImageUpdate(true)">
+            <carbon:upgrade :class="{ 'animate-spin': checkingImageUpdate }" />
+            {{ checkingImageUpdate ? $t("toolbar.checking-for-updates") : $t("toolbar.check-for-updates") }}
+          </a>
+        </li>
+      </template>
+
+      <template v-if="imageCheckState === 'checking'">
+        <li class="section flex-row items-center gap-1.5">
+          <carbon:upgrade class="size-3 animate-spin" /> {{ $t("toolbar.checking-for-updates") }}
+        </li>
+      </template>
+
+      <template v-if="imageCheckState === 'none'">
+        <li class="section flex-row items-center gap-1.5">
+          <carbon:checkmark class="size-3" /> {{ $t("toolbar.no-updates") }}
+        </li>
+      </template>
+
+      <!-- Shown regardless of actions: an update is worth knowing about even
+           when Dozzle cannot apply it. -->
+      <template v-if="imageCheckState === 'available'">
+        <li class="section warn flex-row items-center gap-1.5">
+          <span class="relative flex size-1.5">
+            <span class="bg-warning absolute size-full rounded-full opacity-75 motion-safe:animate-ping"></span>
+            <span class="bg-warning relative size-full rounded-full"></span>
+          </span>
+          {{ $t("toolbar.update-available") }}
+        </li>
+        <li v-if="isSelfContainer">
+          <a :href="releaseNotesUrl" target="_blank" rel="noreferrer noopener">
+            <mdi:script-text-outline /> {{ $t("toolbar.view-release-notes") }}
+          </a>
+        </li>
+        <li>
+          <a @click="copyImageReference()"> <mdi:content-copy /> {{ $t("toolbar.copy-image") }} </a>
+        </li>
+        <li>
+          <a @click="dismissImageUpdate()"> <mdi:bell-off-outline /> {{ $t("toolbar.dismiss-update") }} </a>
         </li>
       </template>
     </ul>
@@ -429,6 +432,23 @@ const { downloadUrl, isFiltered } = useDownloadUrl(
 
 const disableRestart = computed(() => actionStates.stop || actionStates.start || actionStates.restart);
 
+// The section header is shared by container actions and the shell entries, so it
+// only shows when at least one of them is actually rendered.
+const showContainerSection = computed(() => (enableActions || enableShell) && !historical);
+
+// Collapsed submenus say what they are currently set to, so the menu answers
+// "what am I looking at?" without being opened.
+const streamSummary = computed(() => {
+  if (streamConfig.value.stdout && streamConfig.value.stderr) return t("toolbar.all");
+  if (streamConfig.value.stdout) return "STDOUT";
+  if (streamConfig.value.stderr) return "STDERR";
+  return t("toolbar.none");
+});
+
+const levelSummary = computed(() =>
+  levels.value.size === allLevels.length ? t("toolbar.all") : `${levels.value.size}/${allLevels.length}`,
+);
+
 const toggleAllLevels = computed({
   get: () => levels.value.size === allLevels.length,
   set: (value) => {
@@ -454,12 +474,42 @@ const hideMenu = (e: MouseEvent) => {
 <style scoped>
 @reference "@/main.css";
 
-li.line {
-  @apply bg-base-content/20 h-px;
+/* Section headers replace the old hairline dividers: they separate and label at
+ * the same time. The first one has nothing above it to divide from. */
+li.section {
+  @apply text-base-content/40 border-base-content/10 mt-1.5 border-t px-2 pt-2 pb-1 text-[10px] font-semibold tracking-wider uppercase;
 }
 
-a {
+/* Same specificity as li.section, declared after it, so the accent wins. */
+li.section.warn {
+  @apply text-warning/90;
+}
+
+/* daisyUI pads every direct child of a menu li as if it were a clickable row,
+ * which squeezes the status dot and spinner in these headers down to nothing. */
+li.section > * {
+  @apply p-0;
+}
+
+li.section:first-child {
+  @apply mt-0 border-t-0 pt-1;
+}
+
+a,
+button,
+summary {
   @apply whitespace-nowrap;
+}
+
+/* One icon size for every row, so labels line up on a single text column. */
+.menu > li > :where(a, button, summary) > svg {
+  @apply size-4 shrink-0 opacity-70;
+}
+
+/* The collapsed-state value sits in the trailing grid column daisyUI reserves,
+ * next to (not on top of) the disclosure chevron. */
+.value {
+  @apply text-base-content/40 text-xs tabular-nums;
 }
 
 /* daisyUI's .menu is width: fit-content, so nested submenus (Streams, Levels)

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Kopiér logs
   copy-filtered-logs: Kopiér filtrerede logs
   copying-logs: Kopierer logs...
+  streams: Streams
+  levels: Niveauer
+  toggle-all-levels: Slå alle niveauer til/fra
+  all: Alle
+  none: Ingen
+  section-logs: Logs
+  section-filters: Filtre
+  section-export: Eksport
+  section-container: Container
+  section-image: Image
 action:
   copy-log: Kopier log
   copy-link: Kopier permalink

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Logs kopieren
   copy-filtered-logs: Gefilterte Logs kopieren
   copying-logs: Logs werden kopiert...
+  streams: Streams
+  levels: Level
+  toggle-all-levels: Alle Level umschalten
+  all: Alle
+  none: Keine
+  section-logs: Logs
+  section-filters: Filter
+  section-export: Export
+  section-container: Container
+  section-image: Image
 action:
   copy-log: Log kopieren
   copy-link: Permalink kopieren

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Copy logs
   copy-filtered-logs: Copy Filtered Logs
   copying-logs: Copying logs...
+  streams: Streams
+  levels: Levels
+  toggle-all-levels: Toggle all levels
+  all: All
+  none: None
+  section-logs: Logs
+  section-filters: Filters
+  section-export: Export
+  section-container: Container
+  section-image: Image
 action:
   copy-log: Copy log
   copy-link: Copy permalink

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Copiar registros
   copy-filtered-logs: Copiar registros filtrados
   copying-logs: Copiando registros...
+  streams: Flujos
+  levels: Niveles
+  toggle-all-levels: Alternar todos los niveles
+  all: Todos
+  none: Ninguno
+  section-logs: Registros
+  section-filters: Filtros
+  section-export: Exportar
+  section-container: Contenedor
+  section-image: Imagen
 action:
   copy-log: Copiar registro
   copy-link: Copiar enlace permanente

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Copier les journaux
   copy-filtered-logs: Copier les journaux filtrés
   copying-logs: Copie des journaux...
+  streams: Flux
+  levels: Niveaux
+  toggle-all-levels: Basculer tous les niveaux
+  all: Tous
+  none: Aucun
+  section-logs: Journaux
+  section-filters: Filtres
+  section-export: Exporter
+  section-container: Conteneur
+  section-image: Image
 action:
   copy-log: Copier le journal
   copy-link: Copier le permalien

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Salin log
   copy-filtered-logs: Salin log terfilter
   copying-logs: Menyalin log...
+  streams: Stream
+  levels: Level
+  toggle-all-levels: Alihkan semua level
+  all: Semua
+  none: Tidak ada
+  section-logs: Log
+  section-filters: Filter
+  section-export: Ekspor
+  section-container: Kontainer
+  section-image: Image
 action:
   copy-log: Salin log
   copy-link: Salin permalink

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Copia log
   copy-filtered-logs: Copia log filtrati
   copying-logs: Copia dei log...
+  streams: Stream
+  levels: Livelli
+  toggle-all-levels: Attiva/disattiva tutti i livelli
+  all: Tutti
+  none: Nessuno
+  section-logs: Log
+  section-filters: Filtri
+  section-export: Esporta
+  section-container: Container
+  section-image: Immagine
 action:
   copy-log: Copia log
   copy-link: Copia permalink

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: 로그 복사
   copy-filtered-logs: 필터된 로그 복사
   copying-logs: 로그 복사 중...
+  streams: 스트림
+  levels: 레벨
+  toggle-all-levels: 모든 레벨 전환
+  all: 전체
+  none: 없음
+  section-logs: 로그
+  section-filters: 필터
+  section-export: 내보내기
+  section-container: 컨테이너
+  section-image: 이미지
 action:
   copy-log: 로그 복사
   copy-link: 영구 링크 복사

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Logs kopiëren
   copy-filtered-logs: Gefilterde logs kopiëren
   copying-logs: Logs kopiëren...
+  streams: Streams
+  levels: Niveaus
+  toggle-all-levels: Alle niveaus omschakelen
+  all: Alle
+  none: Geen
+  section-logs: Logs
+  section-filters: Filters
+  section-export: Exporteren
+  section-container: Container
+  section-image: Image
 action:
   copy-log: Log kopiëren
   copy-link: Permalink kopiëren

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Kopiuj logi
   copy-filtered-logs: Kopiuj filtrowane logi
   copying-logs: Kopiowanie logów...
+  streams: Strumienie
+  levels: Poziomy
+  toggle-all-levels: Przełącz wszystkie poziomy
+  all: Wszystkie
+  none: Brak
+  section-logs: Logi
+  section-filters: Filtry
+  section-export: Eksport
+  section-container: Kontener
+  section-image: Obraz
 action:
   copy-log: Skopiuj log
   copy-link: Skopiuj permalink

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Copiar logs
   copy-filtered-logs: Copiar logs filtrados
   copying-logs: Copiando logs...
+  streams: Streams
+  levels: Níveis
+  toggle-all-levels: Alternar todos os níveis
+  all: Todos
+  none: Nenhum
+  section-logs: Logs
+  section-filters: Filtros
+  section-export: Exportar
+  section-container: Contêiner
+  section-image: Imagem
 action:
   copy-log: Copiar log
   copy-link: Copiar permalink

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Скопировать логи
   copy-filtered-logs: Скопировать отфильтрованные логи
   copying-logs: Копирование логов...
+  streams: Потоки
+  levels: Уровни
+  toggle-all-levels: Переключить все уровни
+  all: Все
+  none: Нет
+  section-logs: Логи
+  section-filters: Фильтры
+  section-export: Экспорт
+  section-container: Контейнер
+  section-image: Образ
 action:
   copy-log: Копировать лог
   copy-link: Копировать постоянную ссылку

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -17,6 +17,16 @@ toolbar:
   copy-logs: Kopiraj dnevnike
   copy-filtered-logs: Kopiraj filtrirane dnevnike
   copying-logs: Kopiranje dnevnikov...
+  streams: Tokovi
+  levels: Ravni
+  toggle-all-levels: Preklopi vse ravni
+  all: Vse
+  none: Brez
+  section-logs: Dnevniki
+  section-filters: Filtri
+  section-export: Izvoz
+  section-container: Vsebnik
+  section-image: Slika
   restart: Ponovni zagon
   update: Posodobi
   update-service: Posodobi Storitev

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: Günlükleri kopyala
   copy-filtered-logs: Filtrelenmiş günlükleri kopyala
   copying-logs: Günlükler kopyalanıyor...
+  streams: Akışlar
+  levels: Seviyeler
+  toggle-all-levels: Tüm seviyeleri değiştir
+  all: Tümü
+  none: Hiçbiri
+  section-logs: Günlükler
+  section-filters: Filtreler
+  section-export: Dışa aktar
+  section-container: Konteyner
+  section-image: İmaj
 action:
   copy-log: Günlüğü kopyala
   copy-link: Kalıcı bağlantıyı kopyala

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: 複製日誌
   copy-filtered-logs: 複製篩選日誌
   copying-logs: 正在複製日誌...
+  streams: 輸出串流
+  levels: 級別
+  toggle-all-levels: 切換所有級別
+  all: 全部
+  none: 無
+  section-logs: 日誌
+  section-filters: 篩選
+  section-export: 匯出
+  section-container: 容器
+  section-image: 映像
 action:
   copy-log: 複製日誌
   copy-link: 複製永久連結

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -31,6 +31,16 @@ toolbar:
   copy-logs: 复制日志
   copy-filtered-logs: 复制筛选日志
   copying-logs: 正在复制日志...
+  streams: 输出流
+  levels: 级别
+  toggle-all-levels: 切换所有级别
+  all: 全部
+  none: 无
+  section-logs: 日志
+  section-filters: 筛选
+  section-export: 导出
+  section-container: 容器
+  section-image: 镜像
 action:
   copy-log: 复制日志
   copy-link: 复制永久链接


### PR DESCRIPTION
The container toolbar menu had grown to five anonymous groups separated by hairlines, so scanning it meant reading every row.

- Sections are labeled: Logs, Filters, Export, Container, Image, plus an accent `UPDATE AVAILABLE` header carrying the same pulsing dot as the trigger badge.
- Attach and Shell moved up next to Stop/Restart/Update instead of sitting alone at the bottom.
- Collapsed Streams and Levels rows show what they are set to (All, STDOUT, 4/7), so the menu says what the view is filtered to without being opened.
- Stream dots stay visible and dim when a stream is off, rather than disappearing and shifting the row.
- Icons are one size at a single opacity so labels line up. The fixed `w-52` that content kept overflowing became `w-max min-w-60`.
- Streams, Levels and the level toggle title were hardcoded English. They are keys now, translated across every locale.

Two daisyUI quirks are worked around and commented in the CSS: it pads any direct child of a menu `li` as if it were a clickable row, which collapsed the status dot and spinner to zero width, and `li.section` outspecifies a `text-warning` utility, hence the `.warn` modifier class.

Verified in light and dark, with both submenus open and the no-updates and update-available states forced. `pnpm typecheck` and all 294 frontend tests pass. No visual e2e snapshot covers this dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WQaEkup5DGcbs72qucLphS
