### PR TITLE
perf(logs): cut the delay before the first log lines paint

### DIFF
--- a/assets/components/LogViewer/__snapshots__/EventSource.spec.ts.snap
+++ b/assets/components/LogViewer/__snapshots__/EventSource.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`<ContainerEventSource /> > render html correctly > should render dates with 12 hour style 1`] = `
 "<ul data-v-cf9ff940="" class="group pt-4 medium" data-logs="" show-container-name="false">
-  <li data-v-cf9ff940="" id="1560336942709" data-time="1560336942709" class="group/entry">
+  <li data-v-cf9ff940="" id="1560336942509" data-time="1560336942509" class="group/entry">
     <div data-v-cf9ff940="" class="flex min-h-[1px] flex-1 content-center justify-center"><span class="loading loading-bars loading-md text-primary m-2" style="display: none;"></span></div>
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
@@ -54,7 +54,7 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
 
 exports[`<ContainerEventSource /> > render html correctly > should render dates with 24 hour style 1`] = `
 "<ul data-v-cf9ff940="" class="group pt-4 medium" data-logs="" show-container-name="false">
-  <li data-v-cf9ff940="" id="1560336942709" data-time="1560336942709" class="group/entry">
+  <li data-v-cf9ff940="" id="1560336942509" data-time="1560336942509" class="group/entry">
     <div data-v-cf9ff940="" class="flex min-h-[1px] flex-1 content-center justify-center"><span class="loading loading-bars loading-md text-primary m-2" style="display: none;"></span></div>
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
@@ -106,7 +106,7 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
 
 exports[`<ContainerEventSource /> > render html correctly > should render messages 1`] = `
 "<ul data-v-cf9ff940="" class="group pt-4 medium" data-logs="" show-container-name="false">
-  <li data-v-cf9ff940="" id="1560336942709" data-time="1560336942709" class="group/entry">
+  <li data-v-cf9ff940="" id="1560336942509" data-time="1560336942509" class="group/entry">
     <div data-v-cf9ff940="" class="flex min-h-[1px] flex-1 content-center justify-center"><span class="loading loading-bars loading-md text-primary m-2" style="display: none;"></span></div>
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
@@ -160,8 +160,8 @@ exports[`<ContainerEventSource /> > should parse messages 1`] = `
 LoadMoreLogEntry {
   "_message": "",
   "containerID": "",
-  "date": 2019-06-12T10:55:42.709Z,
-  "id": 1560336942709,
+  "date": 2019-06-12T10:55:42.509Z,
+  "id": 1560336942509,
   "level": undefined,
   "loader": [Function],
   "rawMessage": "info",

--- a/assets/composable/eventStreams.ts
+++ b/assets/composable/eventStreams.ts
@@ -78,7 +78,10 @@ export type LogStreamSource = ReturnType<typeof useLogStream>;
 
 function useLogStream(url: Ref<string>, container?: Ref<Container>) {
   const messages: ShallowRef<LogEntry<LogMessage>[]> = shallowRef([]);
-  const buffer: ShallowRef<LogEntry<LogMessage>[]> = shallowRef([]);
+  // A plain array, not a ref: nothing renders the buffer, and rebuilding a new
+  // array per arriving line turned the ~100-line opening burst into O(n^2)
+  // copies right when the view is trying to paint for the first time.
+  let buffer: LogEntry<LogMessage>[] = [];
   const opened = ref(false);
   const loading = ref(true);
   const error = ref(false);
@@ -116,47 +119,68 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
     // Only the first assembly triggers an immediate alert pass; after that the
     // poll owns the cadence, so log volume cannot drive request volume.
     let wasInitial = false;
-    if (messages.value.length + buffer.value.length > config.maxLogs) {
+    // Only merged views need this. A single container's stream already arrives in
+    // order, and sorting it would reorder stdout against stderr, which are separate
+    // pipes the daemon can stamp out of delivery order. With several containers a
+    // batch is genuinely interleaved, and sorting every one of them (not just the
+    // first) is what lets the opening window be short.
+    if (initial || allContainers.value.length > 1) {
+      buffer.sort((a, b) => a.date.getTime() - b.date.getTime());
+    }
+    if (messages.value.length + buffer.length > config.maxLogs) {
       if (scrollingPaused.value === true) {
         if (messages.value.at(-1) instanceof SkippedLogsEntry) {
           const lastEvent = messages.value.at(-1) as SkippedLogsEntry;
-          const lastItem = buffer.value.at(-1) as LogEntry<string | JSONObject>;
-          lastEvent.addSkippedEntries(buffer.value.length, lastItem);
+          const lastItem = buffer.at(-1) as LogEntry<string | JSONObject>;
+          lastEvent.addSkippedEntries(buffer.length, lastItem);
         } else {
-          const firstItem = buffer.value.at(0) as LogEntry<string | JSONObject>;
-          const lastItem = buffer.value.at(-1) as LogEntry<string | JSONObject>;
+          const firstItem = buffer.at(0) as LogEntry<string | JSONObject>;
+          const lastItem = buffer.at(-1) as LogEntry<string | JSONObject>;
           messages.value = [
             ...messages.value,
-            new SkippedLogsEntry(new Date(), buffer.value.length, firstItem, lastItem, loadSkippedLogs),
+            new SkippedLogsEntry(new Date(), buffer.length, firstItem, lastItem, loadSkippedLogs),
           ];
         }
-        buffer.value = [];
+        buffer = [];
       } else {
-        if (buffer.value.length > config.maxLogs / 2) {
-          messages.value = buffer.value.slice(-config.maxLogs / 2);
+        if (buffer.length > config.maxLogs / 2) {
+          messages.value = buffer.slice(-config.maxLogs / 2);
         } else {
-          messages.value = [...messages.value, ...buffer.value].slice(-config.maxLogs);
+          messages.value = [...messages.value, ...buffer].slice(-config.maxLogs);
         }
-        buffer.value = [];
+        buffer = [];
       }
     } else {
       if (initial) {
         wasInitial = true;
-        // sort the buffer the very first time because of multiple logs in parallel
-        buffer.value.sort((a, b) => a.date.getTime() - b.date.getTime());
-
         if (container || containers.value.length > 0) {
           const loadMoreItem = new LoadMoreLogEntry(new Date(), loadOlderLogs);
           messages.value = [loadMoreItem];
         }
         initial = false;
       }
-      messages.value = [...messages.value, ...buffer.value];
-      buffer.value = [];
+      messages.value = [...messages.value, ...buffer];
+      buffer = [];
     }
     if (wasInitial) decorateWithAlerts();
   }
-  const flushBuffer = debounce(flushNow, 250, { maxWait: 1000 });
+
+  // Two cadences. Steady state batches hard so a chatty container can't drive a
+  // render per line. The opening burst gets a much tighter window instead: the
+  // skeleton stays up until the first flush, so the 250ms/1000ms pair spent up
+  // to a full second showing nothing on a view whose logs had already arrived.
+  const initialFlush = debounce(flushNow, 50, { maxWait: 150 });
+  const steadyFlush = debounce(flushNow, 250, { maxWait: 1000 });
+  const flushBuffer = Object.assign(() => (initial ? initialFlush() : steadyFlush()), {
+    cancel: () => {
+      initialFlush.cancel();
+      steadyFlush.cancel();
+    },
+    flush: () => {
+      initialFlush.flush();
+      steadyFlush.flush();
+    },
+  });
   let es: EventSource | null = null;
 
   function close() {
@@ -169,7 +193,7 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
   function clearMessages() {
     flushBuffer.cancel();
     messages.value = [];
-    buffer.value = [];
+    buffer = [];
   }
 
   const urlWithParams = computed(() => withBase(`${url.value}?${params.value.toString()}`));
@@ -196,7 +220,7 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
         event.name,
       );
 
-      buffer.value = [...buffer.value, containerEvent];
+      buffer.push(containerEvent);
       flushBuffer();
       flushBuffer.flush();
     });
@@ -226,7 +250,7 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
 
     es.onmessage = (e) => {
       if (e.data) {
-        buffer.value = [...buffer.value, parseMessage(e.data)];
+        buffer.push(parseMessage(e.data));
         flushBuffer();
       }
     };

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -286,7 +286,7 @@ func (h *handler) streamContainerLogs(w http.ResponseWriter, r *http.Request) {
 
 	h.streamLogsForContainers(w, r, func(container *container.Container) bool {
 		return container.ID == id && container.Host == hostKey(r)
-	})
+	}, hostKey(r))
 }
 
 func (h *handler) streamLogsMerged(w http.ResponseWriter, r *http.Request) {
@@ -297,7 +297,7 @@ func (h *handler) streamLogsMerged(w http.ResponseWriter, r *http.Request) {
 
 	h.streamLogsForContainers(w, r, func(container *container.Container) bool {
 		return ids[container.ID] && container.Host == hostKey(r)
-	})
+	}, hostKey(r))
 }
 
 func (h *handler) streamLogsWithLabels(w http.ResponseWriter, r *http.Request) {
@@ -328,7 +328,7 @@ func (h *handler) streamLogsWithLabels(w http.ResponseWriter, r *http.Request) {
 		}
 
 		return len(labelFilters) > 0
-	})
+	}, "")
 }
 
 func (h *handler) streamGroupedLogs(w http.ResponseWriter, r *http.Request) {
@@ -336,7 +336,7 @@ func (h *handler) streamGroupedLogs(w http.ResponseWriter, r *http.Request) {
 
 	h.streamLogsForContainers(w, r, func(container *container.Container) bool {
 		return container.State == "running" && container.Group == group
-	})
+	}, "")
 }
 
 func (h *handler) streamHostGroupLogs(w http.ResponseWriter, r *http.Request) {
@@ -356,17 +356,21 @@ func (h *handler) streamHostGroupLogs(w http.ResponseWriter, r *http.Request) {
 	h.streamLogsForContainers(w, r, func(c *container.Container) bool {
 		_, ok := hostIDs[c.Host]
 		return c.State == "running" && ok
-	})
+	}, "")
 }
 
 func (h *handler) streamHostLogs(w http.ResponseWriter, r *http.Request) {
 	host := hostKey(r)
 	h.streamLogsForContainers(w, r, func(container *container.Container) bool {
 		return container.State == "running" && container.Host == host
-	})
+	}, host)
 }
 
