### PR TITLE
feat(cloud): draw the agent chat and indexed data meters

### DIFF
--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -40,6 +40,7 @@ declare module 'vue' {
     CloudEventLogItem: typeof import('./components/LogViewer/CloudEventLogItem.vue')['default']
     CloudPopover: typeof import('./components/CloudPopover.vue')['default']
     CloudSettingsCard: typeof import('./components/CloudSettingsCard.vue')['default']
+    CloudUsage: typeof import('./components/CloudUsage.vue')['default']
     CollapsibleSection: typeof import('./components/common/CollapsibleSection.vue')['default']
     ComplexLogItem: typeof import('./components/LogViewer/ComplexLogItem.vue')['default']
     ContainerActionsToolbar: typeof import('./components/ContainerViewer/ContainerActionsToolbar.vue')['default']

--- a/assets/components/CloudPopover.vue
+++ b/assets/components/CloudPopover.vue
@@ -150,12 +150,7 @@
             <div class="bg-base-content/10 my-1.5 h-px"></div>
 
             <div class="px-2 py-1">
-              <UsageMeter
-                compact
-                :used="cloudStatus.usage.events_used"
-                :limit="cloudStatus.usage.events_limit"
-                :period="cloudStatus.usage.period"
-              />
+              <CloudUsage compact :usage="cloudStatus.usage" />
             </div>
 
             <div class="bg-base-content/10 my-1.5 h-px"></div>

--- a/assets/components/CloudSettingsCard.vue
+++ b/assets/components/CloudSettingsCard.vue
@@ -76,11 +76,7 @@
         </div>
 
         <div class="p-4">
-          <UsageMeter
-            :used="cloudStatus.usage.events_used"
-            :limit="cloudStatus.usage.events_limit"
-            :period="cloudStatus.usage.period"
-          />
+          <CloudUsage :usage="cloudStatus.usage" />
         </div>
 
         <!--

--- a/assets/components/CloudUsage.vue
+++ b/assets/components/CloudUsage.vue
@@ -1,0 +1,37 @@
+<template>
+  <!--
+    Every meter the plan actually caps, in one block, with the billing period stated
+    once underneath rather than repeated under each bar.
+
+    The two newer meters are guarded: an instance can be pointed at a cloud that has
+    not shipped them yet, and a meter reading 0 / 0 would claim the account had no
+    agent chats left rather than admitting the number is unknown.
+  -->
+  <div class="flex flex-col" :class="compact ? 'gap-3' : 'gap-4'">
+    <UsageMeter :label="$t('cloud.usage')" :used="usage.events_used" :limit="usage.events_limit" :compact="compact" />
+    <UsageMeter
+      v-if="usage.agent_messages_limit"
+      :label="$t('cloud.usage-agent-messages')"
+      :used="usage.agent_messages_used ?? 0"
+      :limit="usage.agent_messages_limit"
+      :compact="compact"
+    />
+    <UsageMeter
+      v-if="usage.log_bytes_limit"
+      :label="$t('cloud.usage-log-bytes')"
+      :used="usage.log_bytes_used ?? 0"
+      :limit="usage.log_bytes_limit"
+      unit="bytes"
+      :compact="compact"
+    />
+    <div v-if="usage.period" class="text-base-content/40 font-mono" :class="compact ? 'text-[0.6875rem]' : 'text-xs'">
+      {{ usage.period }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { CloudStatus } from "@/types/notifications";
+
+defineProps<{ usage: CloudStatus["usage"]; compact?: boolean }>();
+</script>

--- a/assets/components/Notification/CloudDestinationForm.vue
+++ b/assets/components/Notification/CloudDestinationForm.vue
@@ -72,11 +72,7 @@
         </div>
 
         <div v-else-if="cloudStatus" class="p-4">
-          <UsageMeter
-            :used="cloudStatus.usage.events_used"
-            :limit="cloudStatus.usage.events_limit"
-            :period="cloudStatus.usage.period"
-          />
+          <CloudUsage :usage="cloudStatus.usage" />
         </div>
 
         <!-- Managed channels live on the cloud side, so the drawer ends in a way out to them. -->

--- a/assets/components/common/UsageMeter.vue
+++ b/assets/components/common/UsageMeter.vue
@@ -7,10 +7,10 @@
   -->
   <div class="flex flex-col" :class="compact ? 'gap-1.5' : 'gap-2'">
     <div class="flex items-baseline justify-between gap-2">
-      <span class="text-base-content/60" :class="compact ? 'text-xs' : 'text-sm'">{{ $t("cloud.usage") }}</span>
-      <span class="font-mono" :class="compact ? 'text-xs' : 'text-sm'">
-        <span class="font-semibold">{{ used.toLocaleString() }}</span>
-        <span class="text-base-content/40"> / {{ limit.toLocaleString() }}</span>
+      <span class="text-base-content/60 truncate" :class="compact ? 'text-xs' : 'text-sm'">{{ label }}</span>
+      <span class="shrink-0 font-mono" :class="compact ? 'text-xs' : 'text-sm'">
+        <span class="font-semibold">{{ display(used) }}</span>
+        <span class="text-base-content/40"> / {{ display(limit) }}</span>
       </span>
     </div>
     <div class="bg-base-content/10 h-1.5 w-full overflow-hidden rounded-full">
@@ -20,25 +20,29 @@
         :style="{ width: `${Math.min(percent, 100)}%` }"
       ></div>
     </div>
-    <div
-      class="text-base-content/40 flex justify-between gap-2 font-mono"
-      :class="compact ? 'text-[0.6875rem]' : 'text-xs'"
-    >
-      <span class="truncate">{{ period }}</span>
-      <span class="shrink-0">{{ percent.toFixed(1) }}%</span>
+    <div class="text-base-content/40 text-right font-mono" :class="compact ? 'text-[0.6875rem]' : 'text-xs'">
+      {{ percent.toFixed(1) }}%
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-const { used, limit } = defineProps<{
+const {
+  used,
+  limit,
+  unit = "count",
+} = defineProps<{
+  label: string;
   used: number;
   limit: number;
-  period?: string;
+  /** Byte meters are unreadable as raw digits: 3221225472 / 10737418240 says nothing. */
+  unit?: "count" | "bytes";
   /** Tightens type and spacing for the popover, which is a third of the width of the other two. */
   compact?: boolean;
 }>();
 
 // A plan without a limit would otherwise divide by zero and render a NaN-wide bar.
 const percent = computed(() => (limit ? (used / limit) * 100 : 0));
+
+const display = (value: number) => (unit === "bytes" ? formatBytes(value, { decimals: 1 }) : value.toLocaleString());
 </script>

--- a/assets/types/notifications.ts
+++ b/assets/types/notifications.ts
@@ -105,6 +105,22 @@ export interface CloudConfig {
 
 export interface CloudStatus {
   user: { email: string; name: string };
-  plan: { name: string; events_per_month: number; retention_days: number };
-  usage: { events_used: number; events_limit: number; period: string };
+  plan: {
+    name: string;
+    events_per_month: number;
+    agent_messages_per_month?: number;
+    log_bytes_per_month?: number;
+    retention_days: number;
+  };
+  // Agent chats and indexed log bytes are metered too, but a cloud older than they are
+  // does not send them, so everything past events is optional and rendered only when present.
+  usage: {
+    events_used: number;
+    events_limit: number;
+    agent_messages_used?: number;
+    agent_messages_limit?: number;
+    log_bytes_used?: number;
+    log_bytes_limit?: number;
+    period: string;
+  };
 }

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -546,7 +546,9 @@ cloud:
   connected: Tilsluttet
   pro-badge: Dozzle Cloud Pro
   plan: Plan
-  usage: Begivenheder i denne periode
+  usage: Begivenheder
+  usage-agent-messages: Agent-chats
+  usage-log-bytes: Indekseret data
   dashboard: Dashboard
   settings: Indstillinger
   error: Forbindelsesfejl. Gentilknyt venligst din instans.

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -546,7 +546,9 @@ cloud:
   connected: Verbunden
   pro-badge: Dozzle Cloud Pro
   plan: Plan
-  usage: Ereignisse in diesem Zeitraum
+  usage: Ereignisse
+  usage-agent-messages: Agent-Chats
+  usage-log-bytes: Indexierte Daten
   dashboard: Dashboard
   settings: Einstellungen
   error: Verbindungsfehler. Bitte verknüpfen Sie Ihre Instanz erneut.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -606,7 +606,9 @@ cloud:
   connected: Connected
   pro-badge: Dozzle Cloud Pro
   plan: Plan
-  usage: Events this period
+  usage: Events
+  usage-agent-messages: Agent chats
+  usage-log-bytes: Data indexed
   dashboard: Dashboard
   settings: Settings
   error: Connection error. Please re-link your instance.

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -596,7 +596,9 @@ cloud:
   connected: Conectado
   pro-badge: Dozzle Cloud Pro
   plan: Plan
-  usage: Eventos en este período
+  usage: Eventos
+  usage-agent-messages: Chats del agente
+  usage-log-bytes: Datos indexados
   dashboard: Panel
   settings: Configuración
   error: Error de conexión. Por favor, revincule su instancia.

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -546,7 +546,9 @@ cloud:
   connected: Connecté
   pro-badge: Dozzle Cloud Pro
   plan: Plan
-  usage: Événements pour cette période
+  usage: Événements
+  usage-agent-messages: Discussions avec l'agent
+  usage-log-bytes: Données indexées
   dashboard: Tableau de bord
   settings: Paramètres
   error: Erreur de connexion. Veuillez relier votre instance.

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -558,7 +558,9 @@ cloud:
   connected: Terhubung
   pro-badge: Dozzle Cloud Pro
   plan: Paket
-  usage: Event periode ini
+  usage: Event
+  usage-agent-messages: Obrolan agen
+  usage-log-bytes: Data terindeks
   dashboard: Dasbor
   settings: Pengaturan
   error: Kesalahan koneksi. Silakan tautkan ulang instans Anda.

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -546,7 +546,9 @@ cloud:
   connected: Connesso
   pro-badge: Dozzle Cloud Pro
   plan: Piano
-  usage: Eventi in questo periodo
+  usage: Eventi
+  usage-agent-messages: Chat con l'agente
+  usage-log-bytes: Dati indicizzati
   dashboard: Dashboard
   settings: Impostazioni
   error: Errore di connessione. Ricollega la tua istanza.

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -550,7 +550,9 @@ cloud:
   connected: 연결됨
   pro-badge: Dozzle Cloud Pro
   plan: 플랜
-  usage: 이번 기간 이벤트
+  usage: 이벤트
+  usage-agent-messages: 에이전트 대화
+  usage-log-bytes: 색인된 데이터
   dashboard: 대시보드
   settings: 설정
   error: 연결 오류. 인스턴스를 다시 연결해 주세요.

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -547,7 +547,9 @@ cloud:
   connected: Verbonden
   pro-badge: Dozzle Cloud Pro
   plan: Plan
-  usage: Gebeurtenissen deze periode
+  usage: Gebeurtenissen
+  usage-agent-messages: Agentgesprekken
+  usage-log-bytes: Geïndexeerde data
   dashboard: Dashboard
   settings: Instellingen
   error: Verbindingsfout. Koppel je instantie opnieuw.

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -549,7 +549,9 @@ cloud:
   connected: Połączony
   pro-badge: Dozzle Cloud Pro
   plan: Plan
-  usage: Zdarzenia w tym okresie
+  usage: Zdarzenia
+  usage-agent-messages: Czaty z agentem
+  usage-log-bytes: Zaindeksowane dane
   dashboard: Panel
   settings: Ustawienia
   error: Błąd połączenia. Połącz ponownie swoją instancję.

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -546,7 +546,9 @@ cloud:
   connected: Conectado
   pro-badge: Dozzle Cloud Pro
   plan: Plano
-  usage: Eventos neste período
+  usage: Eventos
+  usage-agent-messages: Conversas com o agente
+  usage-log-bytes: Dados indexados
   dashboard: Painel
   settings: Configurações
   error: Erro de conexão. Por favor, revincule sua instância.

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -546,7 +546,9 @@ cloud:
   connected: Подключён
   pro-badge: Dozzle Cloud Pro
   plan: План
-  usage: События за этот период
+  usage: События
+  usage-agent-messages: Чаты с агентом
+  usage-log-bytes: Проиндексированные данные
   dashboard: Панель управления
   settings: Настройки
   error: Ошибка подключения. Пожалуйста, привяжите экземпляр повторно.

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -552,7 +552,9 @@ cloud:
   connected: Povezano
   pro-badge: Dozzle Cloud Pro
   plan: Načrt
-  usage: Dogodki v tem obdobju
+  usage: Dogodki
+  usage-agent-messages: Klepeti z agentom
+  usage-log-bytes: Indeksirani podatki
   dashboard: Nadzorna plošča
   settings: Nastavitve
   error: Napaka povezave. Prosimo, ponovno povežite svojo instanco.

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -550,7 +550,9 @@ cloud:
   connected: Bağlı
   pro-badge: Dozzle Cloud Pro
   plan: Plan
-  usage: Bu dönemdeki olaylar
+  usage: Olaylar
+  usage-agent-messages: Aracı sohbetleri
+  usage-log-bytes: Dizine eklenen veri
   dashboard: Pano
   settings: Ayarlar
   error: Bağlantı hatası. Lütfen örneğinizi yeniden bağlayın.

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -549,7 +549,9 @@ cloud:
   connected: 已連線
   pro-badge: Dozzle Cloud Pro
   plan: 方案
-  usage: 本期事件數
+  usage: 事件
+  usage-agent-messages: 智慧代理對話
+  usage-log-bytes: 已索引資料
   dashboard: 儀表板
   settings: 設定
   error: 連線錯誤。請重新連結您的實例。

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -546,7 +546,9 @@ cloud:
   connected: 已连接
   pro-badge: Dozzle Cloud Pro
   plan: 计划
-  usage: 本期事件数
+  usage: 事件
+  usage-agent-messages: 智能体对话
+  usage-log-bytes: 已索引数据
   dashboard: 仪表盘
   settings: 设置
   error: 连接错误。请重新关联您的实例。


### PR DESCRIPTION
Stacked on #5071. Review that one first; this PR targets `redesign-cloud-destination-drawer` and the diff below is only the second commit.

The plan meters three things and the UI showed one, so the agent chat and log byte caps stayed invisible until one of them bit. The cloud already tracks both in `usage_counters` and both limits already ride on the plan, so this is a display change on top of a small `/api/status` addition on the doligence side.

- `CloudUsage` renders the whole usage block once, shared by the popover, the settings card and the destination drawer. Billing period is stated once underneath instead of under every bar.
- The two new meters are guarded on their limit being present. An instance can point at a cloud that has not shipped them yet, and a meter reading 0 / 0 would claim the account was out of agent chats rather than admitting it does not know.
- Byte meters format through `formatBytes`, because `3221225472 / 10737418240` says nothing at a glance.
- `cloud.usage` drops "this period" now that the period has its own line, and the two new labels are translated in all 16 locales.

Needs the doligence change (agent_messages_used / log_bytes_used on `/api/status`) deployed first. Until then the extra meters simply do not render.

Typecheck, build and all 302 frontend tests pass. Not verified visually in a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqAH4x8o7nrTN3Z3UB4MRR
