### PR TITLE
fix(logs): apply field toggles in service views

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -424,6 +424,7 @@ declare global {
   const useWindowFocus: typeof import('@vueuse/core').useWindowFocus
   const useWindowScroll: typeof import('@vueuse/core').useWindowScroll
   const useWindowSize: typeof import('@vueuse/core').useWindowSize
+  const visibleKeysForContainer: typeof import('./composable/storage').visibleKeysForContainer
   const watch: typeof import('vue').watch
   const watchArray: typeof import('@vueuse/core').watchArray
   const watchAtMost: typeof import('@vueuse/core').watchAtMost
@@ -474,6 +475,9 @@ declare global {
   // @ts-ignore
   export type { TemplateEditorOptions, TemplateVariable, PayloadMode } from './composable/templateEditor'
   import('./composable/templateEditor')
+  // @ts-ignore
+  export type { VisibleKeysSource } from './composable/visible'
+  import('./composable/visible')
   // @ts-ignore
   export type { Config, Profile } from './stores/config'
   import('./stores/config')
@@ -902,6 +906,7 @@ declare module 'vue' {
     readonly useWindowFocus: UnwrapRef<typeof import('@vueuse/core')['useWindowFocus']>
     readonly useWindowScroll: UnwrapRef<typeof import('@vueuse/core')['useWindowScroll']>
     readonly useWindowSize: UnwrapRef<typeof import('@vueuse/core')['useWindowSize']>
+    readonly visibleKeysForContainer: UnwrapRef<typeof import('./composable/storage')['visibleKeysForContainer']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>
     readonly watchArray: UnwrapRef<typeof import('@vueuse/core')['watchArray']>
     readonly watchAtMost: UnwrapRef<typeof import('@vueuse/core')['watchAtMost']>

--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -416,6 +416,7 @@ declare global {
   const useVibrate: typeof import('@vueuse/core').useVibrate
   const useVirtualList: typeof import('@vueuse/core').useVirtualList
   const useVisibleFilter: typeof import('./composable/visible').useVisibleFilter
+  const useVisibleKeysByContainer: typeof import('./composable/visible').useVisibleKeysByContainer
   const useWakeLock: typeof import('@vueuse/core').useWakeLock
   const useWebNotification: typeof import('@vueuse/core').useWebNotification
   const useWebSocket: typeof import('@vueuse/core').useWebSocket
@@ -898,6 +899,7 @@ declare module 'vue' {
     readonly useVibrate: UnwrapRef<typeof import('@vueuse/core')['useVibrate']>
     readonly useVirtualList: UnwrapRef<typeof import('@vueuse/core')['useVirtualList']>
     readonly useVisibleFilter: UnwrapRef<typeof import('./composable/visible')['useVisibleFilter']>
+    readonly useVisibleKeysByContainer: UnwrapRef<typeof import('./composable/visible')['useVisibleKeysByContainer']>
     readonly useWakeLock: UnwrapRef<typeof import('@vueuse/core')['useWakeLock']>
     readonly useWebNotification: UnwrapRef<typeof import('@vueuse/core')['useWebNotification']>
     readonly useWebSocket: UnwrapRef<typeof import('@vueuse/core')['useWebSocket']>

--- a/assets/components/FuzzySearchModal.spec.ts
+++ b/assets/components/FuzzySearchModal.spec.ts
@@ -34,7 +34,7 @@ function createFuzzySearchModal() {
               containers: [
                 new Container(
                   "123",
-                  new Date(),
+                  new Date("2026-01-03T00:00:00Z"),
                   new Date(),
                   new Date(),
                   "image",
@@ -49,7 +49,7 @@ function createFuzzySearchModal() {
                 ),
                 new Container(
                   "345",
-                  new Date(),
+                  new Date("2026-01-02T00:00:00Z"),
                   new Date(),
                   new Date(),
                   "image",
@@ -64,7 +64,7 @@ function createFuzzySearchModal() {
                 ),
                 new Container(
                   "567",
-                  new Date(),
+                  new Date("2026-01-01T00:00:00Z"),
                   new Date(),
                   new Date(),
                   "image",

--- a/assets/components/GroupedViewer/GroupedLog.vue
+++ b/assets/components/GroupedViewer/GroupedLog.vue
@@ -10,12 +10,7 @@
       </div>
     </template>
     <template #default>
-      <ViewerWithSource
-        ref="viewer"
-        :stream-source="useGroupedStream"
-        :entity="group"
-        :visible-keys="new Map<string[], boolean>()"
-      />
+      <ViewerWithSource ref="viewer" :stream-source="useGroupedStream" :entity="group" :visible-keys="visibleKeys" />
     </template>
   </ScrollableView>
 </template>
@@ -44,4 +39,5 @@ provideLoggingContext(
   toRef(() => group.value.containers),
   { showContainerName: true, showHostname: false },
 );
+const visibleKeys = useVisibleKeysByContainer();
 </script>

--- a/assets/components/HostViewer/HostGroupLog.vue
+++ b/assets/components/HostViewer/HostGroupLog.vue
@@ -50,7 +50,7 @@ const { containersByHost } = storeToRefs(store);
 
 const groupHosts = computed(() => Object.values(hosts.value).filter((h) => h.group === name));
 const groupRef = computed(() => ({ name }));
-const visibleKeys = new Map<string[], boolean>();
+const visibleKeys = useVisibleKeysByContainer();
 
 const containers = computed(() =>
   groupHosts.value.flatMap((h) => containersByHost.value?.[h.id]?.filter((c) => c.state === "running") ?? []),

--- a/assets/components/HostViewer/HostLog.vue
+++ b/assets/components/HostViewer/HostLog.vue
@@ -16,12 +16,7 @@
       </div>
     </template>
     <template #default>
-      <ViewerWithSource
-        ref="viewer"
-        :stream-source="useHostStream"
-        :entity="host"
-        :visible-keys="new Map<string[], boolean>()"
-      />
+      <ViewerWithSource ref="viewer" :stream-source="useHostStream" :entity="host" :visible-keys="visibleKeys" />
     </template>
   </ScrollableView>
 </template>
@@ -40,4 +35,5 @@ const host = computed(() => hosts.value[id]);
 const containers = computed(() => containersByHost.value?.[id]?.filter((c) => c.state === "running") ?? []);
 const viewer = useTemplateRef<ComponentExposed<typeof ViewerWithSource>>("viewer");
 provideLoggingContext(containers, { showContainerName: true, showHostname: false });
+const visibleKeys = useVisibleKeysByContainer();
 </script>

--- a/assets/components/K8sViewer/NamespaceLog.vue
+++ b/assets/components/K8sViewer/NamespaceLog.vue
@@ -18,7 +18,7 @@
         ref="viewer"
         :stream-source="useNamespaceStream"
         :entity="namespace"
-        :visible-keys="new Map<string[], boolean>()"
+        :visible-keys="visibleKeys"
       />
     </template>
   </ScrollableView>
@@ -40,4 +40,5 @@ provideLoggingContext(
   toRef(() => namespace.containers),
   { showContainerName: true, showHostname: false },
 );
+const visibleKeys = useVisibleKeysByContainer();
 </script>

--- a/assets/components/K8sViewer/OwnerLog.vue
+++ b/assets/components/K8sViewer/OwnerLog.vue
@@ -14,12 +14,7 @@
       </div>
     </template>
     <template #default>
-      <ViewerWithSource
-        ref="viewer"
-        :stream-source="useOwnerStream"
-        :entity="owner"
-        :visible-keys="new Map<string[], boolean>()"
-      />
+      <ViewerWithSource ref="viewer" :stream-source="useOwnerStream" :entity="owner" :visible-keys="visibleKeys" />
     </template>
   </ScrollableView>
 </template>
@@ -40,4 +35,5 @@ provideLoggingContext(
   toRef(() => owner.containers),
   { showContainerName: true, showHostname: false },
 );
+const visibleKeys = useVisibleKeysByContainer();
 </script>

--- a/assets/components/LogViewer/LogViewer.vue
+++ b/assets/components/LogViewer/LogViewer.vue
@@ -3,11 +3,12 @@
 </template>
 
 <script lang="ts" setup>
-import { type JSONObject, LogEntry } from "@/models/LogEntry";
+import { type LogMessage, LogEntry } from "@/models/LogEntry";
+import type { VisibleKeysSource } from "@/composable/visible";
 
 const props = defineProps<{
-  messages: LogEntry<string | string[] | JSONObject>[];
-  visibleKeys: Map<string[], boolean>;
+  messages: LogEntry<LogMessage>[];
+  visibleKeys: VisibleKeysSource;
 }>();
 
 const { messages, visibleKeys } = toRefs(props);

--- a/assets/components/LogViewer/ViewerWithSource.vue
+++ b/assets/components/LogViewer/ViewerWithSource.vue
@@ -7,11 +7,12 @@
 <script lang="ts" setup generic="T">
 import EventSource from "@/components/LogViewer/EventSource.vue";
 import { LogStreamSource } from "@/composable/eventStreams";
+import type { VisibleKeysSource } from "@/composable/visible";
 import { ComponentExposed } from "vue-component-type-helpers";
 
 const { streamSource, visibleKeys, entity } = defineProps<{
   streamSource: (t: Ref<T>) => LogStreamSource;
-  visibleKeys: Map<string[], boolean>;
+  visibleKeys: VisibleKeysSource;
   entity: T;
 }>();
 

--- a/assets/components/MultiContainerViewer/MultiContainerLog.vue
+++ b/assets/components/MultiContainerViewer/MultiContainerLog.vue
@@ -13,7 +13,7 @@
         ref="viewer"
         :stream-source="useMergedStream"
         :entity="containers"
-        :visible-keys="new Map<string[], boolean>()"
+        :visible-keys="visibleKeys"
       />
     </template>
   </ScrollableView>
@@ -34,4 +34,5 @@ const { allContainersById, ready } = storeToRefs(containerStore);
 const containers = computed(() => ids.map((id) => allContainersById.value[id]));
 
 provideLoggingContext(containers, { showContainerName: true, showHostname: false });
+const visibleKeys = useVisibleKeysByContainer();
 </script>

--- a/assets/components/ServiceViewer/ServiceLog.spec.ts
+++ b/assets/components/ServiceViewer/ServiceLog.spec.ts
@@ -1,0 +1,160 @@
+/** @vitest-environment jsdom */
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { describe, expect, test, vi } from "vitest";
+import { defineComponent, h, nextTick, provide, shallowRef, Suspense, type Ref } from "vue";
+import { createI18n } from "vue-i18n";
+import { Container } from "@/models/Container";
+import { ComplexLogEntry } from "@/models/LogEntry";
+import { drawerContext } from "@/composable/drawer";
+import { useContainerStore } from "@/stores/container";
+import ComplexLogItem from "@/components/LogViewer/ComplexLogItem.vue";
+import LogDetails from "@/components/LogViewer/LogDetails.vue";
+import ServiceLog from "./ServiceLog.vue";
+
+vi.mock("@/stores/config", () => ({
+  default: { base: "", mode: "swarm", hosts: [{ id: "host", name: "test host" }] },
+  withBase: (path: string) => path,
+}));
+
+vi.mock("@/stores/container", async () => {
+  const { defineStore } = await import("pinia");
+  const { shallowRef, computed } = await import("vue");
+  return {
+    useContainerStore: defineStore("service-log-test-containers", () => {
+      const containers = shallowRef<Container[]>([]);
+      const findContainerById = (id: string) => containers.value.find((container) => container.id === id);
+      const currentContainer = (id: Ref<string>) => computed(() => findContainerById(id.value));
+      return { containers, findContainerById, currentContainer };
+    }),
+  };
+});
+
+function container(id: string, image: string, command: string) {
+  return new Container(
+    id,
+    new Date(),
+    new Date(),
+    new Date(),
+    image,
+    id,
+    command,
+    "host",
+    { "com.docker.swarm.service.name": "service" },
+    "running",
+    0,
+    0,
+    [],
+  );
+}
+
+function entry(id: string, sequence: number) {
+  const payload = { message: id, secret: "hidden candidate", nested: { debug: "details" } };
+  return new ComplexLogEntry(payload, id, sequence, new Date(), "info", "stdout", JSON.stringify(payload));
+}
+
+describe("service log field settings", () => {
+  test("applies drawer toggles per source and preserves shared replica settings", async () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const store = useContainerStore();
+    store.containers = [
+      container("a", "fixture/shared:1", "/app"),
+      container("b", "fixture/shared:2", "/app"),
+      container("c", "fixture/other:1", "/other"),
+    ];
+    const messages = shallowRef([entry("a", 1), entry("b", 2), entry("c", 3)]);
+    const selected = shallowRef<ComplexLogEntry | null>(null);
+    const Root = defineComponent({
+      setup() {
+        provide(drawerContext, (_component, props) => {
+          selected.value = props.entry;
+        });
+        return () =>
+          h("div", [
+            h(ServiceLog, { name: "service" }),
+            h(Suspense, null, {
+              default: () =>
+                selected.value ? h(LogDetails, { entry: selected.value, key: selected.value.id }) : h("div"),
+            }),
+          ]);
+      },
+    });
+    const wrapper = mount(Root, {
+      global: {
+        plugins: [
+          pinia,
+          createI18n({ legacy: false, locale: "en", messages: { en: {} }, missingWarn: false, fallbackWarn: false }),
+        ],
+        stubs: {
+          ScrollableView: { template: "<section><slot /></section>" },
+          EventSource: defineComponent({
+            props: ["streamSource", "entity"],
+            setup(_props, { slots }) {
+              return () => slots.default?.({ messages: messages.value });
+            },
+          }),
+          LogList: defineComponent({
+            props: ["messages"],
+            setup(props) {
+              return () =>
+                h(
+                  "section",
+                  { "data-testid": "service-lines" },
+                  props.messages.map((log: ComplexLogEntry) =>
+                    h("article", { "data-container": log.containerID, key: log.id }, [
+                      h(ComplexLogItem, { logEntry: log }),
+                    ]),
+                  ),
+                );
+            },
+          }),
+          LogItem: { template: "<div><slot /></div>" },
+          LogLevel: true,
+          DateTime: true,
+          RelativeTime: true,
+          JsonFormatted: true,
+        },
+      },
+    });
+    const line = (id: string) => wrapper.find(`[data-container="${id}"]`);
+    const toggle = async (id: string, key: string) => {
+      await line(id).find(".cursor-pointer").trigger("click");
+      await flushPromises();
+      await vi.waitFor(() => expect(wrapper.find("tbody .field-row").exists()).toBe(true));
+      const row = wrapper.findAll("tbody .field-row").find((row) => row.find("td span").text() === key);
+      expect(row, `field ${key}`).toBeDefined();
+      await row!.find("input").setValue(false);
+      await nextTick();
+    };
+    try {
+      expect(line("c").text()).toContain("secret=");
+      await toggle("c", "secret");
+      expect(line("c").text()).not.toContain("secret=");
+      expect(line("a").text()).toContain("secret=");
+      expect(line("b").text()).toContain("secret=");
+
+      await toggle("a", "nested.debug");
+      expect(line("a").text()).not.toContain("nested.debug=");
+      expect(line("b").text()).not.toContain("nested.debug=");
+      expect(line("c").text()).toContain("nested.debug=");
+      expect(line("c").text()).not.toContain("secret=");
+
+      messages.value = [...messages.value, entry("b", 4)];
+      await nextTick();
+      expect(wrapper.findAll('[data-container="b"]')).toHaveLength(2);
+      for (const row of wrapper.findAll('[data-container="b"]')) {
+        expect(row.text()).not.toContain("nested.debug=");
+      }
+
+      messages.value = [...messages.value, entry("missing", 5)];
+      await nextTick();
+      expect(line("missing").text()).toContain("secret=");
+      store.containers = [...store.containers, container("missing", "fixture/other:2", "/other")];
+      await nextTick();
+      expect(line("missing").text()).not.toContain("secret=");
+    } finally {
+      wrapper.unmount();
+    }
+  });
+});

--- a/assets/components/ServiceViewer/ServiceLog.vue
+++ b/assets/components/ServiceViewer/ServiceLog.vue
@@ -9,12 +9,7 @@
       </div>
     </template>
     <template #default>
-      <ViewerWithSource
-        ref="viewer"
-        :stream-source="useServiceStream"
-        :entity="service"
-        :visible-keys="getVisibleKeys"
-      />
+      <ViewerWithSource ref="viewer" :stream-source="useServiceStream" :entity="service" :visible-keys="visibleKeys" />
     </template>
   </ScrollableView>
 </template>
@@ -33,8 +28,7 @@ const viewer = ref<ComponentExposed<typeof ViewerWithSource>>();
 const store = useSwarmStore();
 const { services } = storeToRefs(store) as unknown as { services: Ref<Service[]> };
 const service = computed(() => services.value.find((s) => s.name === name) ?? new Service("", []));
-const { findContainerById } = useContainerStore();
-const getVisibleKeys = (containerID: string) => visibleKeysForContainer(findContainerById(containerID));
+const visibleKeys = useVisibleKeysByContainer();
 
 provideLoggingContext(
   toRef(() => service.value.containers),

--- a/assets/components/ServiceViewer/ServiceLog.vue
+++ b/assets/components/ServiceViewer/ServiceLog.vue
@@ -13,7 +13,7 @@
         ref="viewer"
         :stream-source="useServiceStream"
         :entity="service"
-        :visible-keys="new Map<string[], boolean>()"
+        :visible-keys="getVisibleKeys"
       />
     </template>
   </ScrollableView>
@@ -33,6 +33,8 @@ const viewer = ref<ComponentExposed<typeof ViewerWithSource>>();
 const store = useSwarmStore();
 const { services } = storeToRefs(store) as unknown as { services: Ref<Service[]> };
 const service = computed(() => services.value.find((s) => s.name === name) ?? new Service("", []));
+const { findContainerById } = useContainerStore();
+const getVisibleKeys = (containerID: string) => visibleKeysForContainer(findContainerById(containerID));
 
 provideLoggingContext(
   toRef(() => service.value.containers),

--- a/assets/components/StackViewer/StackLog.vue
+++ b/assets/components/StackViewer/StackLog.vue
@@ -14,12 +14,7 @@
       </div>
     </template>
     <template #default>
-      <ViewerWithSource
-        ref="viewer"
-        :stream-source="useStackStream"
-        :entity="stack"
-        :visible-keys="new Map<string[], boolean>()"
-      />
+      <ViewerWithSource ref="viewer" :stream-source="useStackStream" :entity="stack" :visible-keys="visibleKeys" />
     </template>
   </ScrollableView>
 </template>
@@ -41,4 +36,5 @@ provideLoggingContext(
   toRef(() => stack.value.containers),
   { showContainerName: true, showHostname: false },
 );
+const visibleKeys = useVisibleKeysByContainer();
 </script>

--- a/assets/composable/storage.spec.ts
+++ b/assets/composable/storage.spec.ts
@@ -1,0 +1,53 @@
+/** @vitest-environment jsdom */
+import { describe, expect, test, vi } from "vitest";
+import { shallowRef } from "vue";
+import { Container } from "@/models/Container";
+import { persistentVisibleKeysForContainer, visibleKeysForContainer } from "./storage";
+
+vi.mock("@/stores/config", () => ({
+  __esModule: true,
+  default: { base: "", hosts: [{ name: "localhost", id: "localhost" }] },
+  withBase: (path: string) => path,
+}));
+
+function makeContainer(image: string): Container {
+  return new Container(
+    "id-1",
+    new Date(),
+    new Date(),
+    new Date(),
+    image,
+    "name",
+    "command",
+    "localhost",
+    {},
+    "running",
+    0,
+    0,
+    [],
+  );
+}
+
+describe("persistentVisibleKeysForContainer", () => {
+  test("persists per storage key", () => {
+    const container = shallowRef<Container | undefined>(makeContainer("image-a"));
+    const visibleKeys = persistentVisibleKeysForContainer(container);
+    const keys = new Map([[["secret"], false]]);
+
+    visibleKeys.value = keys;
+
+    expect(visibleKeys.value).toEqual(keys);
+    expect(visibleKeysForContainer(container.value)).toEqual(keys);
+    expect(visibleKeysForContainer(makeContainer("image-b")).size).toBe(0);
+  });
+
+  test("stays usable when the container is gone", () => {
+    // A replica can be destroyed while its log lines are still on screen.
+    const container = shallowRef<Container | undefined>(undefined);
+    const visibleKeys = persistentVisibleKeysForContainer(container);
+
+    expect(visibleKeys.value.size).toBe(0);
+    expect(() => (visibleKeys.value = new Map([[["secret"], false]]))).not.toThrow();
+    expect(visibleKeys.value.size).toBe(0);
+  });
+});

--- a/assets/composable/storage.ts
+++ b/assets/composable/storage.ts
@@ -21,11 +21,18 @@ export function visibleKeysForContainer(container: Container | undefined): Map<s
   return (container && storage.value.get(container.storageKey)) || new Map<string[], boolean>();
 }
 
-export function persistentVisibleKeysForContainer(container: Ref<Container>): Ref<Map<string[], boolean>> {
+export function persistentVisibleKeysForContainer(container: Ref<Container | undefined>): Ref<Map<string[], boolean>> {
   // Computed property to only store to storage when the value changes
   return computed({
     get: () => visibleKeysForContainer(container.value),
-    set: (value: Map<string[], boolean>) => storage.value.set(container.value.storageKey, value),
+    // The container can go away while its log lines are still on screen, e.g. a
+    // replica is destroyed and the stream reconnects. Toggling a field then has
+    // nowhere to persist to, so drop it instead of blowing up the drawer.
+    set: (value: Map<string[], boolean>) => {
+      if (container.value) {
+        storage.value.set(container.value.storageKey, value);
+      }
+    },
   });
 }
 

--- a/assets/composable/storage.ts
+++ b/assets/composable/storage.ts
@@ -17,10 +17,14 @@ const storage = useProfileStorage("visibleKeys", new Map<string, Map<string[], b
     return inner;
   },
 });
+export function visibleKeysForContainer(container: Container | undefined): Map<string[], boolean> {
+  return (container && storage.value.get(container.storageKey)) || new Map<string[], boolean>();
+}
+
 export function persistentVisibleKeysForContainer(container: Ref<Container>): Ref<Map<string[], boolean>> {
   // Computed property to only store to storage when the value changes
   return computed({
-    get: () => storage.value.get(container.value.storageKey) || new Map<string[], boolean>(),
+    get: () => visibleKeysForContainer(container.value),
     set: (value: Map<string[], boolean>) => storage.value.set(container.value.storageKey, value),
   });
 }

--- a/assets/composable/visible.spec.ts
+++ b/assets/composable/visible.spec.ts
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { ref, shallowRef } from "vue";
+import { ComplexLogEntry, SimpleLogEntry, type JSONObject } from "@/models/LogEntry";
+import { useSearchFilter } from "./search";
+import { useVisibleFilter, type VisibleKeysSource } from "./visible";
+
+function entry(container: string, payload: JSONObject) {
+  return new ComplexLogEntry(payload, container, 1, new Date(), "info", "stdout", JSON.stringify(payload));
+}
+
+afterEach(() => useSearchFilter().resetSearch());
+
+describe("visible log fields", () => {
+  test("tracks source-specific map mutations, replacements and new entries", () => {
+    const key = ["secret"];
+    const first = ref(new Map<string[], boolean>());
+    const second = ref(new Map<string[], boolean>());
+    const source = ref<VisibleKeysSource>((id) => (id === "a" ? first.value : second.value));
+    const a = entry("a", { message: "a", secret: "one", nested: { detail: "shown" } });
+    const b = entry("b", { message: "b", secret: "two" });
+    const messages = shallowRef([a, b]);
+    const filtered = useVisibleFilter(source).filteredPayload(messages);
+
+    first.value = new Map([[key, false]]);
+    expect(filtered.value[0].message).toEqual({ message: "a", "nested.detail": "shown" });
+    expect(filtered.value[1].message).toEqual({ message: "b", secret: "two" });
+    expect(a.unfilteredMessage).toEqual({ message: "a", secret: "one", nested: { detail: "shown" } });
+
+    first.value.set(key, true);
+    expect(filtered.value[0].message).toHaveProperty("secret", "one");
+    first.value = new Map([[["secret"], false]]);
+    messages.value = [...messages.value, entry("a", { secret: "three", newField: "visible" })];
+    expect(filtered.value[2].message).toEqual({ newField: "visible" });
+
+    source.value = new Map([[["message"], false]]);
+    expect(filtered.value[0].message).not.toHaveProperty("message");
+    expect(filtered.value[1].message).toEqual({ secret: "two" });
+  });
+
+  test("preserves the existing shared-map mode and non-JSON entries", () => {
+    const fields = ref<VisibleKeysSource>(new Map<string[], boolean>([[["secret"], false]]));
+    const plain = new SimpleLogEntry("plain", "a", 2, new Date(), "info", "stdout", "plain");
+    const filtered = useVisibleFilter(fields).filteredPayload(
+      shallowRef([entry("a", { secret: "hidden", message: "ok" }), plain]),
+    );
+    expect(filtered.value[0].message).toEqual({ message: "ok" });
+    expect(filtered.value[1]).toBe(plain);
+
+    fields.value = new Map([
+      [["secret"], true],
+      [["message"], true],
+    ]);
+    expect(Object.keys(filtered.value[0].message)).toEqual(["secret", "message"]);
+  });
+
+  test("applies search and inverse search after each source's field filtering", async () => {
+    const search = useSearchFilter();
+    search.searchQueryFilter.value = "hit";
+    search.showSearch.value = true;
+    await vi.waitFor(() => expect(search.isSearching.value).toBe(true));
+    const fields = ref(new Map<string[], boolean>([[["match"], false]]));
+    const source = ref<VisibleKeysSource>((id) => (id === "a" ? fields.value : new Map()));
+    const messages = shallowRef([
+      entry("a", { match: "<mark>hit</mark>", message: "a" }),
+      entry("b", { match: "<mark>hit</mark>", message: "b" }),
+    ]);
+    const filtered = useVisibleFilter(source).filteredPayload(messages);
+    expect(filtered.value.map((entry) => entry.containerID)).toEqual(["b"]);
+    search.inverseFilter.value = true;
+    expect(filtered.value.map((entry) => entry.containerID)).toEqual(["a"]);
+    search.inverseFilter.value = false;
+    fields.value = new Map();
+    expect(filtered.value.map((entry) => entry.containerID)).toEqual(["a", "b"]);
+  });
+});

--- a/assets/composable/visible.ts
+++ b/assets/composable/visible.ts
@@ -2,6 +2,15 @@ import { ComplexLogEntry, type LogMessage, type LogEntry } from "@/models/LogEnt
 
 export type VisibleKeysSource = Map<string[], boolean> | ((containerID: string) => Map<string[], boolean>);
 
+/**
+ * Visible keys for multi-container viewers. Each log line resolves its own container so
+ * field toggles made on a single container view carry over here.
+ */
+export function useVisibleKeysByContainer(): (containerID: string) => Map<string[], boolean> {
+  const { findContainerById } = useContainerStore();
+  return (containerID: string) => visibleKeysForContainer(findContainerById(containerID));
+}
+
 export function useVisibleFilter(visibleKeys: Ref<VisibleKeysSource>) {
   const { isSearching, inverseFilter } = useSearchFilter();
   function filteredPayload(messages: Ref<LogEntry<LogMessage>[]>) {

--- a/assets/composable/visible.ts
+++ b/assets/composable/visible.ts
@@ -1,13 +1,19 @@
 import { ComplexLogEntry, type LogMessage, type LogEntry } from "@/models/LogEntry";
 
-export function useVisibleFilter(visibleKeys: Ref<Map<string[], boolean>>) {
+export type VisibleKeysSource = Map<string[], boolean> | ((containerID: string) => Map<string[], boolean>);
+
+export function useVisibleFilter(visibleKeys: Ref<VisibleKeysSource>) {
   const { isSearching, inverseFilter } = useSearchFilter();
   function filteredPayload(messages: Ref<LogEntry<LogMessage>[]>) {
     return computed(() => {
       return messages.value
         .map((d) => {
           if (d instanceof ComplexLogEntry) {
-            return ComplexLogEntry.fromLogEvent(d, visibleKeys);
+            const keys = toRef(() => {
+              const source = visibleKeys.value;
+              return typeof source === "function" ? source(d.containerID) : source;
+            });
+            return ComplexLogEntry.fromLogEvent(d, keys);
           } else {
             return d;
           }


### PR DESCRIPTION
Fixes #5036

Service log rows now resolve field settings from their source container instead of an empty map. Replicas with the same image (without tag) and command still share settings. Different images or commands remain independent.

- Regression coverage includes drawer toggles, new messages, late metadata, shared replicas and search.
- Checks: 300 frontend tests, typecheck, production build, Staticcheck and all 17 Go test packages with `-race` as non-root.
- Browser: desktop and mobile passed toggling, source isolation, container-view sharing and persistence after reload, using real Docker logs.
- The browser setup used service-labelled containers in server mode, not a native Swarm cluster.

A separate test-only commit fixes a pre-existing timing-dependent recent-container fixture.
