### PR TITLE
docs: list agent mode before remote hosts

### DIFF
--- a/docs/.vitepress/locales/structure.ts
+++ b/docs/.vitepress/locales/structure.ts
@@ -31,7 +31,7 @@ export const SECTIONS: Section[] = [
         items: ["authentication/simple", "authentication/oauth", "authentication/forward-proxy"],
       },
       { group: "containers", items: ["container-names", "container-groups", "container-links", "app-icons"] },
-      { group: "hosts", items: ["remote-hosts", "agent", "hostname"] },
+      { group: "hosts", items: ["agent", "remote-hosts", "hostname"] },
       { group: "control", items: ["actions", "shell"] },
       { group: "logs", items: ["sql-engine", "log-files-on-disk"] },
       { group: "tools", items: ["dtop", "mcp"] },


### PR DESCRIPTION
Agent mode is the recommended way to connect hosts, so it goes first in the Connecting Hosts group.

Ordering lives once in `structure.ts`, so this covers all five locales. Locale files only map slugs to labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Linq3vJhGBGeczhQt2TmgK