### PR TITLE
feat(nav): add an action row to the container popup and merge from the sidebar

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -384,6 +384,7 @@ declare global {
   const useStepper: typeof import('@vueuse/core').useStepper
   const useStorage: typeof import('@vueuse/core').useStorage
   const useStorageAsync: typeof import('@vueuse/core').useStorageAsync
+  const useStreamedContainers: typeof import('./composable/streamedContainers').useStreamedContainers
   const useStyleTag: typeof import('@vueuse/core').useStyleTag
   const useSupported: typeof import('@vueuse/core').useSupported
   const useSwarmStore: typeof import('./stores/swarm').useSwarmStore
@@ -861,6 +862,7 @@ declare module 'vue' {
     readonly useStepper: UnwrapRef<typeof import('@vueuse/core')['useStepper']>
     readonly useStorage: UnwrapRef<typeof import('@vueuse/core')['useStorage']>
     readonly useStorageAsync: UnwrapRef<typeof import('@vueuse/core')['useStorageAsync']>
+    readonly useStreamedContainers: UnwrapRef<typeof import('./composable/streamedContainers')['useStreamedContainers']>
     readonly useStyleTag: UnwrapRef<typeof import('@vueuse/core')['useStyleTag']>
     readonly useSupported: UnwrapRef<typeof import('@vueuse/core')['useSupported']>
     readonly useSwarmStore: UnwrapRef<typeof import('./stores/swarm')['useSwarmStore']>

--- a/assets/components/ContainerPopup.vue
+++ b/assets/components/ContainerPopup.vue
@@ -31,18 +31,113 @@
       </template>
     </div>
 
-    <ContainerLink
-      v-if="container.url"
-      :container="container"
-      class="border-base-content/10 text-primary! border-t pt-2 text-xs hover:underline"
-    >
-      <span class="flex-1 truncate">{{ shortUrl }}</span>
-    </ContainerLink>
+    <!-- Everything below the hairline is a control rather than a fact about the
+         container, so the URL link and the icon row share one divider. -->
+    <div class="border-base-content/10 flex flex-col gap-2 border-t pt-2">
+      <ContainerLink v-if="container.url" :container="container" class="text-primary! text-xs hover:underline">
+        <span class="flex-1 truncate">{{ shortUrl }}</span>
+      </ContainerLink>
+
+      <!-- Icon-only, unlabeled: the popup is already dense, and every one of these
+           has a labeled twin in the container toolbar for anyone hunting by name. -->
+      <div class="flex items-center gap-0.5">
+        <button
+          type="button"
+          class="nav-btn icon-btn"
+          :class="{ 'text-secondary!': isPinnedColumn }"
+          :title="isPinnedColumn ? $t('tooltip.unpin-column') : $t('tooltip.pin-column')"
+          :aria-label="isPinnedColumn ? $t('tooltip.unpin-column') : $t('tooltip.pin-column')"
+          :aria-pressed="isPinnedColumn"
+          @click="togglePinnedColumn()"
+        >
+          <cil:columns class="size-4" />
+        </button>
+
+        <button
+          type="button"
+          class="nav-btn icon-btn"
+          :class="{ 'text-secondary!': pinned }"
+          :title="pinned ? $t('toolbar.unpin') : $t('toolbar.pin')"
+          :aria-label="pinned ? $t('toolbar.unpin') : $t('toolbar.pin')"
+          :aria-pressed="pinned"
+          @click="pinned = !pinned"
+        >
+          <ph:map-pin-simple-fill v-if="pinned" class="size-4" />
+          <ph:map-pin-simple v-else class="size-4" />
+        </button>
+
+        <button
+          type="button"
+          class="nav-btn icon-btn"
+          v-if="enableShell && isRunning"
+          :title="$t('toolbar.shell')"
+          :aria-label="$t('toolbar.shell')"
+          @click="showDrawer(Terminal, { container, action: 'exec' }, 'lg')"
+        >
+          <material-symbols:terminal class="size-4" />
+        </button>
+
+        <!-- aria-disabled rather than disabled: the reason it cannot be used right
+             now lives in the tooltip, and a real disabled button never shows one. -->
+        <button
+          type="button"
+          class="nav-btn icon-btn aria-disabled:cursor-default aria-disabled:opacity-40"
+          :class="{ 'text-secondary!': isMerged }"
+          :aria-disabled="!canMerge"
+          :title="mergeTitle"
+          :aria-label="mergeTitle"
+          :aria-pressed="isMerged"
+          @click="canMerge && toggleMerge(container.id)"
+        >
+          <ph:arrows-merge class="size-4" />
+        </button>
+
+        <!-- Start/stop/restart sit apart from the view controls above: one group
+             changes what you are looking at, the other changes the container. -->
+        <template v-if="enableActions">
+          <button
+            type="button"
+            class="nav-btn icon-btn hover:text-error! ms-auto disabled:pointer-events-none disabled:opacity-40"
+            v-if="isRunning"
+            :disabled="actionStates.stop || actionStates.restart"
+            :title="$t('toolbar.stop')"
+            :aria-label="$t('toolbar.stop')"
+            @click="stop()"
+          >
+            <carbon:stop-filled-alt class="size-4" />
+          </button>
+          <button
+            type="button"
+            class="nav-btn icon-btn hover:text-success! ms-auto disabled:pointer-events-none disabled:opacity-40"
+            v-else
+            :disabled="actionStates.start || actionStates.restart"
+            :title="$t('toolbar.start')"
+            :aria-label="$t('toolbar.start')"
+            @click="start()"
+          >
+            <carbon:play class="size-4" />
+          </button>
+
+          <button
+            type="button"
+            class="nav-btn icon-btn disabled:pointer-events-none disabled:opacity-40"
+            :disabled="actionStates.stop || actionStates.start || actionStates.restart"
+            :title="$t('toolbar.restart')"
+            :aria-label="$t('toolbar.restart')"
+            @click="restart()"
+          >
+            <carbon:restart class="size-4" :class="{ 'text-secondary animate-spin': actionStates.restart }" />
+          </button>
+        </template>
+      </div>
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { Container } from "@/models/Container";
+import Terminal from "@/components/Terminal.vue";
+import { useStreamedContainers } from "@/composable/streamedContainers";
 
 const { container } = defineProps<{
   container: Container;
@@ -50,11 +145,44 @@ const { container } = defineProps<{
 
 const { t } = useI18n();
 const { hosts } = useHosts();
+const { enableActions, enableShell } = config;
+const showDrawer = useDrawer();
+const pinnedStore = usePinnedLogsStore();
+const { actionStates, start, stop, restart } = useContainerActions(toRef(() => container));
 
 const host = computed(() => hosts.value[container.host]);
 const isRunning = computed(() => container.state === "running");
 const imageTag = computed(() => container.image.replace(/@sha.*/, ""));
 const shortUrl = computed(() => container.url?.replace(/^https?:\/\//, "").replace(/\/$/, ""));
+
+const { ids: streamedIds, toggle: toggleMerge } = useStreamedContainers();
+
+const isMerged = computed(() => streamedIds.value.includes(container.id));
+
+// Nothing to merge into from a dashboard or a group view, and removing the last
+// id would leave a merged view with no containers in it.
+const canMerge = computed(() => streamedIds.value.length > (isMerged.value ? 1 : 0));
+
+const mergeTitle = computed(() => {
+  if (streamedIds.value.length === 0) return t("tooltip.merge-stream-hint");
+  return isMerged.value ? t("tooltip.unmerge-stream") : t("tooltip.merge-stream");
+});
+
+const isPinnedColumn = computed(() => pinnedStore.isPinned(container));
+const togglePinnedColumn = () =>
+  isPinnedColumn.value ? pinnedStore.unPinContainer(container) : pinnedStore.pinContainer(container);
+
+// Name-based, like the sidebar's "Pinned" group and the title bar's pin.
+const pinned = computed({
+  get: () => pinnedContainers.value.has(container.name),
+  set: (value) => {
+    if (value) {
+      pinnedContainers.value.add(container.name);
+    } else {
+      pinnedContainers.value.delete(container.name);
+    }
+  },
+});
 
 const rows = computed(() => {
   const rows: { label: string; value: string; title?: string }[] = [

--- a/assets/components/HostMenu.vue
+++ b/assets/components/HostMenu.vue
@@ -71,7 +71,7 @@
               :to="{ name: '/container/[id]', params: { id: item.id } }"
               :label="item.name"
               :title="item.name"
-              :class="[item.state, { 'highlight-new': item.isNew }]"
+              :class="[item.state, { 'highlight-new': item.isNew, 'is-merged': isMerged && isStreaming(item.id) }]"
               @click.alt.stop.prevent="pinnedStore.pinContainer(item)"
               @animationend="item.isNew = false"
             >
@@ -79,15 +79,10 @@
                 <svg-spinners:ring-resize v-if="item.isNew" class="text-secondary size-4" />
                 <ContainerIcon v-else :state="item.state" :health="item.health" :slug="item.icon" class="size-5" />
               </template>
-              <template #trailing>
-                <span
-                  class="icon-btn hover:text-secondary hidden group-hover/nav-item:inline-flex"
-                  @click.stop.prevent="pinnedStore.pinContainer(item)"
-                  v-show="!pinnedStore.isPinned(item)"
-                  :title="$t('tooltip.pin-column')"
-                >
-                  <cil:columns class="size-4" />
-                </span>
+              <!-- The tint alone reads as "selected"; the arrows say why several rows
+                   are selected at once. -->
+              <template #trailing v-if="isMerged && isStreaming(item.id)">
+                <ph:arrows-merge class="size-3.5" />
               </template>
             </NavItem>
             <template #content>
@@ -103,6 +98,7 @@
 <script lang="ts" setup>
 import { Container } from "@/models/Container";
 import { sessionHost } from "@/composable/storage";
+import { useStreamedContainers } from "@/composable/streamedContainers";
 import { showAllContainers, groupContainers } from "@/stores/settings";
 
 import Pin from "~icons/ph/map-pin-simple";
@@ -114,6 +110,8 @@ const containerStore = useContainerStore();
 const { visibleContainers } = storeToRefs(containerStore);
 
 const pinnedStore = usePinnedLogsStore();
+
+const { isStreaming, isMerged } = useStreamedContainers();
 
 const { hosts } = useHosts();
 

--- a/assets/components/LogViewer/MultiContainerActionToolbar.vue
+++ b/assets/components/LogViewer/MultiContainerActionToolbar.vue
@@ -6,78 +6,104 @@
     </label>
     <ul
       tabindex="0"
-      class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 shadow-sm"
+      class="menu dropdown-content rounded-box bg-base-200 border-base-content/10 z-50 w-max min-w-60 border p-1.5 shadow-lg"
       @click="hideMenu"
     >
-      <li>
-        <a @click="clear()">
-          <octicon:trash-24 /> {{ $t("toolbar.clear") }}
-          <KeyShortcut char="l" :modifiers="['shift', 'meta']" />
-        </a>
-      </li>
-      <li v-if="enableDownload">
-        <a :href="downloadUrl" download>
-          <octicon:download-24 />
-          {{ isFiltered ? $t("toolbar.download-filtered") : $t("toolbar.download") }}
-        </a>
-      </li>
+      <li class="section">{{ $t("toolbar.section-logs") }}</li>
       <li>
         <a @click="showSearch = true">
           <mdi:magnify /> {{ $t("toolbar.search") }}
           <KeyShortcut char="f" />
         </a>
       </li>
-      <li class="line"></li>
       <li>
-        <a
-          @click="
-            streamConfig.stdout = true;
-            streamConfig.stderr = true;
-          "
-        >
-          <div class="flex size-4 gap-0.5">
-            <template v-if="streamConfig.stderr && streamConfig.stdout">
-              <carbon:circle-solid class="text-red w-2" />
-              <carbon:circle-solid class="text-blue w-2" />
-            </template>
-          </div>
-          {{ $t("toolbar.show-all") }}
+        <a @click="clear()">
+          <octicon:trash-24 /> {{ $t("toolbar.clear") }}
+          <KeyShortcut char="l" :modifiers="['shift', 'meta']" />
         </a>
       </li>
+
+      <li class="section">{{ $t("toolbar.section-filters") }}</li>
       <li>
-        <a
-          @click="
-            streamConfig.stdout = true;
-            streamConfig.stderr = false;
-          "
-        >
-          <div class="flex size-4 flex-col gap-1">
-            <carbon:circle-solid class="text-blue w-2" v-if="!streamConfig.stderr && streamConfig.stdout" />
-          </div>
-          {{ $t("toolbar.show", { std: "STDOUT" }) }}
-        </a>
+        <details>
+          <summary>
+            <div class="flex w-4 items-center gap-0.5">
+              <carbon:circle-solid class="size-2" :class="streamConfig.stderr ? 'text-red' : 'opacity-20'" />
+              <carbon:circle-solid class="size-2" :class="streamConfig.stdout ? 'text-blue' : 'opacity-20'" />
+            </div>
+            {{ $t("toolbar.streams") }}
+            <span class="value">{{ streamSummary }}</span>
+          </summary>
+          <ul class="menu">
+            <li>
+              <a
+                @click="
+                  streamConfig.stdout = true;
+                  streamConfig.stderr = true;
+                "
+              >
+                <mdi:check class="w-4" v-if="streamConfig.stdout == true && streamConfig.stderr == true" />
+                <div v-else class="w-4"></div>
+                {{ $t("toolbar.show-all") }}
+              </a>
+            </li>
+            <li>
+              <a
+                @click="
+                  streamConfig.stdout = true;
+                  streamConfig.stderr = false;
+                "
+              >
+                <mdi:check class="w-4" v-if="streamConfig.stdout == true && streamConfig.stderr == false" />
+                <div v-else class="w-4"></div>
+                {{ $t("toolbar.show", { std: "STDOUT" }) }}
+              </a>
+            </li>
+            <li>
+              <a
+                @click="
+                  streamConfig.stdout = false;
+                  streamConfig.stderr = true;
+                "
+              >
+                <mdi:check class="w-4" v-if="streamConfig.stdout == false && streamConfig.stderr == true" />
+                <div v-else class="w-4"></div>
+                {{ $t("toolbar.show", { std: "STDERR" }) }}
+              </a>
+            </li>
+          </ul>
+        </details>
       </li>
       <li>
-        <a
-          @click="
-            streamConfig.stdout = false;
-            streamConfig.stderr = true;
-          "
-        >
-          <div class="flex size-4 flex-col gap-1">
-            <carbon:circle-solid class="text-red w-2" v-if="streamConfig.stderr && !streamConfig.stdout" />
-          </div>
-          {{ $t("toolbar.show", { std: "STDERR" }) }}
-        </a>
+        <details class="group/details">
+          <summary>
+            <mdi:gauge />
+            {{ $t("toolbar.levels") }}
+            <span class="value group-open/details:hidden">{{ levelSummary }}</span>
+            <Toggle
+              class="toggle-xs hidden group-open/details:inline-flex"
+              v-model="toggleAllLevels"
+              :title="$t('toolbar.toggle-all-levels')"
+            />
+          </summary>
+          <ul class="menu">
+            <li v-for="level in allLevels">
+              <a class="capitalize" @click="levels.has(level) ? levels.delete(level) : levels.add(level)">
+                <mdi:check class="w-4" v-if="levels.has(level)" />
+                <div v-else class="w-4"></div>
+
+                <div class="flex">
+                  <div class="badge" :data-level="level">{{ level }}</div>
+                </div>
+              </a>
+            </li>
+          </ul>
+        </details>
       </li>
-      <li class="line"></li>
-      <li>
-        <a @click="showHostname = !showHostname">
-          <mdi:check class="w-4" v-if="showHostname" />
-          <div v-else class="w-4"></div>
-          {{ $t("toolbar.show-hostname") }}
-        </a>
-      </li>
+
+      <!-- Only a merged stream mixes containers and hosts in one column, so these
+           two toggles have nowhere else to live. -->
+      <li class="section">{{ $t("toolbar.section-display") }}</li>
       <li>
         <a @click="showContainerName = !showContainerName">
           <mdi:check class="w-4" v-if="showContainerName" />
@@ -85,20 +111,64 @@
           {{ $t("toolbar.show-container-name") }}
         </a>
       </li>
+      <li>
+        <a @click="showHostname = !showHostname">
+          <mdi:check class="w-4" v-if="showHostname" />
+          <div v-else class="w-4"></div>
+          {{ $t("toolbar.show-hostname") }}
+        </a>
+      </li>
+
+      <template v-if="enableDownload">
+        <li class="section">{{ $t("toolbar.section-export") }}</li>
+        <li>
+          <a :href="downloadUrl" download>
+            <octicon:download-24 />
+            {{ isFiltered ? $t("toolbar.download-filtered") : $t("toolbar.download") }}
+          </a>
+        </li>
+      </template>
     </ul>
   </div>
 </template>
 
 <script lang="ts" setup>
+import { allLevels } from "@/composable/logContext";
+
 const { showSearch } = useSearchFilter();
 const { enableDownload } = config;
 const clear = defineEmit();
+const { t } = useI18n();
 
 const { name } = defineProps<{ name?: string }>();
 
 const { streamConfig, showHostname, showContainerName, containers, levels } = useLoggingContext();
 
 const { downloadUrl, isFiltered } = useDownloadUrl(containers, streamConfig, levels, name);
+
+// Collapsed submenus say what they are currently set to, so the menu answers
+// "what am I looking at?" without being opened.
+const streamSummary = computed(() => {
+  if (streamConfig.value.stdout && streamConfig.value.stderr) return t("toolbar.all");
+  if (streamConfig.value.stdout) return "STDOUT";
+  if (streamConfig.value.stderr) return "STDERR";
+  return t("toolbar.none");
+});
+
+const levelSummary = computed(() =>
+  levels.value.size === allLevels.length ? t("toolbar.all") : `${levels.value.size}/${allLevels.length}`,
+);
+
+const toggleAllLevels = computed({
+  get: () => levels.value.size === allLevels.length,
+  set: (value) => {
+    if (value) {
+      allLevels.forEach((level) => levels.value.add(level));
+    } else {
+      levels.value.clear();
+    }
+  },
+});
 
 const hideMenu = (e: MouseEvent) => {
   if (e.target instanceof HTMLAnchorElement) {
@@ -113,11 +183,59 @@ const hideMenu = (e: MouseEvent) => {
 
 <style scoped>
 @reference "@/main.css";
-li.line {
-  @apply bg-base-content/20 h-px;
+
+/* Section headers replace the old hairline dividers: they separate and label at
+ * the same time. The first one has nothing above it to divide from. */
+li.section {
+  @apply text-base-content/40 border-base-content/10 mt-1.5 border-t px-2 pt-2 pb-1 text-[10px] font-semibold tracking-wider uppercase;
 }
 
-a {
+/* daisyUI pads every direct child of a menu li as if it were a clickable row,
+ * which squeezes anything sitting inside these headers down to nothing. */
+li.section > * {
+  @apply p-0;
+}
+
+li.section:first-child {
+  @apply mt-0 border-t-0 pt-1;
+}
+
+a,
+button,
+summary {
   @apply whitespace-nowrap;
+}
+
+/* One icon size for every row, so labels line up on a single text column. */
+.menu > li > :where(a, button, summary) > svg {
+  @apply size-4 shrink-0 opacity-70;
+}
+
+/* The collapsed-state value sits in the trailing grid column daisyUI reserves,
+ * next to (not on top of) the disclosure chevron. */
+.value {
+  @apply text-base-content/40 text-xs tabular-nums;
+}
+
+/* daisyUI's .menu is width: fit-content, so nested submenus (Streams, Levels)
+ * shrink to their content and the hover highlight stops short. Stretch them to
+ * fill the dropdown so the row highlight spans the full width. */
+.menu li ul {
+  margin-inline-start: 0;
+  width: 100%;
+  &:before {
+    display: none;
+  }
+}
+
+/* Keep the solid level colors, but use white labels in the light theme so the
+ * text reads against the saturated chip backgrounds. warn is a light orange,
+ * where dark text has better contrast than white, so it keeps the default. */
+[data-theme="light"] .badge[data-level="info"],
+[data-theme="light"] .badge[data-level="debug"],
+[data-theme="light"] .badge[data-level="trace"],
+[data-theme="light"] .badge[data-level="error"],
+[data-theme="light"] .badge[data-level="fatal"] {
+  color: oklch(100% 0 0) !important;
 }
 </style>

--- a/assets/components/nav/NavItem.vue
+++ b/assets/components/nav/NavItem.vue
@@ -62,6 +62,17 @@ const bindings = computed(() => (to ? { to, activeClass: "is-active" } : { type:
   @apply bg-primary absolute top-1/2 left-0 h-4 w-0.5 -translate-y-1/2 rounded-full;
 }
 
+/* A merged view has no single active row, so every container feeding the stream
+ * carries the active row's marker in the accent colour instead. */
+.nav-item.is-merged {
+  @apply text-secondary bg-secondary/12 font-medium;
+}
+
+.nav-item.is-merged::before {
+  content: "";
+  @apply bg-secondary absolute top-1/2 left-0 h-4 w-0.5 -translate-y-1/2 rounded-full;
+}
+
 .nav-item.is-muted {
   @apply text-base-content/40 pointer-events-none;
 }

--- a/assets/composable/streamedContainers.ts
+++ b/assets/composable/streamedContainers.ts
@@ -1,0 +1,35 @@
+/**
+ * The container ids the main view is currently streaming: one for a container page,
+ * many for a merged one, none anywhere else. Shared by the sidebar, which marks the
+ * rows feeding the stream, and the popup, which adds and removes them.
+ */
+export const useStreamedContainers = () => {
+  const route = useRoute();
+  const router = useRouter();
+
+  const ids = computed(() => {
+    if (route.name === "/merged/[ids]") return String(route.params.ids).split(",");
+    if (route.name === "/container/[id]") return [String(route.params.id)];
+    return [];
+  });
+
+  const isStreaming = (id: string) => ids.value.includes(id);
+
+  // A single container is just the container page, so there is nothing to mark.
+  const isMerged = computed(() => ids.value.length > 1);
+
+  const toggle = (id: string) => {
+    const next = isStreaming(id) ? ids.value.filter((i) => i !== id) : [...ids.value, id];
+
+    // Would leave a merged view with nothing in it.
+    if (next.length === 0) return;
+
+    router.push(
+      next.length === 1
+        ? { name: "/container/[id]", params: { id: next[0] } }
+        : { name: "/merged/[ids]", params: { ids: next.join(",") } },
+    );
+  };
+
+  return { ids, isStreaming, isMerged, toggle };
+};

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Ingen
   section-logs: Logs
   section-filters: Filtre
+  section-display: Visning
   section-export: Eksport
   section-container: Container
   section-image: Image
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Søg containere (⌘ + k, ⌃k)
   pin-column: Fastgør som kolonne
+  unpin-column: Frigør kolonne
+  merge-stream: Flet ind i strømmen
+  merge-stream-hint: Åbn en container for at flette med den
+  unmerge-stream: Fjern fra strømmen
   merge-all: Sammenlæg alt i én stream
   network-io: "Netværk: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Disk: ↑ {write}/s · ↓ {read}/s"

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Keine
   section-logs: Logs
   section-filters: Filter
+  section-display: Anzeige
   section-export: Export
   section-container: Container
   section-image: Image
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Suche Container (⌘ + k, ⌃k)
   pin-column: Als Spalte anheften
+  unpin-column: Spalte lösen
+  merge-stream: In den Stream einfügen
+  merge-stream-hint: Zum Zusammenführen zuerst einen Container öffnen
+  unmerge-stream: Aus dem Stream entfernen
   merge-all: Alles in einen Stream zusammenführen
   network-io: "Netzwerk: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Festplatte: ↑ {write}/s · ↓ {read}/s"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -40,6 +40,7 @@ toolbar:
   none: None
   section-logs: Logs
   section-filters: Filters
+  section-display: Display
   section-export: Export
   section-container: Container
   section-image: Image
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Search containers (⌘ + k, ⌃k)
   pin-column: Pin as column
+  unpin-column: Unpin column
+  merge-stream: Merge into stream
+  merge-stream-hint: Open a container to merge it with
+  unmerge-stream: Remove from stream
   merge-all: Merge all into one stream
   network-io: "Network: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Disk: ↑ {write}/s · ↓ {read}/s"

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Ninguno
   section-logs: Registros
   section-filters: Filtros
+  section-display: Visualización
   section-export: Exportar
   section-container: Contenedor
   section-image: Imagen
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Buscar contenedores (⌘ + K, CTRL + K)
   pin-column: Anclar como columna
+  unpin-column: Desanclar columna
+  merge-stream: Combinar en el flujo
+  merge-stream-hint: Abre un contenedor para combinarlo
+  unmerge-stream: Quitar del flujo
   merge-all: Fusionar todo en un flujo
   network-io: "Red: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Disco: ↑ {write}/s · ↓ {read}/s"

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Aucun
   section-logs: Journaux
   section-filters: Filtres
+  section-display: Affichage
   section-export: Exporter
   section-container: Conteneur
   section-image: Image
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Recherche de conteneurs (⌘ + k, ⌃k)
   pin-column: Epinglé en colonne
+  unpin-column: Détacher la colonne
+  merge-stream: Fusionner dans le flux
+  merge-stream-hint: Ouvrez un conteneur pour fusionner avec lui
+  unmerge-stream: Retirer du flux
   merge-all: Fusionner tout dans un flux
   network-io: "Réseau : ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Disque : ↑ {write}/s · ↓ {read}/s"

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Tidak ada
   section-logs: Log
   section-filters: Filter
+  section-display: Tampilan
   section-export: Ekspor
   section-container: Kontainer
   section-image: Image
@@ -121,6 +122,10 @@ label:
 tooltip:
   search: Cari kontainer (⌘ + k, ⌃k)
   pin-column: Sematkan sebagai kolom
+  unpin-column: Lepas sematan kolom
+  merge-stream: Gabungkan ke aliran
+  merge-stream-hint: Buka kontainer untuk digabungkan
+  unmerge-stream: Hapus dari aliran
   merge-all: Gabungkan semua ke dalam satu aliran
   network-io: "Jaringan: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Disk: ↑ {write}/s · ↓ {read}/s"

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Nessuno
   section-logs: Log
   section-filters: Filtri
+  section-display: Visualizzazione
   section-export: Esporta
   section-container: Container
   section-image: Immagine
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Ricerca container (⌘ + k, ⌃k)
   pin-column: Blocca come colonna
+  unpin-column: Sblocca colonna
+  merge-stream: Unisci al flusso
+  merge-stream-hint: Apri un container per unirlo
+  unmerge-stream: Rimuovi dal flusso
   merge-all: Unisci tutto in un flusso
   network-io: "Rete: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Disco: ↑ {write}/s · ↓ {read}/s"

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -40,6 +40,7 @@ toolbar:
   none: 없음
   section-logs: 로그
   section-filters: 필터
+  section-display: 표시
   section-export: 내보내기
   section-container: 컨테이너
   section-image: 이미지
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: 컨테이너 검색 (⌘ + k, ⌃k)
   pin-column: 열로 고정
+  unpin-column: 열 고정 해제
+  merge-stream: 스트림에 병합
+  merge-stream-hint: 병합하려면 먼저 컨테이너를 여세요
+  unmerge-stream: 스트림에서 제거
   merge-all: 모두 하나의 스트림으로 병합
   network-io: "네트워크: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "디스크: ↑ {write}/s · ↓ {read}/s"

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Geen
   section-logs: Logs
   section-filters: Filters
+  section-display: Weergave
   section-export: Exporteren
   section-container: Container
   section-image: Image
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Zoek containers (⌘ + k, ⌃k)
   pin-column: Vastzetten als kolom
+  unpin-column: Kolom losmaken
+  merge-stream: Samenvoegen met stream
+  merge-stream-hint: Open een container om mee samen te voegen
+  unmerge-stream: Verwijderen uit stream
   merge-all: Voeg alles samen in één stream
   network-io: "Netwerk: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Schijf: ↑ {write}/s · ↓ {read}/s"

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Brak
   section-logs: Logi
   section-filters: Filtry
+  section-display: Wyświetlanie
   section-export: Eksport
   section-container: Kontener
   section-image: Obraz
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Przeszukaj kontenery (⌘ + k, ⌃k)
   pin-column: Przypnij jako kolumna
+  unpin-column: Odepnij kolumnę
+  merge-stream: Scal ze strumieniem
+  merge-stream-hint: Otwórz kontener, aby go scalić
+  unmerge-stream: Usuń ze strumienia
   merge-all: Scal wszystko w jeden strumień
   network-io: "Sieć: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Dysk: ↑ {write}/s · ↓ {read}/s"

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Nenhum
   section-logs: Logs
   section-filters: Filtros
+  section-display: Exibição
   section-export: Exportar
   section-container: Contêiner
   section-image: Imagem
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Pesquisar containers (⌘ + k, ⌃k)
   pin-column: Fixar como coluna
+  unpin-column: Desafixar coluna
+  merge-stream: Mesclar no fluxo
+  merge-stream-hint: Abra um contêiner para mesclar com ele
+  unmerge-stream: Remover do fluxo
   merge-all: Unir tudo em um fluxo
   network-io: "Rede: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Disco: ↑ {write}/s · ↓ {read}/s"

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Нет
   section-logs: Логи
   section-filters: Фильтры
+  section-display: Отображение
   section-export: Экспорт
   section-container: Контейнер
   section-image: Образ
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Поиск контейнеров (⌘ + k, ⌃k)
   pin-column: Закрепить столбец
+  unpin-column: Открепить столбец
+  merge-stream: Объединить с потоком
+  merge-stream-hint: Откройте контейнер, чтобы объединить с ним
+  unmerge-stream: Убрать из потока
   merge-all: Объединить все в один поток
   network-io: "Сеть: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Диск: ↑ {write}/s · ↓ {read}/s"

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -26,6 +26,7 @@ toolbar:
   none: Brez
   section-logs: Dnevniki
   section-filters: Filtri
+  section-display: Prikaz
   section-export: Izvoz
   section-container: Vsebnik
   section-image: Slika
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Iskanje zabojnikov (⌘ + k, ⌃k)
   pin-column: Pripni kot stolpec
+  unpin-column: Odpni stolpec
+  merge-stream: Združi s tokom
+  merge-stream-hint: Odprite vsebnik za združevanje
+  unmerge-stream: Odstrani iz toka
   merge-all: Združi vse v en tok
   network-io: "Omrežje: ↑ {tx}/s · ↓ {rx}/s"
   disk-io: "Disk: ↑ {write}/s · ↓ {read}/s"

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -40,6 +40,7 @@ toolbar:
   none: Hiçbiri
   section-logs: Günlükler
   section-filters: Filtreler
+  section-display: Görünüm
   section-export: Dışa aktar
   section-container: Konteyner
   section-image: İmaj
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: Konteynerlerde ara (⌘ + k, ⌃k)
   pin-column: Sütun olarak sabitle
+  unpin-column: Sütun sabitlemesini kaldır
+  merge-stream: Akışa birleştir
+  merge-stream-hint: Birleştirmek için bir konteyner açın
+  unmerge-stream: Akıştan çıkar
   merge-all: Tümünü tek bir akışta birleştir
   network-io: "Ağ: ↑ {tx}/sn · ↓ {rx}/sn"
   disk-io: "Disk: ↑ {write}/sn · ↓ {read}/sn"

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -40,6 +40,7 @@ toolbar:
   none: 無
   section-logs: 日誌
   section-filters: 篩選
+  section-display: 顯示
   section-export: 匯出
   section-container: 容器
   section-image: 映像
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: 搜尋容器 (⌘ + k, ⌃k)
   pin-column: 釘選為欄位
+  unpin-column: 取消釘選欄位
+  merge-stream: 合併到串流
+  merge-stream-hint: 開啟一個容器以進行合併
+  unmerge-stream: 從串流移除
   merge-all: 將所有內容合併到一個流中
   network-io: "網路：↑ {tx}/s · ↓ {rx}/s"
   disk-io: "磁碟：↑ {write}/s · ↓ {read}/s"

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -40,6 +40,7 @@ toolbar:
   none: 无
   section-logs: 日志
   section-filters: 筛选
+  section-display: 显示
   section-export: 导出
   section-container: 容器
   section-image: 镜像
@@ -119,6 +120,10 @@ label:
 tooltip:
   search: 搜索 (⌘ + k, ⌃k)
   pin-column: 固定为列
+  unpin-column: 取消固定列
+  merge-stream: 合并到日志流
+  merge-stream-hint: 打开一个容器以进行合并
+  unmerge-stream: 从日志流移除
   merge-all: 将所有内容合并到一个流中
   network-io: "网络：↑ {tx}/s · ↓ {rx}/s"
   disk-io: "磁盘：↑ {write}/s · ↓ {read}/s"


### PR DESCRIPTION
The sidebar hover popup was read-only, so acting on a container you were already hovering meant clicking through to it first. It now ends in a row of icon buttons.

### Popup action row

Pin as column, pin to the top of the sidebar, shell, merge, then stop/start and restart pushed to the right. Shell and the container actions respect `enableShell` / `enableActions` like the toolbar does.

The column button that used to appear on hover in the nav row is removed, since the popup carries it and toggles both ways instead of only pinning. Alt+click on the row still works as the shortcut.

### Merging from the sidebar

`/merged/[ids]` already existed, but only the group-level merge-all link ever built a list, so there was no way to merge two arbitrary containers. New `useStreamedContainers` composable derives the ids currently on screen from the route and owns add/remove:

- open a container, hover another, click merge -> two-way merged view
- keep merging to stack more in
- click merge on one already in the stream -> it drops out, and at one id it falls back to the single container view

When nothing is open the button is dimmed with a tooltip saying why, rather than disappearing.

Every row feeding a merged stream is marked in the sidebar with the active row's left bar in the accent color plus a merge glyph, so it is clear what the view is made of.

### Merged view dropdown

Still on the old flat layout with hairline dividers, so it gets what the single container menu got: labeled sections (Logs / Filters / Display / Export), streams and levels as `<details>` submenus with a collapsed summary, and the same scoped styles so the two menus render identically. Level filtering already reached the merged download URL but had no UI here.

### Notes

- Four new locale keys, translated across all 16 files
- `pnpm typecheck` clean, 294 frontend tests pass
- Not visually verified in a browser on my end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DcQCFZSVyeBqvUMUtnTM6a