-func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request, containerFilter container_support.ContainerFilter) {
+// hostScope, when non-empty, names the single host every container this stream
+// can match lives on. Listing just that host skips the fleet-wide fan-out, which
+// re-dials every unreachable agent at up to --timeout each before the first log
+// line can be read. Streams that legitimately span hosts pass "".
+func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request, containerFilter container_support.ContainerFilter, hostScope string) {
 	stdTypes := parseStdTypes(r)
 	if stdTypes == 0 {
 		http.Error(w, "stdout or stderr is required", http.StatusBadRequest)
@@ -383,9 +387,23 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 
 	userLabels := h.resolveLabels(r)
 
-	existingContainers, errs := h.hostService.ListAllContainersFiltered(userLabels, containerFilter)
-	if len(errs) > 0 {
-		log.Warn().Err(errs[0]).Msg("error while listing containers")
+	var existingContainers []container.Container
+	if hostScope != "" {
+		hostContainers, err := h.hostService.ListContainersForHost(hostScope, userLabels)
+		if err != nil {
+			log.Warn().Err(err).Str("host", hostScope).Msg("error while listing containers")
+		}
+		for _, c := range hostContainers {
+			if containerFilter(&c) {
+				existingContainers = append(existingContainers, c)
+			}
+		}
+	} else {
+		var errs []error
+		existingContainers, errs = h.hostService.ListAllContainersFiltered(userLabels, containerFilter)
+		if len(errs) > 0 {
+			log.Warn().Err(errs[0]).Msg("error while listing containers")
+		}
 	}
 
 	absoluteTime := time.Time{}


### PR DESCRIPTION
The log view spent most of its startup showing a skeleton over data it already had. Two independent causes, one on each side.

## Frontend

The buffer flushed on `debounce(250, maxWait: 1000)`. Nothing renders until the first flush, and the backend's opening `Tail: 100` burst keeps resetting the 250ms timer, so first paint landed at 250ms best case and 1000ms typically. The opening burst now uses a 50/150 window, and only steady state keeps 250/1000 so a chatty container still can't drive a render per line.

Rebuilding the buffer array per arriving line (`buffer.value = [...buffer.value, msg]`) also made that 100-line burst O(n^2) in copies, right when the view was trying to paint. Nothing renders the buffer, so it's a plain array now.

Merged views sort every batch rather than only the first. That's what lets the opening window be short without shrinking the span that corrects interleaving. Single-container views keep sorting only the initial batch, since their stream already arrives in order and sorting it would reorder stdout against stderr.

## Backend

Opening any log stream called `ListAllContainersFiltered`, which goes through `RetryAndList` and re-dials every unreachable agent at up to `--timeout` (10s by default) before a single line could be read. `multi_host_service.go` already warns against exactly this on per-container lookups.

Single-container, merged and single-host streams now name their host and list only it. Label, group and host-group streams still fan out, since they really do span hosts.

## Effect

Roughly 200-900ms off first paint everywhere, plus seconds off multi-host setups with a flaky agent.

## Not covered

On a cold page load the log stream is still serialized behind `/api/events/stream`: `pages/container/[id].vue` gates `ContainerLog` on `currentContainer`, and the stream URL needs `container.host`, which only arrives with `containers-changed`. Fixing that needs a host-less route so the log stream can open in parallel with the store. Left for a separate PR.

## Testing

`pnpm test` (294 pass), `pnpm typecheck`, `go test ./...`. The snapshot diff is the load-more row's timestamp moving 250ms to 50ms under fake timers, which is the debounce change itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6meMHib31vma4XTmgHjEr
