### PR TITLE
feat(logs): redesign the log stream and details drawer

### DIFF
--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -143,6 +143,7 @@ declare module 'vue' {
     'Mdi:cog': typeof import('~icons/mdi/cog')['default']
     'Mdi:contentCopy': typeof import('~icons/mdi/content-copy')['default']
     'Mdi:docker': typeof import('~icons/mdi/docker')['default']
+    'Mdi:dragVertical': typeof import('~icons/mdi/drag-vertical')['default']
     'Mdi:filterOffOutline': typeof import('~icons/mdi/filter-off-outline')['default']
     'Mdi:filterOutline': typeof import('~icons/mdi/filter-outline')['default']
     'Mdi:flash': typeof import('~icons/mdi/flash')['default']

--- a/assets/components/LogViewer/ContainerEventLogItem.vue
+++ b/assets/components/LogViewer/ContainerEventLogItem.vue
@@ -1,6 +1,6 @@
 <template>
   <LogItem :logEntry>
-    <div class="whitespace-pre-wrap" :data-event="logEntry.event" v-html="logEntry.message"></div>
+    <div class="log-message whitespace-pre-wrap" :data-event="logEntry.event" v-html="logEntry.message"></div>
   </LogItem>
 </template>
 <script lang="ts" setup>

--- a/assets/components/LogViewer/GroupedLogItem.vue
+++ b/assets/components/LogViewer/GroupedLogItem.vue
@@ -9,7 +9,7 @@
           :event="index === 0 ? logEntry.matchedEvent : undefined"
         />
         <div
-          class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre"
+          class="log-message [word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre"
           v-html="colorize(msg)"
           :class="{ 'min-h-4': msg === '' }"
         ></div>

--- a/assets/components/LogViewer/LogActions.vue
+++ b/assets/components/LogViewer/LogActions.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="dropdown dropdown-hover absolute -left-2 z-10 font-sans"
+    class="dropdown dropdown-hover absolute -left-2 z-10 font-sans md:-left-8"
     :class="shouldShowBelow ? 'dropdown-right' : 'dropdown-right dropdown-end'"
     v-show="container"
     ref="dropdownRef"

--- a/assets/components/LogViewer/LogDate.vue
+++ b/assets/components/LogViewer/LogDate.vue
@@ -1,7 +1,12 @@
 <template>
-  <Tag class="items-start!">
-    <DateTime :date="date" class="text-blue whitespace-nowrap" />
-  </Tag>
+  <!-- Deliberately unboxed: in a wall of monospace text the timestamp is a
+       reference, not content, so it reads as a quiet left column and only
+       sharpens when the row is hovered. -->
+  <div
+    class="text-base-content/45 group-hover/entry:text-base-content/80 pt-px whitespace-nowrap tabular-nums transition-colors"
+  >
+    <DateTime :date="date" />
+  </div>
 </template>
 <script lang="ts" setup>
 defineProps<{

--- a/assets/components/LogViewer/LogDetails.vue
+++ b/assets/components/LogViewer/LogDetails.vue
@@ -1,76 +1,102 @@
 <template>
-  <header class="flex items-center gap-4">
-    <Tag :data-level="entry.level" class="show-unknown text-white uppercase" v-if="entry.level">{{ entry.level }}</Tag>
-    <h1 class="text-lg max-md:hidden">
+  <!-- pr-24 keeps the title clear of the drawer's maximize/close buttons, which
+       float over this slot. -->
+  <header class="border-base-content/10 flex flex-wrap items-center gap-x-3 gap-y-2 border-b pr-24 pb-4">
+    <span class="level-pill" :data-pill-level="entry.level ?? 'unknown'" v-if="entry.level">{{ entry.level }}</span>
+    <h1 class="font-mono text-base tabular-nums max-md:hidden">
       <DateTime :date="entry.date" />
     </h1>
-    <h2 class="text-sm"><RelativeTime :date="entry.date" /> on {{ entry.std }}</h2>
+    <h2 class="text-base-content/55 text-xs">
+      <RelativeTime :date="entry.date" />
+      <span class="px-1">&middot;</span>
+      <span :data-std="entry.std">{{ $t("log-details.on-std", { std: entry.std }) }}</span>
+    </h2>
   </header>
 
-  <div class="mt-8 flex flex-col gap-10">
-    <section class="grid grid-cols-3 gap-2">
-      <div>
-        <div class="font-thin">Container Name</div>
-        <div class="truncate text-lg font-bold">{{ container.name }}</div>
+  <div class="mt-5 flex flex-col gap-6">
+    <!-- Facts about where the line came from. Small labels, plain values: this
+         is context for the payload below, not the headline. -->
+    <section class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-3">
+      <div class="min-w-0">
+        <div class="field-label">{{ $t("label.container-name") }}</div>
+        <div class="truncate font-medium" :title="container.name">{{ container.name }}</div>
       </div>
-      <div>
-        <div class="font-thin">Host</div>
-        <div class="truncate text-lg font-bold">
-          {{ hosts[container.host].name }}
-        </div>
+      <div class="min-w-0">
+        <div class="field-label">{{ $t("label.host") }}</div>
+        <div class="truncate font-medium" :title="hosts[container.host].name">{{ hosts[container.host].name }}</div>
       </div>
-      <div>
-        <div class="font-thin">Image</div>
-        <div class="truncate text-lg font-bold">{{ container.image }}</div>
+      <div class="min-w-0">
+        <div class="field-label">{{ $t("log-details.image") }}</div>
+        <div class="truncate font-medium" :title="container.image">{{ container.image }}</div>
       </div>
     </section>
 
     <section class="flex flex-col gap-2">
-      <div class="flex gap-2">
-        Raw JSON
+      <div class="flex items-center gap-1">
+        <div class="field-label">{{ $t("log-details.raw-json") }}</div>
 
         <UseClipboard v-slot="{ copy, copied }" :source="entry.rawMessage">
-          <button class="icon-btn swap outline-hidden" @click="copy()" :class="{ 'hover:swap-active': copied }">
+          <button
+            class="icon-btn swap ml-auto outline-hidden"
+            @click="copy()"
+            :class="{ 'hover:swap-active': copied }"
+            :title="$t('log-details.copy')"
+          >
             <mdi:check class="swap-on" />
             <material-symbols:content-copy class="swap-off" />
           </button>
         </UseClipboard>
 
-        <button class="icon-btn outline-hidden" @click="downloadJSON()" title="Download JSON">
+        <button class="icon-btn outline-hidden" @click="downloadJSON()" :title="$t('log-details.download')">
           <material-symbols:download />
         </button>
       </div>
-      <div class="bg-base-200 max-h-125 overflow-scroll rounded-sm border border-white/20 p-2">
-        <JsonFormatted :value="entry.rawMessage" class="text-sm" />
+      <div class="bg-base-200 border-base-content/10 max-h-125 overflow-auto rounded-md border p-3">
+        <JsonFormatted :value="entry.rawMessage" class="text-xs leading-relaxed" />
       </div>
     </section>
-    <table class="table-pin-rows table table-fixed" v-if="entry instanceof ComplexLogEntry">
-      <caption class="caption-bottom">
-        Fields are sortable by dragging and dropping.
-      </caption>
-      <thead class="text-lg">
-        <tr>
-          <th class="w-60">Field</th>
-          <th class="max-md:hidden">Value</th>
-          <th class="w-20">
-            <input type="checkbox" class="toggle toggle-primary" v-model="toggleAllFields" title="Toggle all" />
-          </th>
-        </tr>
-      </thead>
-      <tbody ref="list">
-        <tr v-for="{ key, value, enabled } in fields" :key="key.join('.')" class="hover">
-          <td class="cursor-move font-mono break-all">
-            {{ key.join(".") }}
-          </td>
-          <td class="truncate max-md:hidden">
-            <code class="font-mono">{{ JSON.stringify(value) }}</code>
-          </td>
-          <td>
-            <input type="checkbox" class="toggle toggle-primary" :checked="enabled" @change="toggleField(key)" />
-          </td>
-        </tr>
-      </tbody>
-    </table>
+
+    <section class="flex flex-col gap-2" v-if="entry instanceof ComplexLogEntry">
+      <div class="flex items-center gap-3">
+        <div class="field-label">{{ $t("log-details.fields") }}</div>
+        <p class="text-base-content/45 text-xs">{{ $t("log-details.fields-hint") }}</p>
+      </div>
+      <table class="w-full table-fixed border-collapse text-sm">
+        <thead>
+          <tr class="border-base-content/15 border-b">
+            <th class="field-label w-1/3 pb-1.5 text-left">{{ $t("log-details.field") }}</th>
+            <th class="field-label pb-1.5 text-left max-md:hidden">{{ $t("log-details.value") }}</th>
+            <th class="w-14 pb-1.5 text-right">
+              <input
+                type="checkbox"
+                class="toggle toggle-primary toggle-xs align-middle"
+                v-model="toggleAllFields"
+                :title="$t('log-details.toggle-all')"
+              />
+            </th>
+          </tr>
+        </thead>
+        <tbody ref="list">
+          <tr v-for="{ key, value, enabled } in fields" :key="key.join('.')" class="field-row">
+            <td class="cursor-move py-1.5 pr-3 font-mono break-all">
+              <mdi:drag-vertical class="drag-handle -ml-1 inline size-4 align-middle" />
+              <span :class="{ 'opacity-40': !enabled }">{{ key.join(".") }}</span>
+            </td>
+            <td class="text-base-content/65 truncate py-1.5 pr-3 font-mono max-md:hidden">
+              <code :title="JSON.stringify(value)">{{ JSON.stringify(value) }}</code>
+            </td>
+            <td class="py-1.5 text-right">
+              <input
+                type="checkbox"
+                class="toggle toggle-primary toggle-xs align-middle"
+                :checked="enabled"
+                @change="toggleField(key)"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
   </div>
 </template>
 
@@ -167,3 +193,60 @@ const toggleAllFields = computed({
 
 useSortable(list, fields);
 </script>
+
+<style scoped>
+@reference "@/main.css";
+
+/* One label style for every section heading and column header, so the eye has
+   a single "this is a label, not content" cue down the whole drawer. */
+.field-label {
+  @apply text-base-content/50 text-[0.7rem] font-semibold tracking-wider uppercase;
+}
+
+/* Keyed on data-pill-level, NOT data-level: LogLevel.vue ships an unscoped
+   `[data-level="error"] { @apply !bg-red }` that would paint this solid and
+   make the tint below unwinnable. */
+.level-pill {
+  background-color: color-mix(in oklab, var(--pill) 18%, transparent);
+  color: var(--pill);
+  border: 1px solid color-mix(in oklab, var(--pill) 40%, transparent);
+  @apply inline-flex shrink-0 items-center rounded px-2 py-0.5 text-[0.7rem] font-bold tracking-wider uppercase;
+  --pill: var(--color-base-content);
+}
+.level-pill[data-pill-level="debug"],
+.level-pill[data-pill-level="trace"] {
+  --pill: var(--color-purple);
+}
+.level-pill[data-pill-level="info"] {
+  --pill: var(--color-green);
+}
+.level-pill[data-pill-level="warn"] {
+  --pill: var(--color-orange);
+}
+.level-pill[data-pill-level="error"],
+.level-pill[data-pill-level="fatal"] {
+  --pill: var(--color-red);
+}
+
+[data-std="stdout"] {
+  @apply text-blue;
+}
+[data-std="stderr"] {
+  @apply text-red;
+}
+
+/* The handle only appears on the row being pointed at: eighteen of them stacked
+   down the table read as noise, and the rows are draggable either way. */
+.drag-handle {
+  @apply text-base-content/40 opacity-0 transition-opacity;
+}
+.field-row {
+  @apply border-base-content/10 border-b transition-colors;
+}
+.field-row:hover {
+  background-color: color-mix(in oklab, var(--color-base-content) 6%, transparent);
+}
+.field-row:hover .drag-handle {
+  @apply opacity-100;
+}
+</style>

--- a/assets/components/LogViewer/LogItem.vue
+++ b/assets/components/LogViewer/LogItem.vue
@@ -4,7 +4,9 @@
 
     <LogStd :std="logEntry.std" class="shrink-0 select-none" v-if="showStd" />
 
-    <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
+    <div
+      class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:mr-1 md:flex-row!"
+    >
       <RandomColorTag class="w-30 shrink-0 select-none md:w-40" :value="host.name" v-if="showHostname" />
       <RandomColorTag
         v-if="showContainerName"

--- a/assets/components/LogViewer/LogLevel.vue
+++ b/assets/components/LogViewer/LogLevel.vue
@@ -11,13 +11,16 @@
     <mdi:bell-off v-if="event.suppressed" class="size-3.5 shrink-0" />
     <mdi:bell-alert v-else class="size-3.5 shrink-0" />
   </span>
-  <div
-    v-else
-    :data-level="level"
-    :data-position="position"
-    class="mt-1.5 size-2.5 flex-none rounded-lg"
-    :class="{ showUnknown }"
-  ></div>
+  <!-- The rail is 3px inside a 10px slot: it stays a quiet colour cue at the
+       edge of the text instead of a bullet competing with the first word, and
+       the slot keeps every message column aligned whatever the marker is. -->
+  <div v-else class="level-rail mt-1.5 flex w-2.5 flex-none justify-center" :data-position="position">
+    <div
+      :data-level="level"
+      class="w-[3px] rounded-full"
+      :class="[position ? 'h-full' : 'h-[0.9em] min-h-3', { 'show-unknown': showUnknown }]"
+    ></div>
+  </div>
 </template>
 <script lang="ts" setup>
 import { Position, Level, type MatchedEvent } from "@/models/LogEntry";
@@ -37,25 +40,29 @@ const {
 
 <style scoped>
 @reference "@/main.css";
-[data-position="start"],
-[data-position="middle"],
-[data-position="end"] {
+.level-rail[data-position="start"],
+.level-rail[data-position="middle"],
+.level-rail[data-position="end"] {
   align-self: stretch;
   height: auto;
 }
 
-[data-position="start"] {
-  border-radius: 0.375rem 0.375rem 0 0;
+.level-rail[data-position="middle"],
+.level-rail[data-position="end"] {
+  margin-top: 0;
 }
 
-[data-position="middle"] {
+/* Round only the outer ends so a grouped entry reads as one continuous rail. */
+.level-rail[data-position="start"] > div {
+  border-radius: 9999px 9999px 0 0;
+}
+
+.level-rail[data-position="middle"] > div {
   border-radius: 0;
-  margin-top: 0;
 }
 
-[data-position="end"] {
-  border-radius: 0 0 0.375rem 0.375rem;
-  margin-top: 0;
+.level-rail[data-position="end"] > div {
+  border-radius: 0 0 9999px 9999px;
 }
 
 /* Named data-event-level, NOT data-level: the unscoped block below paints any

--- a/assets/components/LogViewer/LogList.vue
+++ b/assets/components/LogViewer/LogList.vue
@@ -6,6 +6,7 @@
       :key="item.id"
       :id="item.id.toString()"
       :data-time="item.date.getTime()"
+      :data-log-level="rowLevel(item)"
       class="group/entry"
       :class="{ 'log-permalink-target': permalinkLogId === item.id.toString() }"
     >
@@ -15,7 +16,7 @@
 </template>
 
 <script lang="ts" setup>
-import type { LogEntry, LogMessage } from "@/models/LogEntry";
+import { AlertLogEntry, CloudEventLogEntry, type LogEntry, type LogMessage } from "@/models/LogEntry";
 
 const { progress, currentDate } = useScrollContext();
 
@@ -24,6 +25,12 @@ const { messages } = defineProps<{
 }>();
 
 const { containers } = useLoggingContext();
+
+// Only real log output gets the row tint. Alert and cloud-event rows already
+// carry their own level marker and deliberately leave the row background alone,
+// so tinting them would fight styling they own.
+const rowLevel = (item: LogEntry<LogMessage>) =>
+  item instanceof AlertLogEntry || item instanceof CloudEventLogEntry ? undefined : item.level;
 
 const route = useRoute();
 const permalinkLogId = computed(() => (typeof route.query.logId === "string" ? route.query.logId : ""));
@@ -61,15 +68,47 @@ useIntersectionObserver(
 @reference "@/main.css";
 ul {
   font-family: var(--font-mono);
+  line-height: 1.55;
 
   > li {
-    @apply flex px-2 py-1 break-words last:snap-end odd:bg-gray-400/[0.07] md:px-4;
+    /* pl leaves an empty gutter on desktop so the hover actions button has a
+       home of its own instead of covering the timestamp. */
+    @apply flex px-2 py-1 break-words transition-colors duration-75 last:snap-end md:pr-4 md:pl-9;
     &:last-child {
       scroll-margin-block-end: 5rem;
     }
 
+    /* Written long-hand rather than as odd:/hover: utilities because the order
+       below is the whole point: hover beats the zebra, and a level tint beats
+       both, with its own (stronger) hover on top. */
+    &:nth-child(odd) {
+      background-color: color-mix(in oklab, var(--color-base-content) 4%, transparent);
+    }
+
+    &:hover {
+      background-color: color-mix(in oklab, var(--color-base-content) 8%, transparent);
+    }
+
+    &[data-log-level="error"],
+    &[data-log-level="fatal"] {
+      background-color: color-mix(in oklab, var(--color-red) 9%, transparent);
+    }
+
+    &[data-log-level="error"]:hover,
+    &[data-log-level="fatal"]:hover {
+      background-color: color-mix(in oklab, var(--color-red) 15%, transparent);
+    }
+
+    &[data-log-level="warn"] {
+      background-color: color-mix(in oklab, var(--color-orange) 8%, transparent);
+    }
+
+    &[data-log-level="warn"]:hover {
+      background-color: color-mix(in oklab, var(--color-orange) 14%, transparent);
+    }
+
     &.log-permalink-target {
-      @apply bg-secondary/15 border-secondary -ml-1 border-l-4 pl-3;
+      @apply bg-secondary/15 border-secondary -ml-1 border-l-4 pl-3 md:pl-8;
       animation: log-permalink-pulse 1.4s ease-out;
     }
   }
@@ -94,6 +133,14 @@ ul {
     :deep(.tag) {
       @apply rounded-none;
     }
+  }
+
+  /* A soft-wrapped line hangs its continuation past the start of the entry, so
+     one long line can never be mistaken for two. Harmless when wrapping is off:
+     the negative indent and the padding cancel out. */
+  :deep(.log-message) {
+    padding-left: 1.5ch;
+    text-indent: -1.5ch;
   }
 
   :deep(mark) {

--- a/assets/components/LogViewer/LogStd.vue
+++ b/assets/components/LogViewer/LogStd.vue
@@ -1,7 +1,7 @@
 <template>
-  <Tag :std="std" class="items-start!">
+  <div :std="std" class="pt-px text-[0.85em] tracking-wide uppercase opacity-70">
     {{ std }}
-  </Tag>
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/assets/components/LogViewer/SimpleLogItem.vue
+++ b/assets/components/LogViewer/SimpleLogItem.vue
@@ -2,7 +2,7 @@
   <LogItem :logEntry>
     <LogLevel class="flex select-none" :level="logEntry.level" :event="logEntry.matchedEvent" />
     <div
-      class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre"
+      class="log-message [word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre"
       v-html="colorize(logEntry.message)"
     ></div>
   </LogItem>

--- a/assets/components/LogViewer/__snapshots__/EventSource.spec.ts.snap
+++ b/assets/components/LogViewer/__snapshots__/EventSource.spec.ts.snap
@@ -7,7 +7,7 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
     <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans md:-left-8 dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
           </svg></a>
         <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
@@ -27,18 +27,26 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
         </ul>
       </div>
       <!--v-if-->
-      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
+      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:mr-1 md:flex-row!">
         <!--v-if-->
         <!--v-if-->
-        <div class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
-          <div class="inline-flex gap-2 text-blue whitespace-nowrap"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42 AM</time></div>
+        <!-- Deliberately unboxed: in a wall of monospace text the timestamp is a
+       reference, not content, so it reads as a quiet left column and only
+       sharpens when the row is hovered. -->
+        <div class="text-base-content/45 group-hover/entry:text-base-content/80 pt-px whitespace-nowrap tabular-nums transition-colors shrink-0 select-none">
+          <div class="inline-flex gap-2"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42 AM</time></div>
         </div>
       </div>
       <!-- A matched notification takes over the level marker instead of adding a
        second icon beside it: the bell is tinted with the level colour, so one
        glyph still says both "this line fired" and what level it was. -->
-      <div data-v-e625cddd="" class="mt-1.5 size-2.5 flex-none rounded-lg flex select-none"></div>
-      <div class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">foo bar</div>
+      <!-- The rail is 3px inside a 10px slot: it stays a quiet colour cue at the
+       edge of the text instead of a bullet competing with the first word, and
+       the slot keeps every message column aligned whatever the marker is. -->
+      <div data-v-e625cddd="" class="level-rail mt-1.5 flex w-2.5 flex-none justify-center flex select-none">
+        <div data-v-e625cddd="" class="w-[3px] rounded-full h-[0.9em] min-h-3"></div>
+      </div>
+      <div class="log-message [word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">foo bar</div>
     </div>
   </li>
 </ul>"
@@ -51,7 +59,7 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
     <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans md:-left-8 dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
           </svg></a>
         <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
@@ -71,18 +79,26 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
         </ul>
       </div>
       <!--v-if-->
-      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
+      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:mr-1 md:flex-row!">
         <!--v-if-->
         <!--v-if-->
-        <div class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
-          <div class="inline-flex gap-2 text-blue whitespace-nowrap"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42</time></div>
+        <!-- Deliberately unboxed: in a wall of monospace text the timestamp is a
+       reference, not content, so it reads as a quiet left column and only
+       sharpens when the row is hovered. -->
+        <div class="text-base-content/45 group-hover/entry:text-base-content/80 pt-px whitespace-nowrap tabular-nums transition-colors shrink-0 select-none">
+          <div class="inline-flex gap-2"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42</time></div>
         </div>
       </div>
       <!-- A matched notification takes over the level marker instead of adding a
        second icon beside it: the bell is tinted with the level colour, so one
        glyph still says both "this line fired" and what level it was. -->
-      <div data-v-e625cddd="" class="mt-1.5 size-2.5 flex-none rounded-lg flex select-none"></div>
-      <div class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">foo bar</div>
+      <!-- The rail is 3px inside a 10px slot: it stays a quiet colour cue at the
+       edge of the text instead of a bullet competing with the first word, and
+       the slot keeps every message column aligned whatever the marker is. -->
+      <div data-v-e625cddd="" class="level-rail mt-1.5 flex w-2.5 flex-none justify-center flex select-none">
+        <div data-v-e625cddd="" class="w-[3px] rounded-full h-[0.9em] min-h-3"></div>
+      </div>
+      <div class="log-message [word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">foo bar</div>
     </div>
   </li>
 </ul>"
@@ -95,7 +111,7 @@ exports[`<ContainerEventSource /> > render html correctly > should render messag
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
     <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans md:-left-8 dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
           </svg></a>
         <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
@@ -115,18 +131,26 @@ exports[`<ContainerEventSource /> > render html correctly > should render messag
         </ul>
       </div>
       <!--v-if-->
-      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:flex-row!">
+      <div class="flex gap-x-2 gap-y-1 group-[.compact]:gap-y-0 has-[>_*:nth-of-type(2)]:flex-col-reverse md:mr-1 md:flex-row!">
         <!--v-if-->
         <!--v-if-->
-        <div class="tag bg-base-100 inline-flex items-center justify-center rounded-sm px-2 py-[0.2em] [[size='small']]:text-[0.8rem] items-start! shrink-0 select-none">
-          <div class="inline-flex gap-2 text-blue whitespace-nowrap"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42 AM</time></div>
+        <!-- Deliberately unboxed: in a wall of monospace text the timestamp is a
+       reference, not content, so it reads as a quiet left column and only
+       sharpens when the row is hovered. -->
+        <div class="text-base-content/45 group-hover/entry:text-base-content/80 pt-px whitespace-nowrap tabular-nums transition-colors shrink-0 select-none">
+          <div class="inline-flex gap-2"><time datetime="2019-06-12T10:55:42.459Z" class="max-md:hidden">06/12/2019</time><time datetime="2019-06-12T10:55:42.459Z">10:55:42 AM</time></div>
         </div>
       </div>
       <!-- A matched notification takes over the level marker instead of adding a
        second icon beside it: the bell is tinted with the level colour, so one
        glyph still says both "this line fired" and what level it was. -->
-      <div data-v-e625cddd="" class="mt-1.5 size-2.5 flex-none rounded-lg flex select-none"></div>
-      <div class="[word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">This is a message.</div>
+      <!-- The rail is 3px inside a 10px slot: it stays a quiet colour cue at the
+       edge of the text instead of a bullet competing with the first word, and
+       the slot keeps every message column aligned whatever the marker is. -->
+      <div data-v-e625cddd="" class="level-rail mt-1.5 flex w-2.5 flex-none justify-center flex select-none">
+        <div data-v-e625cddd="" class="w-[3px] rounded-full h-[0.9em] min-h-3"></div>
+      </div>
+      <div class="log-message [word-break:break-word] whitespace-pre-wrap group-[.disable-wrap]:whitespace-pre">This is a message.</div>
     </div>
   </li>
 </ul>"

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Se i kontekst
   show-details: Vis detaljer
   create-alert: Opret advarsel
+log-details:
+  on-std: på {std}
+  image: Billede
+  raw-json: Rå JSON
+  copy: Kopiér
+  download: Download JSON
+  fields: Felter
+  field: Felt
+  value: Værdi
+  fields-hint: Træk for at ændre rækkefølgen. Slå til eller fra for at vise eller skjule i logstrømmen.
+  toggle-all: Slå alle felter til eller fra
 label:
   containers: Containere
   container: Ingen containere | 1 container | {count} containere

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Im Kontext anzeigen
   show-details: Details anzeigen
   create-alert: Alarm erstellen
+log-details:
+  on-std: auf {std}
+  image: Image
+  raw-json: Rohes JSON
+  copy: Kopieren
+  download: JSON herunterladen
+  fields: Felder
+  field: Feld
+  value: Wert
+  fields-hint: Zum Umsortieren ziehen. Umschalten, um sie im Log-Stream ein- oder auszublenden.
+  toggle-all: Alle Felder umschalten
 label:
   containers: Container
   container: Keine Container | 1 Container | {count} Container

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: See in context
   show-details: Show details
   create-alert: Create alert
+log-details:
+  on-std: on {std}
+  image: Image
+  raw-json: Raw JSON
+  copy: Copy
+  download: Download JSON
+  fields: Fields
+  field: Field
+  value: Value
+  fields-hint: Drag to reorder. Toggle to show or hide in the log stream.
+  toggle-all: Toggle all fields
 label:
   containers: Containers
   container: No containers | 1 container | {count} containers

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Ver en contexto
   show-details: Mostrar detalles
   create-alert: Crear alerta
+log-details:
+  on-std: en {std}
+  image: Imagen
+  raw-json: JSON sin procesar
+  copy: Copiar
+  download: Descargar JSON
+  fields: Campos
+  field: Campo
+  value: Valor
+  fields-hint: Arrastra para reordenar. Activa o desactiva para mostrarlos u ocultarlos en el flujo de registros.
+  toggle-all: Alternar todos los campos
 label:
   containers: Contenedores
   container: No contenedores | 1 contenedor | {count} contenedores

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Voir dans le contexte
   show-details: Afficher les détails
   create-alert: Créer une alerte
+log-details:
+  on-std: sur {std}
+  image: Image
+  raw-json: JSON brut
+  copy: Copier
+  download: Télécharger le JSON
+  fields: Champs
+  field: Champ
+  value: Valeur
+  fields-hint: Faites glisser pour réordonner. Activez ou désactivez pour les afficher ou les masquer dans le flux de logs.
+  toggle-all: Basculer tous les champs
 label:
   containers: Conteneurs
   container: Pas de conteneur | 1 conteneur | {count} conteneurs

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -50,6 +50,17 @@ action:
   show-details: Tampilkan detail
   create-alert: Buat peringatan
 
+log-details:
+  on-std: pada {std}
+  image: Image
+  raw-json: JSON Mentah
+  copy: Salin
+  download: Unduh JSON
+  fields: Bidang
+  field: Bidang
+  value: Nilai
+  fields-hint: Seret untuk mengurutkan ulang. Alihkan untuk menampilkan atau menyembunyikan di aliran log.
+  toggle-all: Alihkan semua bidang
 label:
   containers: Kontainer
   container: Tidak ada kontainer | 1 kontainer | {count} kontainer

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Vedi nel contesto
   show-details: Mostra dettagli
   create-alert: Crea avviso
+log-details:
+  on-std: su {std}
+  image: Immagine
+  raw-json: JSON grezzo
+  copy: Copia
+  download: Scarica JSON
+  fields: Campi
+  field: Campo
+  value: Valore
+  fields-hint: Trascina per riordinare. Attiva o disattiva per mostrarli o nasconderli nel flusso dei log.
+  toggle-all: Attiva o disattiva tutti i campi
 label:
   containers: Container
   container: Nessun container | 1 container | {count} container

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: 컨텍스트에서 보기
   show-details: 세부 정보 표시
   create-alert: 알림 생성
+log-details:
+  on-std: "{std}에서"
+  image: 이미지
+  raw-json: 원본 JSON
+  copy: 복사
+  download: JSON 다운로드
+  fields: 필드
+  field: 필드
+  value: 값
+  fields-hint: 드래그하여 순서를 바꾸세요. 토글하여 로그 스트림에서 표시하거나 숨깁니다.
+  toggle-all: 모든 필드 토글
 label:
   containers: 컨테이너
   container: 컨테이너가 없습니다 | 컨테이너 1개 | 컨테이너 {count}개

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Bekijk in context
   show-details: Toon details
   create-alert: Waarschuwing aanmaken
+log-details:
+  on-std: op {std}
+  image: Image
+  raw-json: Ruwe JSON
+  copy: Kopiëren
+  download: JSON downloaden
+  fields: Velden
+  field: Veld
+  value: Waarde
+  fields-hint: Sleep om te herordenen. Schakel in of uit om ze in de logstroom te tonen of te verbergen.
+  toggle-all: Alle velden omschakelen
 label:
   containers: Containers
   container: Geen containers | 1 container | {count} containers

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Zobacz w kontekście
   show-details: Pokaż szczegóły
   create-alert: Utwórz alert
+log-details:
+  on-std: na {std}
+  image: Obraz
+  raw-json: Surowy JSON
+  copy: Kopiuj
+  download: Pobierz JSON
+  fields: Pola
+  field: Pole
+  value: Wartość
+  fields-hint: Przeciągnij, aby zmienić kolejność. Przełącz, aby pokazać lub ukryć w strumieniu logów.
+  toggle-all: Przełącz wszystkie pola
 label:
   service: Brak usług | 1 usługa | {count} usług
   services: Usługi

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Ver no contexto
   show-details: Mostrar detalhes
   create-alert: Criar alerta
+log-details:
+  on-std: em {std}
+  image: Imagem
+  raw-json: JSON bruto
+  copy: Copiar
+  download: Baixar JSON
+  fields: Campos
+  field: Campo
+  value: Valor
+  fields-hint: Arraste para reordenar. Alterne para mostrar ou ocultar no fluxo de logs.
+  toggle-all: Alternar todos os campos
 label:
   containers: Contêineres
   container: Nenhum container | 1 container | {count} containers

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Посмотреть в контексте
   show-details: Показать детали
   create-alert: Создать оповещение
+log-details:
+  on-std: в {std}
+  image: Образ
+  raw-json: Исходный JSON
+  copy: Копировать
+  download: Скачать JSON
+  fields: Поля
+  field: Поле
+  value: Значение
+  fields-hint: Перетащите, чтобы изменить порядок. Переключите, чтобы показать или скрыть в потоке логов.
+  toggle-all: Переключить все поля
 label:
   containers: Контейнеры
   container: Нет контейнеров | 1 контейнер | {count} контейнеров

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Glej v kontekstu
   show-details: Prikaži podrobnosti
   create-alert: Ustvari opozorilo
+log-details:
+  on-std: na {std}
+  image: Slika
+  raw-json: Neobdelan JSON
+  copy: Kopiraj
+  download: Prenesi JSON
+  fields: Polja
+  field: Polje
+  value: Vrednost
+  fields-hint: Povlecite za spremembo vrstnega reda. Preklopite za prikaz ali skritje v toku dnevnikov.
+  toggle-all: Preklopi vsa polja
 label:
   containers: Zabojniki
   host-count: Ni Gostiteljev | 1 Gostitelj | {count} Gostiteljev

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: Bağlamda gör
   show-details: Detayları göster
   create-alert: Uyarı oluştur
+log-details:
+  on-std: "{std} üzerinde"
+  image: İmaj
+  raw-json: Ham JSON
+  copy: Kopyala
+  download: JSON indir
+  fields: Alanlar
+  field: Alan
+  value: Değer
+  fields-hint: Yeniden sıralamak için sürükleyin. Günlük akışında göstermek veya gizlemek için değiştirin.
+  toggle-all: Tüm alanları değiştir
 label:
   containers: Konteynerlar
   container: Konteyner yok | 1 konteyner | {count} konteyner

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: 在內容中查看
   show-details: 顯示詳細資訊
   create-alert: 建立警報
+log-details:
+  on-std: 來自 {std}
+  image: 映像檔
+  raw-json: 原始 JSON
+  copy: 複製
+  download: 下載 JSON
+  fields: 欄位
+  field: 欄位
+  value: 值
+  fields-hint: 拖曳可重新排序。切換可在日誌串流中顯示或隱藏。
+  toggle-all: 切換所有欄位
 label:
   containers: 容器
   container: 無容器 | 1 個容器 | {count} 個容器

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -49,6 +49,17 @@ action:
   see-in-context: 在上下文中查看
   show-details: 显示详细信息
   create-alert: 创建告警
+log-details:
+  on-std: 来自 {std}
+  image: 镜像
+  raw-json: 原始 JSON
+  copy: 复制
+  download: 下载 JSON
+  fields: 字段
+  field: 字段
+  value: 值
+  fields-hint: 拖动可重新排序。切换可在日志流中显示或隐藏。
+  toggle-all: 切换所有字段
 label:
   containers: 容器
   container: 无容器 | 1 容器 | {count} 容器

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.3.4
+        version: 12.3.4
       pnpm:
         specifier: 12.3.4
         version: 12.3.4
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.3.4':
+    resolution: {integrity: sha512-Rq7JokWAyYF9IFfn8zofB/q2AgnZlmoMuH5fMHB2+Ta61I9aD7sNm+woZpx6iH+5vb38chdSoYRvOtSqlH72YQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.3.4:
     resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.3.4':
     optional: true
+
+  '@pnpm/exe@12.3.4':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
 
   pnpm@12.3.4:
     optionalDependencies:


### PR DESCRIPTION
The rows themselves had never been touched, so this is all about how the stream reads. Nothing was added to or removed from what a row shows.

### Stream

The hover actions button sat on `-left-2`, directly over the timestamp. Desktop rows now reserve a gutter (`md:pl-9`) and the button lives in it. Mobile keeps the old overlay since there's no hover there.

The timestamp is no longer a boxed blue chip. It's muted, `tabular-nums`, and brightens on row hover, so it reads as a reference column rather than competing with the message.

The level marker went from a 10px dot (a full height bar on grouped entries) to a 3px rail centered in the same 10px slot. Columns stay aligned and a 20 line stack trace is no longer dominated by its own marker.

Error and warn rows get a faint level tint so they surface out of a wall of info lines. Row background order is explicit now: zebra, hover, level tint, level hover. Alert and cloud event rows opt out, they already own their row styling. Zebra also moved off a hardcoded `gray-400` to `base-content`, so it works in the light theme.

Soft wrapped lines hang 1.5ch, so one long line can't be misread as two.

### Details drawer

Header is one line: tinted level pill, mono timestamp, muted relative time and std.

Container/host/image dropped from `text-lg font-bold` to small labels with normal weight values, with `title` on the truncated ones.

The fields table is about half the height. Smaller toggles, tighter rows, and a drag handle that appears on hover instead of a caption below the table explaining that rows are draggable. Disabled fields dim.

`border-white/20` on the JSON box was hardcoded white, now `base-content/10`.

Every string in that drawer was hardcoded English. Added a `log-details` block with 10 keys, translated across all 16 locales.

### Knobs

If the tint or the muted timestamp are too strong, the percentages live in `LogList.vue` and the opacity in `LogDate.vue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5tUQRhrqY5YoceaUFVYFw
