### PR TITLE
fix(ui): move every menu to the native popover API

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -212,6 +212,7 @@ declare global {
   const useActiveElement: typeof import('@vueuse/core').useActiveElement
   const useAlertForm: typeof import('./composable/alertForm').useAlertForm
   const useAlertMerger: typeof import('./composable/alertMerger').useAlertMerger
+  const useAnchoredPopover: typeof import('./composable/popover').useAnchoredPopover
   const useAnimate: typeof import('@vueuse/core').useAnimate
   const useAnnouncements: typeof import('./stores/announcements').useAnnouncements
   const useArrayDifference: typeof import('@vueuse/core').useArrayDifference
@@ -472,6 +473,9 @@ declare global {
   export type { ImageUpdateStatus, ImageUpdateResult } from './composable/imageUpdate'
   import('./composable/imageUpdate')
   // @ts-ignore
+  export type { PopoverPlacement } from './composable/popover'
+  import('./composable/popover')
+  // @ts-ignore
   export type { TemplateEditorOptions, TemplateVariable, PayloadMode } from './composable/templateEditor'
   import('./composable/templateEditor')
   // @ts-ignore
@@ -690,6 +694,7 @@ declare module 'vue' {
     readonly useActiveElement: UnwrapRef<typeof import('@vueuse/core')['useActiveElement']>
     readonly useAlertForm: UnwrapRef<typeof import('./composable/alertForm')['useAlertForm']>
     readonly useAlertMerger: UnwrapRef<typeof import('./composable/alertMerger')['useAlertMerger']>
+    readonly useAnchoredPopover: UnwrapRef<typeof import('./composable/popover')['useAnchoredPopover']>
     readonly useAnimate: UnwrapRef<typeof import('@vueuse/core')['useAnimate']>
     readonly useAnnouncements: UnwrapRef<typeof import('./stores/announcements')['useAnnouncements']>
     readonly useArrayDifference: UnwrapRef<typeof import('@vueuse/core')['useArrayDifference']>

--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -212,6 +212,7 @@ declare module 'vue' {
     'Ph:mapPinSimpleFill': typeof import('~icons/ph/map-pin-simple-fill')['default']
     'Ph:stack': typeof import('~icons/ph/stack')['default']
     'Ph:stackSimple': typeof import('~icons/ph/stack-simple')['default']
+    Popover: typeof import('./components/common/Popover.vue')['default']
     Popup: typeof import('./components/Popup.vue')['default']
     ProBadge: typeof import('./components/common/ProBadge.vue')['default']
     RandomColorTag: typeof import('./components/LogViewer/RandomColorTag.vue')['default']

--- a/assets/components/Announcements.vue
+++ b/assets/components/Announcements.vue
@@ -1,7 +1,7 @@
 <template>
   <Dropdown
-    class="dropdown-end"
-    @click="config.releaseCheckMode === 'manual' && fetchReleases()"
+    placement="bottom-end"
+    @opened="config.releaseCheckMode === 'manual' && fetchReleases()"
     @closed="releaseSeen = mostRecent?.tag ?? config.version"
   >
     <template #trigger>

--- a/assets/components/CloudPopover.vue
+++ b/assets/components/CloudPopover.vue
@@ -1,5 +1,5 @@
 <template>
-  <Dropdown class="dropdown-end" @click="onOpen">
+  <Dropdown placement="bottom-end" @opened="onOpen">
     <template #trigger>
       <div class="relative">
         <mdi:cloud

--- a/assets/components/ContainerDropdown.vue
+++ b/assets/components/ContainerDropdown.vue
@@ -1,7 +1,9 @@
 <template>
-  <div class="dropdown">
-    <button tabindex="0" role="button" class="btn btn-xs md:btn-sm"><slot /> <carbon:caret-down /></button>
-    <ul tabindex="0" class="dropdown-content menu rounded-box bg-base-100 border-base-content/20 border shadow-sm">
+  <Popover panel-class="rounded-box bg-base-100 border-base-content/20 border p-1 shadow-sm">
+    <template #trigger>
+      <button type="button" class="btn btn-xs md:btn-sm"><slot /> <carbon:caret-down /></button>
+    </template>
+    <ul class="menu w-full p-0">
       <li v-for="other in containers">
         <router-link :to="{ name: '/container/[id]', params: { id: other.id } }" class="text-nowrap">
           <div
@@ -15,7 +17,7 @@
         </router-link>
       </li>
     </ul>
-  </div>
+  </Popover>
 </template>
 <script lang="ts" setup>
 import { type Container } from "@/models/Container";

--- a/assets/components/ContainerTable.vue
+++ b/assets/components/ContainerTable.vue
@@ -41,7 +41,7 @@
       <div class="text-base-content/50 flex flex-1 items-center justify-end gap-2 text-xs">
         <div class="flex items-center gap-1 md:hidden">
           {{ $t("label.sort-by") }}
-          <DropdownMenu class="dropdown-left btn-xs" v-model="mobileSortField" :options="sortOptions" />
+          <DropdownMenu class="btn-xs" v-model="mobileSortField" :options="sortOptions" />
           <button
             class="btn btn-square btn-ghost btn-xs"
             @click="direction *= -1"
@@ -204,7 +204,7 @@
       </nav>
       <DropdownMenu
         v-else-if="isPaginated"
-        class="dropdown-left btn-xs ml-auto"
+        class="btn-xs ml-auto"
         v-model="currentPage"
         :options="Array.from({ length: totalPages }, (_, i) => ({ label: `${i + 1}`, value: i + 1 }))"
       />

--- a/assets/components/ContainerViewer/ContainerActionsToolbar.vue
+++ b/assets/components/ContainerViewer/ContainerActionsToolbar.vue
@@ -1,22 +1,24 @@
 <template>
-  <div class="dropdown dropdown-end dropdown-hover z-20">
-    <label tabindex="0" class="icon-btn btn btn-ghost btn-sm relative w-8 gap-0 px-0 md:gap-0.5">
-      <carbon:circle-solid class="text-red w-2 md:w-2.5" v-if="streamConfig.stderr" />
-      <carbon:circle-solid class="text-blue w-2 md:w-2.5" v-if="streamConfig.stdout" />
-      <span
-        v-if="showImageUpdateAlert"
-        class="absolute end-0.5 top-0.5 flex size-1.5"
-        :title="$t('toolbar.update-available')"
-      >
-        <span class="bg-warning absolute size-full rounded-full opacity-75 motion-safe:animate-ping"></span>
-        <span class="bg-warning relative size-full rounded-full"></span>
-      </span>
-    </label>
-    <ul
-      tabindex="0"
-      class="menu dropdown-content rounded-box bg-base-200 border-base-content/10 z-50 w-max min-w-60 border p-1.5 shadow-lg"
-      @click="hideMenu"
-    >
+  <Popover
+    hover
+    placement="bottom-end"
+    panel-class="rounded-box bg-base-200 border-base-content/10 w-max min-w-60 border p-1.5 shadow-lg"
+  >
+    <template #trigger>
+      <button type="button" class="icon-btn btn btn-ghost btn-sm relative w-8 gap-0 px-0 md:gap-0.5">
+        <carbon:circle-solid class="text-red w-2 md:w-2.5" v-if="streamConfig.stderr" />
+        <carbon:circle-solid class="text-blue w-2 md:w-2.5" v-if="streamConfig.stdout" />
+        <span
+          v-if="showImageUpdateAlert"
+          class="absolute end-0.5 top-0.5 flex size-1.5"
+          :title="$t('toolbar.update-available')"
+        >
+          <span class="bg-warning absolute size-full rounded-full opacity-75 motion-safe:animate-ping"></span>
+          <span class="bg-warning relative size-full rounded-full"></span>
+        </span>
+      </button>
+    </template>
+    <ul class="menu w-full p-0">
       <li class="section" v-if="!historical || hasComplexLogs">{{ $t("toolbar.section-logs") }}</li>
       <li v-if="!historical">
         <a @click="showSearch = true">
@@ -247,7 +249,7 @@
         </li>
       </template>
     </ul>
-  </div>
+  </Popover>
 </template>
 
 <script lang="ts" setup>
@@ -479,16 +481,6 @@ const toggleAllLevels = computed({
     }
   },
 });
-
-const hideMenu = (e: MouseEvent) => {
-  if (e.target instanceof HTMLAnchorElement) {
-    setTimeout(() => {
-      if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur();
-      }
-    }, 50);
-  }
-};
 </script>
 
 <style scoped>

--- a/assets/components/ContainerViewer/ContainerTitle.vue
+++ b/assets/components/ContainerViewer/ContainerTitle.vue
@@ -16,24 +16,26 @@
               ><span class="block truncate">{{ container.name }}</span></template
             >
             <div v-else class="min-w-0">
-              <!-- daisyUI's .dropdown is inline-block, so it sizes to its content and
-                   silently overflows this shrunken li: the button spilled past the row
-                   and the next control painted over its caret. max-w-full puts it back
-                   under the li's width so the name truncates instead. -->
-              <div class="dropdown max-w-full min-w-0">
-                <!-- Ghost until hover: the name is the page title, and a
-                     permanent button frame made it read as one more chip. -->
-                <button tabindex="0" role="button" class="btn btn-ghost btn-xs md:btn-sm max-w-full min-w-0 px-1.5">
-                  <span class="truncate">{{ container.name }}</span>
-                  <!-- The count and caret are the only affordance for the dropdown, so they
-                       must survive a long image tag squeezing this button. -->
-                  <span class="badge badge-xs badge-neutral shrink-0 font-sans">{{ sameNameContainers.length }}</span>
-                  <carbon:caret-down class="text-base-content/50 shrink-0" />
-                </button>
-                <ul
-                  tabindex="0"
-                  class="dropdown-content menu rounded-box bg-base-100 border-base-content/20 z-10 w-max border p-1 shadow-sm"
-                >
+              <!-- The anchor is inline-block, so it sizes to its content and silently
+                   overflows this shrunken li: the button spilled past the row and the next
+                   control painted over its caret. max-w-full puts it back under the li's
+                   width so the name truncates instead. -->
+              <Popover
+                class="max-w-full min-w-0"
+                panel-class="rounded-box bg-base-100 border-base-content/20 w-max border p-1 shadow-sm"
+              >
+                <template #trigger>
+                  <!-- Ghost until hover: the name is the page title, and a
+                       permanent button frame made it read as one more chip. -->
+                  <button type="button" class="btn btn-ghost btn-xs md:btn-sm max-w-full min-w-0 px-1.5">
+                    <span class="truncate">{{ container.name }}</span>
+                    <!-- The count and caret are the only affordance for the menu, so they
+                         must survive a long image tag squeezing this button. -->
+                    <span class="badge badge-xs badge-neutral shrink-0 font-sans">{{ sameNameContainers.length }}</span>
+                    <carbon:caret-down class="text-base-content/50 shrink-0" />
+                  </button>
+                </template>
+                <ul class="menu w-full p-0">
                   <li class="menu-title px-2 py-1 text-xs">
                     {{ $t("label.container", sameNameContainers.length) }}
                   </li>
@@ -61,7 +63,7 @@
                     </router-link>
                   </li>
                 </ul>
-              </div>
+              </Popover>
             </div>
           </li>
         </ul>

--- a/assets/components/ContainerViewer/VolumeWarning.vue
+++ b/assets/components/ContainerViewer/VolumeWarning.vue
@@ -1,20 +1,22 @@
 <template>
-  <div v-if="worst" class="dropdown dropdown-end" :class="{ 'dropdown-bottom': !openUp }">
-    <button
-      tabindex="0"
-      role="button"
-      class="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium tabular-nums"
-      :class="badgeClass"
-      :title="title"
-    >
-      <PhWarning class="size-3.5" />
-      <span class="max-md:hidden">{{ worst.destination }}</span>
-      <span>{{ formatPct(worst.pct) }}</span>
-    </button>
-    <div
-      tabindex="0"
-      class="dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 mt-1 w-72 border p-2 text-xs shadow-sm"
-    >
+  <Popover
+    v-if="worst"
+    placement="bottom-end"
+    panel-class="rounded-box bg-base-200 border-base-content/20 w-72 border p-2 text-xs shadow-sm"
+  >
+    <template #trigger>
+      <button
+        type="button"
+        class="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-medium tabular-nums"
+        :class="badgeClass"
+        :title="title"
+      >
+        <PhWarning class="size-3.5" />
+        <span class="max-md:hidden">{{ worst.destination }}</span>
+        <span>{{ formatPct(worst.pct) }}</span>
+      </button>
+    </template>
+    <div>
       <div class="text-base-content/60 mb-1.5 px-1 text-[11px] tracking-wide uppercase">{{ t("tooltip.volumes") }}</div>
       <ul class="space-y-1.5">
         <li
@@ -39,7 +41,7 @@
         </li>
       </ul>
     </div>
-  </div>
+  </Popover>
 </template>
 
 <script lang="ts" setup>
@@ -49,7 +51,7 @@ import PhWarning from "~icons/ph/warning-fill";
 const WARN = 0.85;
 const CRITICAL = 0.95;
 
-const { container } = defineProps<{ container: Container; openUp?: boolean }>();
+const { container } = defineProps<{ container: Container }>();
 
 const { t } = useI18n();
 

--- a/assets/components/Links.vue
+++ b/assets/components/Links.vue
@@ -24,7 +24,7 @@
       <mdi:cog class="icon-spin size-6" />
     </router-link>
 
-    <dropdown class="dropdown-end" data-testid="user-menu" v-if="config.user">
+    <Dropdown placement="bottom-end" data-testid="user-menu" v-if="config.user">
       <template #trigger>
         <template v-if="config.disableAvatars || !config.user.email">
           <material-symbols:person class="size-6" />
@@ -65,7 +65,7 @@
           </template>
         </div>
       </template>
-    </dropdown>
+    </Dropdown>
   </div>
 </template>
 <script lang="ts" setup>

--- a/assets/components/LogViewer/LogActions.vue
+++ b/assets/components/LogViewer/LogActions.vue
@@ -1,36 +1,33 @@
 <template>
-  <div
-    class="dropdown dropdown-hover absolute -left-2 z-10 font-sans md:-left-8"
-    :class="shouldShowBelow ? 'dropdown-right' : 'dropdown-right dropdown-end'"
-    v-show="container"
-    ref="dropdownRef"
-    @mouseenter="checkDropdownPosition"
+  <Popover
+    v-if="container"
+    hover
+    placement="right-start"
+    class="absolute -left-2 z-10 font-sans md:-left-8"
+    panel-class="rounded-box bg-base-200 border-base-content/20 w-52 border p-1 text-sm shadow-sm"
   >
-    <router-link
-      v-if="isFiltered"
-      @click="resetSearch()"
-      tabindex="0"
-      class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90"
-      :to="{
-        name: '/container/[id].time.[datetime]',
-        params: { id: container.id, datetime: logEntry.date.toISOString() },
-        query: { logId: logEntry.id },
-      }"
-    >
-      <material-symbols:eye-tracking />
-    </router-link>
-    <button
-      tabindex="0"
-      class="btn btn-square btn-xs border-base-content/20 bg-base-100 border opacity-0 shadow-sm group-hover/entry:opacity-90"
-      v-else
-    >
-      <ion:ellipsis-vertical />
-    </button>
-    <ul
-      tabindex="0"
-      class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm"
-      @click="hideMenu"
-    >
+    <template #trigger>
+      <router-link
+        v-if="isFiltered"
+        @click="resetSearch()"
+        class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90"
+        :to="{
+          name: '/container/[id].time.[datetime]',
+          params: { id: container.id, datetime: logEntry.date.toISOString() },
+          query: { logId: logEntry.id },
+        }"
+      >
+        <material-symbols:eye-tracking />
+      </router-link>
+      <button
+        type="button"
+        class="btn btn-square btn-xs border-base-content/20 bg-base-100 border opacity-0 shadow-sm group-hover/entry:opacity-90"
+        v-else
+      >
+        <ion:ellipsis-vertical />
+      </button>
+    </template>
+    <ul class="menu w-full p-0">
       <li v-if="isFiltered">
         <router-link
           @click="resetSearch()"
