### PR TITLE
feat(logs): redesign the scroll position readout

### DIFF
--- a/assets/components/LogViewer/EventSource.spec.ts
+++ b/assets/components/LogViewer/EventSource.spec.ts
@@ -102,6 +102,9 @@ describe("<ContainerEventSource />", () => {
           [scrollContextKey as symbol]: {
             paused: computed(() => false),
             loading: computed(() => false),
+            progress: ref(1),
+            available: ref(false),
+            currentDate: ref(new Date()),
           },
           [loggingContextKey as symbol]: {
             containers: computed(() => [{ id: "abc", image: "test:v123", host: "localhost" }]),

--- a/assets/components/LogViewer/LogList.vue
+++ b/assets/components/LogViewer/LogList.vue
@@ -18,7 +18,7 @@
 <script lang="ts" setup>
 import { AlertLogEntry, CloudEventLogEntry, type LogEntry, type LogMessage } from "@/models/LogEntry";
 
-const { progress, currentDate } = useScrollContext();
+const { progress, currentDate, available } = useScrollContext();
 
 const { messages } = defineProps<{
   messages: LogEntry<LogMessage>[];
@@ -38,6 +38,10 @@ const permalinkLogId = computed(() => (typeof route.query.logId === "string" ? r
 const list = ref<HTMLElement[]>([]);
 
 let previousDate = new Date();
+// Only a single container has a lifetime to place a log on; merged and grouped
+// views have nothing to measure against, so they say so instead of leaving the
+// readout parked at the default 100%.
+watchEffect(() => (available.value = containers.value.length === 1));
 useIntersectionObserver(
   list,
   (entries) => {

--- a/assets/components/ScrollProgress.vue
+++ b/assets/components/ScrollProgress.vue
@@ -1,102 +1,118 @@
 <template>
-  <transition name="fadeout">
-    <div class="inline-flex flex-col items-end gap-2" ref="root" v-show="!autoHide || show">
-      <div class="relative inline-block">
-        <svg width="100" height="100" viewBox="0 0 100 100" :class="{ indeterminate }">
-          <circle r="44" cx="50" cy="50" class="fill-base-300 stroke-primary" />
-        </svg>
-        <div class="absolute inset-0 flex items-center justify-center font-light">
-          <span class="text-4xl">
-            {{ Math.ceil(progress * 100) }}
-          </span>
-          <span> % </span>
+  <!--
+    Where-am-I-in-time readout for a paused log stream. It floats over the
+    stream, so it reads as a panel in the same family as the toasts and
+    dropdowns (neutral surface, hairline border, backdrop blur) instead of the
+    saturated dial it used to be, and it stays a single short row so it covers
+    one line of logs rather than a block of them.
+  -->
+  <Transition name="scroll-progress">
+    <div
+      v-if="show"
+      class="rounded-box border-base-content/10 bg-base-200 flex items-center gap-2.5 border py-1.5 pr-2.5 pl-3 shadow-md"
+    >
+      <template v-if="available">
+        <RelativeTime :date="date" class="text-base-content/80 text-xs whitespace-nowrap" />
+        <div class="bg-base-content/25 size-1 shrink-0 rounded-full" role="presentation"></div>
+      </template>
+
+      <div class="w-24 shrink-0" role="presentation">
+        <IndeterminateBar v-if="indeterminate" color="primary" />
+        <div v-else class="bg-base-content/15 h-1 overflow-hidden rounded-full">
+          <div class="bg-primary h-full rounded-full" :style="{ width: `${eased * 100}%` }"></div>
         </div>
       </div>
-      <RelativeTime :date="date" class="text-sm whitespace-nowrap" />
+
+      <span v-if="available" class="text-base-content/50 w-8 text-right font-mono text-[0.65rem] tabular-nums">
+        {{ Math.round(eased * 100) }}%
+      </span>
     </div>
-  </transition>
+  </Transition>
 </template>
 
 <script lang="ts" setup>
 const {
   indeterminate = false,
-  autoHide = false,
+  available = true,
+  show = true,
   progress,
   date = new Date(),
 } = defineProps<{
+  /** Draw the sweeping comet instead of a fill: position is unknown right now. */
   indeterminate?: boolean;
-  autoHide?: boolean;
+  /** False when nothing computes a position (merged views), so the readout
+   * drops the date and the percentage rather than showing a stale 100%. */
+  available?: boolean;
+  /** Shown while the user is moving and for a beat afterwards, the way an
+   * overlay scrollbar behaves: an opaque panel sitting over the stream has to
+   * earn its place, so it leaves once nobody is reading it. */
+  show?: boolean;
   progress: number;
   date?: Date;
 }>();
 
-const show = autoResetRef(false, 2000);
+const target = computed(() => Math.min(Math.max(progress, 0), 1));
+const eased = ref(target.value);
 
-watch(
-  () => progress,
-  () => {
-    if (autoHide) {
-      show.value = true;
+// The source position only moves when a new row's timestamp crosses the middle
+// of the view, so it arrives in visible steps. Gliding towards it on an
+// exponential decay (frame-rate independent, and re-aimed rather than
+// restarted when the next step lands mid-flight) is what turns those steps
+// into one continuous motion. The number and the fill both read `eased`, so
+// they can never disagree.
+const reducedMotion = usePreferredReducedMotion();
+let frame = 0;
+
+watch(target, (value) => {
+  if (reducedMotion.value === "reduce") {
+    cancelAnimationFrame(frame);
+    eased.value = value;
+    return;
+  }
+  if (frame) return;
+
+  let last = performance.now();
+  const step = (now: number) => {
+    const delta = now - last;
+    last = now;
+    const remaining = target.value - eased.value;
+    if (Math.abs(remaining) < 0.0005) {
+      eased.value = target.value;
+      frame = 0;
+      return;
     }
-  },
-);
+    eased.value += remaining * (1 - Math.exp(-delta / 90));
+    frame = requestAnimationFrame(step);
+  };
+  frame = requestAnimationFrame(step);
+});
+
+onScopeDispose(() => cancelAnimationFrame(frame));
 </script>
+
 <style scoped>
-svg {
-  filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 0.2));
-  margin-top: 5px;
-  &.indeterminate {
-    animation: 2s linear infinite svg-animation;
-
-    circle {
-      animation: 1.4s ease-in-out infinite both circle-animation;
-    }
-  }
-  circle {
-    fill-opacity: 0.75;
-    transition: stroke-dashoffset 250ms ease-out;
-    transform: rotate(-90deg);
-    transform-origin: 50% 50%;
-    stroke-dashoffset: calc(276.32px - v-bind(progress) * 276.32px);
-    stroke-dasharray: 276.32px 276.32px;
-    stroke-linecap: round;
-    stroke-width: 3;
-    will-change: stroke-dashoffset;
-  }
+.scroll-progress-enter-active,
+.scroll-progress-leave-active {
+  transition:
+    opacity 200ms ease-out,
+    transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-@keyframes svg-animation {
-  0% {
-    transform: rotateZ(0deg);
-  }
-  100% {
-    transform: rotateZ(360deg);
-  }
-}
-
-@keyframes circle-animation {
-  0%,
-  25% {
-    stroke-dashoffset: 275px;
-    transform: rotate(0);
-  }
-  50%,
-  75% {
-    stroke-dashoffset: 70px;
-    transform: rotate(45deg);
-  }
-
-  100% {
-    stroke-dashoffset: 275px;
-    transform: rotate(360deg);
-  }
-}
-
-.fadeout-leave-active {
-  @apply transition-opacity duration-400;
-}
-
-.fadeout-leave-to {
+.scroll-progress-enter-from,
+.scroll-progress-leave-to {
   opacity: 0;
+  transform: translateY(-0.5rem);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-progress-enter-active,
+  .scroll-progress-leave-active {
+    transition: opacity 200ms ease-out;
+  }
+
+  .scroll-progress-enter-from,
+  .scroll-progress-leave-to {
+    transform: none;
+  }
 }
 </style>

--- a/assets/components/ScrollableView.vue
+++ b/assets/components/ScrollableView.vue
@@ -2,23 +2,33 @@
   <section :class="{ 'h-screen min-h-0': scrollable }" class="flex flex-col">
     <header
       v-if="$slots.header"
+      ref="scrollableHeader"
       data-testid="scrollable-header"
       class="border-base-content/10 bg-base-200 sticky top-[var(--mobile-nav-offset)] z-20 border-b py-0.5 shadow-[1px_1px_2px_0_rgb(0,0,0,0.05)] md:top-0 md:py-2"
     >
       <slot name="header"></slot>
     </header>
-    <main :data-scrolling="scrollable ? true : undefined" class="min-h-[300px] snap-y overflow-auto">
-      <div class="invisible relative md:visible" v-show="scrollContext.paused">
-        <div class="absolute top-4 right-44">
-          <ScrollProgress
-            :indeterminate="loadingMore"
-            :auto-hide="!loadingMore"
-            :progress="scrollContext.progress"
-            :date="scrollContext.currentDate"
-            class="fixed! z-10 min-w-40"
-          />
-        </div>
-      </div>
+    <!-- Fixed and centred on the measured log column: `main` is only the
+         scroller when `scrollable` is set, so sticky would fail on the pages
+         where the document scrolls instead, and a split pane means the column
+         is not the window either. -->
+    <div
+      class="pointer-events-none fixed z-20 flex -translate-x-1/2 justify-center max-md:hidden"
+      :style="readoutStyle"
+    >
+      <ScrollProgress
+        :indeterminate="loadingMore"
+        :show="scrollContext.paused && (isScrolling || loadingMore) && (scrollContext.available || loadingMore)"
+        :available="scrollContext.available"
+        :progress="scrollContext.progress"
+        :date="scrollContext.currentDate"
+      />
+    </div>
+    <main
+      ref="scrollableMain"
+      :data-scrolling="scrollable ? true : undefined"
+      class="min-h-[300px] snap-y overflow-auto"
+    >
       <div ref="scrollableContent">
         <slot></slot>
       </div>
@@ -47,6 +57,26 @@ const { scrollable = false } = defineProps<{ scrollable?: boolean }>();
 const hasMore = ref(false);
 const scrollObserver = ref<HTMLElement>();
 const scrollableContent = ref<HTMLElement>();
+const scrollableMain = ref<HTMLElement>();
+const scrollableHeader = ref<HTMLElement>();
+
+// Overlay-scrollbar behaviour: the readout is at full strength while the user
+// is moving and settles back to a dim hint a moment after they stop, so a
+// paused stream is never left without its position but reading it is never
+// fought either. Both scrollers are watched because only one of them moves,
+// depending on whether this view owns its scrolling.
+const { isScrolling: isScrollingMain } = useScroll(scrollableMain, { idle: 1200 });
+const { isScrolling: isScrollingWindow } = useScroll(window, { idle: 1200 });
+const isScrolling = computed(() => isScrollingMain.value || isScrollingWindow.value);
+
+const mainBounds = useElementBounding(scrollableMain);
+const headerBounds = useElementBounding(scrollableHeader);
+const readoutStyle = computed(() => ({
+  left: `${mainBounds.left.value + mainBounds.width.value / 2}px`,
+  // The header is sticky, so its bottom edge is where the logs actually start
+  // once the page has scrolled past the top of the column.
+  top: `${Math.max(headerBounds.bottom.value, mainBounds.top.value) + 8}px`,
+}));
 
 const scrollContext = provideScrollContext();
 

--- a/assets/composable/scrollContext.ts
+++ b/assets/composable/scrollContext.ts
@@ -1,6 +1,10 @@
 type ScrollContext = {
   paused: boolean;
   progress: number;
+  /** Whether anything actually computes `progress`. Only a single-container
+   * view can place a log on its container's lifetime, so merged, stack, host
+   * and group views leave this false and the readout hides the position. */
+  available: boolean;
   currentDate: Date;
 };
 
@@ -22,6 +26,7 @@ function defaultValue() {
   return reactive({
     paused: false,
     progress: 1,
+    available: false,
     currentDate: new Date(),
   });
 }


### PR DESCRIPTION
The paused log stream was labelled with a 100px dial that covered several rows and put a saturated ring over the logs. It's now a short panel in the same family as the toasts and dropdowns: relative time, a thin track, and the percentage in one row.

### Layout

Fixed and centred on the measured log column. `main` is only the scroller when `scrollable` is set, so sticky positioning fails on the pages where the document scrolls instead, and a split pane means the column isn't the window either. Measuring the column handles all three, and drops the hard-coded `right-44` offset.

### Motion

Position arrives in steps, since it only moves when a new row's timestamp crosses the middle of the view. The fill and the number now both read an eased value that glides towards the target on an exponential decay, re-aimed rather than restarted when the next step lands mid-flight, so the two can't disagree and the motion is continuous. Reduced motion snaps.

The readout shows while you're moving and leaves a beat after you stop, the way an overlay scrollbar behaves, with a real enter transition instead of the pop-in it had.

`loadingMore` reuses `IndeterminateBar` for its track rather than spinning the whole dial.

### Bug fix

Only a single-container view can place a log on a container's lifetime. Merged, stack, host, group and k8s views never compute a position, so they were showing a stale 100% and "a few seconds ago" every time you scrolled up. The scroll context now carries whether a position exists and those views drop the readout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qf7RfGXUgcamq2JVHseQc4