@@ -78,7 +75,7 @@
         </a>
       </li>
     </ul>
-  </div>
+  </Popover>
 </template>
 
 <script lang="ts" setup>
@@ -171,25 +168,5 @@ function createAlert() {
   const name = nameParts.join(" ");
 
   showDrawer(AlertForm, { prefill: { name, containerExpression: containerExpr, logExpression: logExpr } }, "lg");
-}
-
-function hideMenu(e: MouseEvent) {
-  if (e.target instanceof HTMLAnchorElement) {
-    setTimeout(() => {
-      if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur();
-      }
-    }, 50);
-  }
-}
-
-const dropdownRef = useTemplateRef<HTMLDivElement>("dropdownRef");
-const shouldShowBelow = ref(false);
-
-function checkDropdownPosition() {
-  if (!dropdownRef.value) return;
-
-  const rect = dropdownRef.value.getBoundingClientRect();
-  shouldShowBelow.value = rect.top < 150;
 }
 </script>

--- a/assets/components/LogViewer/LogAnalytics.vue
+++ b/assets/components/LogViewer/LogAnalytics.vue
@@ -49,12 +49,19 @@
           </span>
         </div>
 
-        <div class="dropdown dropdown-end shrink-0" v-if="canExport">
-          <div tabindex="0" role="button" class="btn btn-xs btn-ghost cursor-pointer gap-1">
-            <ph:download-simple class="size-4" />
-            {{ $t("analytics.export") }}
-          </div>
-          <ul tabindex="0" class="dropdown-content menu bg-base-200 rounded-box z-30 w-44 p-2 shadow-sm">
+        <Popover
+          class="shrink-0"
+          placement="bottom-end"
+          panel-class="bg-base-200 rounded-box w-44 p-2 shadow-sm"
+          v-if="canExport"
+        >
+          <template #trigger>
+            <button type="button" class="btn btn-xs btn-ghost gap-1">
+              <ph:download-simple class="size-4" />
+              {{ $t("analytics.export") }}
+            </button>
+          </template>
+          <ul class="menu w-full p-0">
             <li>
               <a class="cursor-pointer whitespace-nowrap" @click="exportResults('csv')">{{
                 $t("analytics.export_csv")
@@ -66,7 +73,7 @@
               }}</a>
             </li>
           </ul>
-        </div>
+        </Popover>
       </div>
     </section>
 

--- a/assets/components/LogViewer/MultiContainerActionToolbar.vue
+++ b/assets/components/LogViewer/MultiContainerActionToolbar.vue
@@ -1,14 +1,16 @@
 <template>
-  <div class="dropdown dropdown-end dropdown-hover z-20">
-    <label tabindex="0" class="icon-btn btn btn-ghost btn-sm w-8 gap-0 px-0 md:gap-0.5">
-      <carbon:circle-solid class="text-red w-2 md:w-2.5" v-if="streamConfig.stderr" />
-      <carbon:circle-solid class="text-blue w-2 md:w-2.5" v-if="streamConfig.stdout" />
-    </label>
-    <ul
-      tabindex="0"
-      class="menu dropdown-content rounded-box bg-base-200 border-base-content/10 z-50 w-max min-w-60 border p-1.5 shadow-lg"
-      @click="hideMenu"
-    >
+  <Popover
+    hover
+    placement="bottom-end"
+    panel-class="rounded-box bg-base-200 border-base-content/10 w-max min-w-60 border p-1.5 shadow-lg"
+  >
+    <template #trigger>
+      <button type="button" class="icon-btn btn btn-ghost btn-sm w-8 gap-0 px-0 md:gap-0.5">
+        <carbon:circle-solid class="text-red w-2 md:w-2.5" v-if="streamConfig.stderr" />
+        <carbon:circle-solid class="text-blue w-2 md:w-2.5" v-if="streamConfig.stdout" />
+      </button>
+    </template>
+    <ul class="menu w-full p-0">
       <li class="section">{{ $t("toolbar.section-logs") }}</li>
       <li>
         <a @click="showSearch = true">
@@ -129,7 +131,7 @@
         </li>
       </template>
     </ul>
-  </div>
+  </Popover>
 </template>
 
 <script lang="ts" setup>
@@ -169,16 +171,6 @@ const toggleAllLevels = computed({
     }
   },
 });
-
-const hideMenu = (e: MouseEvent) => {
-  if (e.target instanceof HTMLAnchorElement) {
-    setTimeout(() => {
-      if (document.activeElement instanceof HTMLElement) {
-        document.activeElement.blur();
-      }
-    }, 50);
-  }
-};
 </script>
 
 <style scoped>

--- a/assets/components/LogViewer/__snapshots__/EventSource.spec.ts.snap
+++ b/assets/components/LogViewer/__snapshots__/EventSource.spec.ts.snap
@@ -7,10 +7,11 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
     <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans md:-left-8 dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+      <div class="absolute -left-2 z-10 font-sans md:-left-8 popover-anchor"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
-          </svg></a>
-        <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
+          </svg></a></div>
+      <div popover="" class="popover-panel rounded-box bg-base-200 border-base-content/20 w-52 border p-1 text-sm shadow-sm">
+        <ul class="menu w-full p-0">
           <li><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class=""><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
                 <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
               </svg> action.see-in-context</a></li>
@@ -59,10 +60,11 @@ exports[`<ContainerEventSource /> > render html correctly > should render dates 
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
     <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans md:-left-8 dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+      <div class="absolute -left-2 z-10 font-sans md:-left-8 popover-anchor"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
-          </svg></a>
-        <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
+          </svg></a></div>
+      <div popover="" class="popover-panel rounded-box bg-base-200 border-base-content/20 w-52 border p-1 text-sm shadow-sm">
+        <ul class="menu w-full p-0">
           <li><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class=""><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
                 <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
               </svg> action.see-in-context</a></li>
@@ -111,10 +113,11 @@ exports[`<ContainerEventSource /> > render html correctly > should render messag
   </li>
   <li data-v-cf9ff940="" id="1" data-time="1560336942459" class="group/entry">
     <div data-v-cf9ff940="" class="relative flex w-full items-start gap-x-2 group-[.compact]:items-stretch">
-      <div class="dropdown dropdown-hover absolute -left-2 z-10 font-sans md:-left-8 dropdown-right dropdown-end"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90" tabindex="0"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
+      <div class="absolute -left-2 z-10 font-sans md:-left-8 popover-anchor"><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class="btn btn-square btn-xs border-base-content/20 bg-base-100 pointer-events-auto! opacity-0 shadow-sm group-hover/entry:opacity-90"><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
             <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
-          </svg></a>
-        <ul tabindex="0" class="menu dropdown-content rounded-box bg-base-200 border-base-content/20 z-50 w-52 border p-1 text-sm shadow-sm">
+          </svg></a></div>
+      <div popover="" class="popover-panel rounded-box bg-base-200 border-base-content/20 w-52 border p-1 text-sm shadow-sm">
+        <ul class="menu w-full p-0">
           <li><a href="/container/abc/time/2019-06-12T10:55:42.459Z?logId=1" class=""><svg viewBox="0 0 24 24" width="1.2em" height="1.2em">
                 <path fill="currentColor" d="M6 23H3q-.825 0-1.412-.587T1 21v-3h2v3h3zm12 0v-2h3v-3h2v3q0 .825-.587 1.413T21 23zm-6-4.5q-3 0-5.437-1.775T3 12q1.125-2.95 3.563-4.725T12 5.5t5.438 1.775T21 12q-1.125 2.95-3.562 4.725T12 18.5m0-3q1.45 0 2.475-1.025T15.5 12t-1.025-2.475T12 8.5T9.525 9.525T8.5 12t1.025 2.475T12 15.5m0-2q-.625 0-1.062-.437T10.5 12t.438-1.062T12 10.5t1.063.438T13.5 12t-.437 1.063T12 13.5M1 6V3q0-.825.588-1.412T3 1h3v2H3v3zm20 0V3h-3V1h3q.825 0 1.413.588T23 3v3z"></path>
               </svg> action.see-in-context</a></li>

--- a/assets/components/Notification/AlertCard.vue
+++ b/assets/components/Notification/AlertCard.vue
@@ -13,25 +13,28 @@
             <mdi:bell-ring-outline v-else-if="alert.eventExpression" class="text-info shrink-0" />
             <mdi:text-box-outline v-else class="text-info shrink-0" />
             <span class="break-all">{{ alert.name }}</span> <span class="text-sm font-light">→</span>
-            <div class="group/dispatch dropdown dropdown-hover">
-              <div
-                tabindex="0"
-                role="button"
-                class="border-base-content/0 hover:border-base-content/20 flex cursor-pointer items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-light transition-colors"
-                :class="{ 'text-warning': !alert.dispatcher }"
-              >
-                <template v-if="alert.dispatcher">
-                  <mdi:webhook v-if="alert.dispatcher.type === 'webhook'" />
-                  <mdi:cloud v-else />
-                  {{ alert.dispatcher.name }}
-                </template>
-                <template v-else>
-                  <mdi:alert-outline />
-                  {{ $t("notifications.alert.dispatcher-deleted") }}
-                </template>
-                <mdi:chevron-down class="text-[0.6rem] opacity-0 transition-opacity group-hover/dispatch:opacity-100" />
-              </div>
-              <ul tabindex="0" class="dropdown-content menu bg-base-200 rounded-box z-50 w-48 p-2 shadow-lg">
+            <Popover class="group/dispatch" hover panel-class="bg-base-200 rounded-box w-48 p-2 shadow-lg">
+              <template #trigger>
+                <button
+                  type="button"
+                  class="border-base-content/0 hover:border-base-content/20 flex cursor-pointer items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-light transition-colors"
+                  :class="{ 'text-warning': !alert.dispatcher }"
+                >
+                  <template v-if="alert.dispatcher">
+                    <mdi:webhook v-if="alert.dispatcher.type === 'webhook'" />
+                    <mdi:cloud v-else />
+                    {{ alert.dispatcher.name }}
+                  </template>
+                  <template v-else>
+                    <mdi:alert-outline />
+                    {{ $t("notifications.alert.dispatcher-deleted") }}
+                  </template>
+                  <mdi:chevron-down
+                    class="text-[0.6rem] opacity-0 transition-opacity group-hover/dispatch:opacity-100"
+                  />
+                </button>
+              </template>
+              <ul class="menu w-full p-0">
                 <li v-for="dest in dispatchers" :key="dest.id">
                   <a
                     class="flex items-center gap-2"
@@ -44,7 +47,7 @@
                   </a>
                 </li>
               </ul>
-            </div>
+            </Popover>
           </h4>
           <span v-if="!alert.enabled" class="badge badge-warning badge-sm">{{ $t("notifications.alert.paused") }}</span>
         </div>

--- a/assets/components/Notification/DestinationCard.vue
+++ b/assets/components/Notification/DestinationCard.vue
@@ -66,27 +66,30 @@
               </p>
             </div>
           </button>
-          <div class="dropdown dropdown-end" @click.stop>
-            <div tabindex="0" role="button" class="btn btn-ghost btn-sm btn-square">
-              <ion:ellipsis-vertical />
-            </div>
-            <ul
-              tabindex="0"
-              class="menu dropdown-content rounded-box bg-base-100 border-base-content/20 z-50 w-40 border p-1 shadow-sm"
-            >
+          <Popover
+            placement="bottom-end"
+            panel-class="rounded-box bg-base-100 border-base-content/20 w-40 border p-1 shadow-sm"
+            @click.stop
+          >
+            <template #trigger>
+              <button type="button" class="btn btn-ghost btn-sm btn-square">
+                <ion:ellipsis-vertical />
+              </button>
+            </template>
+            <ul class="menu w-full p-0">
               <li>
-                <a @click="runFromMenu(editDestination)">{{ $t("notifications.destination.edit") }}</a>
+                <a @click="editDestination">{{ $t("notifications.destination.edit") }}</a>
               </li>
               <li v-if="destination.type !== 'cloud'">
-                <a @click="runFromMenu(duplicateDestination)">{{ $t("notifications.destination.duplicate") }}</a>
+                <a @click="duplicateDestination">{{ $t("notifications.destination.duplicate") }}</a>
               </li>
               <li v-if="destination.type !== 'cloud'">
-                <a class="text-error" @click="runFromMenu(() => (confirmingDelete = true))">
+                <a class="text-error" @click="confirmingDelete = true">
                   {{ $t("notifications.destination.delete") }}
                 </a>
               </li>
             </ul>
-          </div>
+          </Popover>
         </div>
       </div>
     </div>
@@ -121,15 +124,6 @@ const webhookHost = computed(() => {
     return "";
   }
 });
-
-/**
- * A CSS-only daisyUI dropdown stays open until it loses focus, so picking an item left the menu
- * sitting on top of whatever the item revealed.
- */
-function runFromMenu(action: () => void) {
-  if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
-  action();
-}
 
 function editDestination() {
   showDrawer(

--- a/assets/components/common/DiscoveryHint.vue
+++ b/assets/components/common/DiscoveryHint.vue
@@ -13,7 +13,7 @@
     ref="panel"
     :id="id"
     popover
-    class="rounded-box bg-base-200 border-base-content/20 fixed inset-auto m-0 max-w-[calc(100vw-1rem)] border p-3 text-xs whitespace-normal shadow-sm"
+    class="popover-panel rounded-box bg-base-200 border-base-content/20 border p-3 text-xs whitespace-normal shadow-sm"
     :style="{ width: `${width}px` }"
     @beforetoggle="onBeforeToggle"
     @toggle="onToggle"
@@ -44,10 +44,9 @@
  * A dismissible "did you know" popover hung off a small icon. Use it to teach an opt-in
  * feature at the point where its absence is visible, not as a general tooltip.
  *
- * The panel uses the native popover API so it renders in the top layer. Anything else gets
- * clipped by (and widens) an ancestor with `overflow`, like the container table's scroller.
- * The top layer does not escape inheritance though, so the panel resets `white-space`, which
- * the container table's cells set to `nowrap`.
+ * The panel renders in the top layer, so nothing clips it. The top layer does not escape
+ * inheritance though, so the panel resets `white-space`, which the container table's cells
+ * set to `nowrap`.
  */
 const {
   title,
@@ -68,43 +67,8 @@ const id = `hint-${useId()}`;
 const trigger = useTemplateRef("trigger");
 const panel = useTemplateRef("panel");
 
-const GAP = 4;
-const MARGIN = 8;
-
-// The popover is in the top layer, so it is positioned against the viewport by hand instead
-// of by an anchor. CSS anchor positioning would do this, but Firefox does not have it yet.
-function position() {
-  if (!trigger.value || !panel.value) return;
-  const anchor = trigger.value.getBoundingClientRect();
-  const { offsetWidth, offsetHeight } = panel.value;
-
-  const left = align === "end" ? anchor.right - offsetWidth : anchor.left;
-  panel.value.style.left = `${Math.min(Math.max(MARGIN, left), Math.max(MARGIN, window.innerWidth - offsetWidth - MARGIN))}px`;
-
-  const below = anchor.bottom + GAP;
-  const flip = offsetHeight > 0 && below + offsetHeight > window.innerHeight - MARGIN && anchor.top > offsetHeight;
-  panel.value.style.top = `${flip ? anchor.top - offsetHeight - GAP : below}px`;
-}
-
-function onBeforeToggle(event: ToggleEvent) {
-  if (event.newState === "open") position();
-}
-
-function onToggle(event: ToggleEvent) {
-  if (event.newState === "open") {
-    // Now that it is laid out, its real height is known and it can flip above the trigger.
-    position();
-    window.addEventListener("scroll", position, true);
-    window.addEventListener("resize", position);
-  } else {
-    window.removeEventListener("scroll", position, true);
-    window.removeEventListener("resize", position);
-  }
-}
-
-onScopeDispose(() => {
-  window.removeEventListener("scroll", position, true);
-  window.removeEventListener("resize", position);
+const { onBeforeToggle, onToggle } = useAnchoredPopover(trigger, panel, {
+  placement: () => (align === "end" ? "bottom-end" : "bottom-start"),
 });
 
 function dismiss() {

--- a/assets/components/common/Dropdown.vue
+++ b/assets/components/common/Dropdown.vue
@@ -1,25 +1,24 @@
 <template>
-  <div class="dropdown">
-    <label tabindex="0" class="btn btn-circle btn-sm" @mousedown="checkAndCloseDropDown($event)" @blur="closed()">
-      <slot name="trigger"></slot>
-    </label>
-    <div
-      tabindex="0"
-      class="dropdown-content rounded-box border-base-content/20 bg-base-200 z-50 mt-1 min-w-52 border p-2 shadow-sm"
-    >
-      <slot name="content"></slot>
-    </div>
-  </div>
+  <Popover
+    :placement="placement"
+    panel-class="rounded-box border-base-content/20 bg-base-200 min-w-52 border p-2 shadow-sm"
+    :close-on-select="false"
+    @open="$emit('opened')"
+    @close="$emit('closed')"
+  >
+    <template #trigger>
+      <label tabindex="0" class="btn btn-circle btn-sm">
+        <slot name="trigger"></slot>
+      </label>
+    </template>
+    <template #default="{ close }">
+      <slot name="content" :close="close"></slot>
+    </template>
+  </Popover>
 </template>
 
 <script setup lang="ts">
-const closed = defineEmit();
-function checkAndCloseDropDown(e: MouseEvent) {
-  const target = e.currentTarget as HTMLElement;
-  if (target?.matches(":focus")) {
-    setTimeout(() => target.blur(), 0);
-  }
-}
-</script>
+const { placement = "bottom-start" } = defineProps<{ placement?: PopoverPlacement }>();
 
-<style scoped></style>
+defineEmits<{ opened: []; closed: [] }>();
+</script>

--- a/assets/components/common/DropdownMenu.vue
+++ b/assets/components/common/DropdownMenu.vue
@@ -1,14 +1,17 @@
 <template>
-  <details class="dropdown dropdown-end" ref="details" v-on-click-outside="close">
-    <summary class="btn btn-primary flex-nowrap" v-bind="$attrs">
-      <slot name="trigger"> {{ label }} <carbon:caret-down /></slot>
-    </summary>
-    <ul
-      class="menu dropdown-content rounded-box border-base-content/20 bg-base-200 z-50 mt-1 max-h-72 w-48 flex-nowrap overflow-auto border p-2 shadow-sm"
-    >
+  <Popover
+    placement="bottom-end"
+    panel-class="rounded-box border-base-content/20 bg-base-200 max-h-72 w-48 overflow-auto border p-2 shadow-sm"
+  >
+    <template #trigger>
+      <button type="button" class="btn btn-primary flex-nowrap" v-bind="$attrs">
+        <slot name="trigger"> {{ label }} <carbon:caret-down /></slot>
+      </button>
+    </template>
+    <ul class="menu w-full flex-nowrap p-0">
       <slot>
         <li v-for="item in options">
-          <a @click="update(item.value as T)">
+          <a @click="model = item.value as T">
             <mdi:check class="w-4" v-if="modelValue == item.value" />
             <div v-else class="w-4"></div>
             {{ item.label }}
@@ -16,11 +19,12 @@
         </li>
       </slot>
     </ul>
-  </details>
+  </Popover>
 </template>
 
 <script lang="ts" setup generic="T">
-import { vOnClickOutside } from "@vueuse/components";
+defineOptions({ inheritAttrs: false });
+
 type DropdownItem = {
   label: string;
   value: T;
@@ -34,11 +38,4 @@ const { options, defaultLabel = "" } = defineProps<{
 }>();
 
 const label = computed(() => options.find((item) => item.value === model.value)?.label ?? defaultLabel);
-const details = ref<HTMLElement | null>(null);
-const close = () => details.value?.removeAttribute("open");
-
-const update = (value: T) => {
-  model.value = value;
-  close();
-};
 </script>

--- a/assets/components/common/Popover.vue
+++ b/assets/components/common/Popover.vue
@@ -1,0 +1,88 @@
+<template>
+  <div
+    ref="anchor"
+    v-bind="$attrs"
+    class="popover-anchor"
+    @click="hover || toggle()"
+    @pointerenter="onEnter"
+    @pointerleave="onLeave"
+  >
+    <slot name="trigger" :open="isOpen"></slot>
+  </div>
+  <div
+    ref="panel"
+    popover
+    class="popover-panel"
+    :class="panelClass"
+    @beforetoggle="onBeforeToggle"
+    @toggle="onToggle"
+    @pointerenter="onEnter"
+    @pointerleave="onLeave"
+    @click="onSelect"
+  >
+    <slot :close="hide" :open="isOpen"></slot>
+  </div>
+</template>
+
+<script lang="ts" setup>
+/**
+ * A menu or panel hung off a trigger, rendered in the top layer with the native popover API.
+ * Anything positioned inside the page gets clipped by an ancestor with `overflow`, which is
+ * most of this app: the container table's rounded card, the log list, the sidebar.
+ *
+ * The trigger goes in `#trigger` and keeps its own markup, so a link stays a link. Attributes
+ * land on the wrapper around it, which is what `.dropdown` used to be.
+ */
+defineOptions({ inheritAttrs: false });
+
+const {
+  placement = "bottom-start",
+  hover = false,
+  closeOnSelect = true,
+  panelClass = "",
+} = defineProps<{
+  placement?: PopoverPlacement;
+  /** Opens on pointer enter instead of click. Touch taps fire it too. */
+  hover?: boolean;
+  /** Close when a row is picked. Rows inside a nested <details> submenu never close. */
+  closeOnSelect?: boolean;
+  panelClass?: string;
+}>();
+
+const emit = defineEmits<{ open: []; close: [] }>();
+
+const anchor = useTemplateRef<HTMLElement>("anchor");
+const panel = useTemplateRef<HTMLElement>("panel");
+
+const { isOpen, onBeforeToggle, onToggle, show, hide, toggle } = useAnchoredPopover(anchor, panel, {
+  placement: () => placement,
+  // Hover menus have to be reachable across the gap, so keep it tight.
+  gap: () => (hover ? 2 : 4),
+});
+
+watch(isOpen, (value) => (value ? emit("open") : emit("close")));
+
+// The panel is a sibling of the trigger, not a child, so leaving one to enter the other has
+// to be bridged instead of relying on a single hover region.
+let timer: ReturnType<typeof setTimeout> | undefined;
+function onEnter() {
+  if (!hover) return;
+  clearTimeout(timer);
+  show();
+}
+function onLeave() {
+  if (!hover) return;
+  clearTimeout(timer);
+  timer = setTimeout(hide, 150);
+}
+onScopeDispose(() => clearTimeout(timer));
+
+function onSelect(event: MouseEvent) {
+  if (!closeOnSelect) return;
+  const item = (event.target as HTMLElement | null)?.closest("a, button");
+  // A submenu row is one step of a choice the user is still making, so it stays open.
+  if (item && !item.closest("details")) hide();
+}
+
+defineExpose({ show, hide, toggle });
+</script>

--- a/assets/components/nav/NavOverflow.vue
+++ b/assets/components/nav/NavOverflow.vue
@@ -1,16 +1,15 @@
 <template>
-  <div class="dropdown dropdown-end">
-    <button
-      tabindex="0"
-      type="button"
-      class="icon-btn nav-btn"
-      :title="$t('label.more-options')"
-      :aria-label="$t('label.more-options')"
-    >
-      <ion:ellipsis-vertical class="size-4" />
-    </button>
-    <div tabindex="0" class="nav-menu-panel">
-      <slot />
-    </div>
-  </div>
+  <Popover placement="bottom-end" panel-class="nav-menu-panel">
+    <template #trigger>
+      <button
+        type="button"
+        class="icon-btn nav-btn"
+        :title="$t('label.more-options')"
+        :aria-label="$t('label.more-options')"
+      >
+        <ion:ellipsis-vertical class="size-4" />
+      </button>
+    </template>
+    <slot />
+  </Popover>
 </template>

--- a/assets/composable/popover.ts
+++ b/assets/composable/popover.ts
@@ -1,0 +1,100 @@
+import type { Ref } from "vue";
+
+export type PopoverPlacement = "bottom-start" | "bottom-end" | "right-start" | "right-end";
+
+/** Viewport breathing room kept around a panel. */
+const MARGIN = 8;
+
+/**
+ * Drives a native popover panel anchored to a trigger element.
+ *
+ * The panel lives in the top layer, so nothing in the page can clip it: an ancestor with
+ * `overflow` (the container table's rounded card, the log list's scroller) used to cut menus
+ * in half. The top layer has no anchor of its own, so the panel is placed against the
+ * viewport by hand. CSS anchor positioning would do this, but Firefox does not have it yet.
+ */
+export function useAnchoredPopover(
+  anchor: Ref<HTMLElement | null>,
+  panel: Ref<HTMLElement | null>,
+  options: {
+    placement?: () => PopoverPlacement;
+    /** Space between the trigger and the panel. Hover menus want this small to cross. */
+    gap?: () => number;
+  } = {},
+) {
+  const isOpen = ref(false);
+  // A click on the trigger of an open popover is an outside click, so the browser light
+  // dismisses it before the click handler runs. Without this the menu would reopen at once
+  // and never close from its own button.
+  let closedAt = 0;
+
+  const placement = () => options.placement?.() ?? "bottom-start";
+  const gap = () => options.gap?.() ?? 4;
+
+  function position() {
+    if (!anchor.value || !panel.value) return;
+    const rect = anchor.value.getBoundingClientRect();
+    const { offsetWidth: width, offsetHeight: height } = panel.value;
+
+    const [side, align] = placement().split("-");
+    let left: number;
+    let top: number;
+
+    if (side === "right") {
+      left = rect.right + gap();
+      if (left + width > window.innerWidth - MARGIN) left = rect.left - width - gap();
+      top = align === "end" ? rect.bottom - height : rect.top;
+    } else {
+      left = align === "end" ? rect.right - width : rect.left;
+      top = rect.bottom + gap();
+      // Flip above only when there is actually more room up there.
+      if (top + height > window.innerHeight - MARGIN && rect.top > height) top = rect.top - height - gap();
+    }
+
+    const clamp = (value: number, max: number) => Math.min(Math.max(MARGIN, value), Math.max(MARGIN, max - MARGIN));
+    panel.value.style.left = `${clamp(left, window.innerWidth - width)}px`;
+    panel.value.style.top = `${clamp(top, window.innerHeight - height)}px`;
+  }
+
+  function onBeforeToggle(event: ToggleEvent) {
+    if (event.newState !== "open" || !panel.value) return;
+    // The panel is still display:none here, so it cannot be measured and this first pass can
+    // only be a guess. Keeping it invisible until `toggle` avoids showing that guess.
+    panel.value.style.visibility = "hidden";
+    position();
+  }
+
+  function onToggle(event: ToggleEvent) {
+    isOpen.value = event.newState === "open";
+    if (isOpen.value) {
+      // Now that it is laid out its real size is known, so it can flip and clamp.
+      position();
+      if (panel.value) panel.value.style.visibility = "";
+      window.addEventListener("scroll", position, true);
+      window.addEventListener("resize", position);
+    } else {
+      closedAt = performance.now();
+      stopTracking();
+    }
+  }
+
+  function stopTracking() {
+    window.removeEventListener("scroll", position, true);
+    window.removeEventListener("resize", position);
+  }
+
+  const show = () => {
+    if (!isOpen.value) panel.value?.showPopover();
+  };
+  const hide = () => {
+    if (isOpen.value) panel.value?.hidePopover();
+  };
+  const toggle = () => {
+    if (isOpen.value) hide();
+    else if (performance.now() - closedAt > 250) show();
+  };
+
+  onScopeDispose(stopTracking);
+
+  return { isOpen, position, onBeforeToggle, onToggle, show, hide, toggle };
+}

--- a/assets/main.css
+++ b/assets/main.css
@@ -192,7 +192,7 @@
 }
 
 @utility nav-menu-panel {
-  @apply dropdown-content rounded-box border-base-content/15 bg-base-200 z-50 mt-1 w-56 border p-1.5 shadow-lg;
+  @apply rounded-box border-base-content/15 bg-base-200 w-56 border p-1.5 shadow-lg;
 }
 
 @utility animate-bounce-fast {
@@ -204,6 +204,30 @@
 }
 
 @layer base {
+  /* Popover panels come with UA chrome (a border, padding, centering inset) meant for a
+   * standalone dialog. Resetting it in the base layer lets a component's own utilities style
+   * the panel without fighting the reset for source order. */
+  .popover-panel {
+    position: fixed;
+    inset: auto;
+    margin: 0;
+    border: 0 solid;
+    padding: 0;
+    overflow: visible;
+    width: auto;
+    height: auto;
+    max-width: calc(100vw - 1rem);
+    background: none;
+    color: inherit;
+  }
+
+  /* What `.dropdown` used to be: a box that wraps a trigger without changing its layout.
+   * It stays positioned because triggers hang badges and status dots off it. */
+  .popover-anchor {
+    position: relative;
+    display: inline-block;
+  }
+
   @media screen and (max-device-width: 480px) {
     body {
       -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
The sort menu in the container table was getting cut off by the card's `overflow-hidden`. Every other menu in the app had the same bug waiting: daisyUI dropdowns are absolutely positioned inside the page, so any ancestor with overflow clips them.

All menus now render in the top layer via a shared `Popover` component (`assets/components/common/Popover.vue`) plus a `useAnchoredPopover` composable that places the panel against the viewport by hand. CSS anchor positioning would do this, but Firefox still doesn't have it.

Converted: container table sort and per page menus, host picker, user menu, announcements, cloud popover, nav overflow, container name picker, volume warning, log actions, container and merged toolbars, alert dispatcher picker, destination card menu, SQL export menu.

Things that got deleted along the way:

- `shouldShowBelow` in LogActions and the `openUp` prop on VolumeWarning. Flip and clamp are automatic now.
- The three copies of `hideMenu` and `runFromMenu` that blurred the document to close a CSS only dropdown after picking a row. Rows inside a nested `<details>` submenu still keep the menu open.
- `dropdown-content` in the `nav-menu-panel` utility.

DiscoveryHint already used the popover API and now shares the same composable.

Verified against a local build in Chromium: menus open, close on a second click of their trigger, close on select, and stay on screen at 420px wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wj2Jueqyfx61kLf4qpZPXx