### PR TITLE
fix(analytics): jsonOnly keeps only complex events

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -38,10 +38,12 @@ declare global {
   const createContainerHints: typeof import('./composable/exprEditor').createContainerHints
   const createDisposableDirective: typeof import('@vueuse/core').createDisposableDirective
   const createDrawer: typeof import('./composable/drawer').createDrawer
+  const createEditorTheme: typeof import('./composable/editorTheme').createEditorTheme
   const createEventHints: typeof import('./composable/exprEditor').createEventHints
   const createEventHook: typeof import('@vueuse/core').createEventHook
   const createExprEditor: typeof import('./composable/exprEditor').createExprEditor
   const createGlobalState: typeof import('@vueuse/core').createGlobalState
+  const createHighlightStyle: typeof import('./composable/editorTheme').createHighlightStyle
   const createInjectionState: typeof import('@vueuse/core').createInjectionState
   const createLogHints: typeof import('./composable/exprEditor').createLogHints
   const createMetricHints: typeof import('./composable/exprEditor').createMetricHints
@@ -49,6 +51,7 @@ declare global {
   const createReactiveFn: typeof import('@vueuse/core').createReactiveFn
   const createRef: typeof import('@vueuse/core').createRef
   const createReusableTemplate: typeof import('@vueuse/core').createReusableTemplate
+  const createSQLEditor: typeof import('./composable/sqlEditor').createSQLEditor
   const createSharedComposable: typeof import('@vueuse/core').createSharedComposable
   const createTemplateEditor: typeof import('./composable/templateEditor').createTemplateEditor
   const createTemplatePromise: typeof import('@vueuse/core').createTemplatePromise
@@ -363,6 +366,7 @@ declare global {
   const useResolvedTheme: typeof import('./composable/theme').useResolvedTheme
   const useRoute: typeof import('vue-router/auto').useRoute
   const useRouter: typeof import('vue-router/auto').useRouter
+  const useSQLEditorField: typeof import('./composable/useSQLEditorField').useSQLEditorField
   const useSSRWidth: typeof import('@vueuse/core').useSSRWidth
   const useScreenOrientation: typeof import('@vueuse/core').useScreenOrientation
   const useScreenSafeArea: typeof import('@vueuse/core').useScreenSafeArea
@@ -478,6 +482,9 @@ declare global {
   export type { PopoverPlacement } from './composable/popover'
   import('./composable/popover')
   // @ts-ignore
+  export type { SQLColumn, SQLEditorOptions } from './composable/sqlEditor'
+  import('./composable/sqlEditor')
+  // @ts-ignore
   export type { TemplateEditorOptions, TemplateVariable, PayloadMode } from './composable/templateEditor'
   import('./composable/templateEditor')
   // @ts-ignore
@@ -529,10 +536,12 @@ declare module 'vue' {
     readonly createContainerHints: UnwrapRef<typeof import('./composable/exprEditor')['createContainerHints']>
     readonly createDisposableDirective: UnwrapRef<typeof import('@vueuse/core')['createDisposableDirective']>
     readonly createDrawer: UnwrapRef<typeof import('./composable/drawer')['createDrawer']>
+    readonly createEditorTheme: UnwrapRef<typeof import('./composable/editorTheme')['createEditorTheme']>
     readonly createEventHints: UnwrapRef<typeof import('./composable/exprEditor')['createEventHints']>
     readonly createEventHook: UnwrapRef<typeof import('@vueuse/core')['createEventHook']>
     readonly createExprEditor: UnwrapRef<typeof import('./composable/exprEditor')['createExprEditor']>
     readonly createGlobalState: UnwrapRef<typeof import('@vueuse/core')['createGlobalState']>
+    readonly createHighlightStyle: UnwrapRef<typeof import('./composable/editorTheme')['createHighlightStyle']>
     readonly createInjectionState: UnwrapRef<typeof import('@vueuse/core')['createInjectionState']>
     readonly createLogHints: UnwrapRef<typeof import('./composable/exprEditor')['createLogHints']>
     readonly createMetricHints: UnwrapRef<typeof import('./composable/exprEditor')['createMetricHints']>
@@ -540,6 +549,7 @@ declare module 'vue' {
     readonly createReactiveFn: UnwrapRef<typeof import('@vueuse/core')['createReactiveFn']>
     readonly createRef: UnwrapRef<typeof import('@vueuse/core')['createRef']>
     readonly createReusableTemplate: UnwrapRef<typeof import('@vueuse/core')['createReusableTemplate']>
+    readonly createSQLEditor: UnwrapRef<typeof import('./composable/sqlEditor')['createSQLEditor']>
     readonly createSharedComposable: UnwrapRef<typeof import('@vueuse/core')['createSharedComposable']>
     readonly createTemplateEditor: UnwrapRef<typeof import('./composable/templateEditor')['createTemplateEditor']>
     readonly createTemplatePromise: UnwrapRef<typeof import('@vueuse/core')['createTemplatePromise']>
@@ -848,6 +858,7 @@ declare module 'vue' {
     readonly useResolvedTheme: UnwrapRef<typeof import('./composable/theme')['useResolvedTheme']>
     readonly useRoute: UnwrapRef<typeof import('vue-router/auto')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router/auto')['useRouter']>
+    readonly useSQLEditorField: UnwrapRef<typeof import('./composable/useSQLEditorField')['useSQLEditorField']>
     readonly useSSRWidth: UnwrapRef<typeof import('@vueuse/core')['useSSRWidth']>
     readonly useScreenOrientation: UnwrapRef<typeof import('@vueuse/core')['useScreenOrientation']>
     readonly useScreenSafeArea: UnwrapRef<typeof import('@vueuse/core')['useScreenSafeArea']>

--- a/assets/components/ContainerViewer/ContainerActionsToolbar.vue
+++ b/assets/components/ContainerViewer/ContainerActionsToolbar.vue
@@ -43,7 +43,7 @@
       </li>
       <li v-if="hasComplexLogs">
         <a @click="showDrawer(LogAnalytics, { container }, 'lg')">
-          <ph:file-sql /> SQL Analytics
+          <ph:file-sql /> {{ $t("analytics.title") }}
           <KeyShortcut char="f" :modifiers="['shift', 'meta']" />
         </a>
       </li>

--- a/assets/components/LogViewer/LogAnalytics.vue
+++ b/assets/components/LogViewer/LogAnalytics.vue
@@ -1,56 +1,96 @@
 <template>
-  <aside class="flex flex-col gap-5 pb-8">
-    <header class="flex items-center gap-3 pr-8">
-      <ph:file-sql class="text-primary size-7 shrink-0" />
-      <div class="flex min-w-0 flex-col">
-        <h1 class="text-xl leading-tight font-semibold">{{ $t("analytics.title") }}</h1>
-        <p class="text-base-content/60 flex items-center gap-1.5 text-sm">
-          <span class="truncate">{{ container.name }}</span>
-          <span class="opacity-40">·</span>
-          <RelativeTime :date="container.created" />
-        </p>
+  <!-- pr-24 keeps the title clear of the drawer's maximize/close buttons, which
+       float over this slot. -->
+  <header class="border-base-content/10 flex flex-wrap items-center gap-x-3 gap-y-1 border-b pr-24 pb-4">
+    <ph:file-sql class="text-primary size-6 shrink-0" />
+    <h1 class="text-base font-semibold">{{ $t("analytics.title") }}</h1>
+    <h2 class="text-base-content/55 flex min-w-0 items-center text-xs">
+      <span class="truncate">{{ container.name }}</span>
+      <span class="px-1">&middot;</span>
+      <RelativeTime :date="container.created" />
+    </h2>
+  </header>
+
+  <div class="mt-5 flex flex-col gap-6 pb-8">
+    <section class="flex flex-col gap-2">
+      <div class="flex items-center gap-3">
+        <div class="field-label">{{ $t("analytics.query") }}</div>
+        <div class="text-base-content/40 ml-auto flex items-center gap-1.5 text-xs">
+          <KeyShortcut char="&crarr;" />
+          {{ $t("analytics.run") }}
+        </div>
       </div>
-    </header>
+
+      <div
+        class="bg-base-200 focus-within:border-primary/60 min-h-24 rounded-md border px-3 py-1"
+        :class="error ? 'border-error/50' : 'border-base-content/10'"
+      >
+        <div ref="editorEl" class="w-full" :aria-label="$t('analytics.title')"></div>
+      </div>
+
+      <!-- Binder errors name the offending column and clause, so they wrap
+           rather than truncate: the useful half is usually at the end. -->
+      <p
+        v-if="error"
+        class="border-error/30 bg-error/10 text-error rounded-md border px-3 py-2 font-mono text-xs leading-relaxed whitespace-pre-wrap"
+      >
+        {{ error }}
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-3" v-if="state === 'ready' && columns.length">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+        <div class="field-label">{{ $t("analytics.examples") }}</div>
+        <button v-for="ex in examples" :key="ex.key" class="chip" @click="applyExample(ex.sql)">
+          {{ $t(ex.key, ex.params ?? {}) }}
+        </button>
+      </div>
+
+      <details class="group">
+        <summary class="text-base-content/50 hover:text-base-content/80 flex w-fit cursor-pointer items-center gap-1">
+          <ph:caret-right class="size-3 transition-transform group-open:rotate-90" />
+          <span class="field-label">{{ $t("analytics.columns") }}</span>
+          <span class="text-xs opacity-60">{{ columns.length }}</span>
+        </summary>
+        <div class="mt-2 flex max-h-40 flex-wrap gap-1.5 overflow-y-auto">
+          <button
+            v-for="col in columns"
+            :key="col.name"
+            class="chip font-mono"
+            :title="col.type"
+            @click="insertColumn(col.name)"
+          >
+            {{ col.name }}
+          </button>
+        </div>
+      </details>
+    </section>
 
     <section class="flex flex-col gap-2">
-      <textarea
-        ref="queryEl"
-        v-model="query"
-        class="textarea textarea-primary w-full resize-y font-mono text-sm leading-relaxed"
-        :class="{ 'textarea-error!': error }"
-        :disabled="state !== 'ready'"
-        rows="3"
-        spellcheck="false"
-        autocapitalize="off"
-        autocomplete="off"
-        :aria-label="$t('analytics.title')"
-        @keydown.meta.enter.prevent="run"
-        @keydown.ctrl.enter.prevent="run"
-      ></textarea>
+      <div class="flex items-center gap-3">
+        <div class="field-label shrink-0">{{ $t("analytics.results") }}</div>
 
-      <div class="flex min-h-6 items-center text-sm">
-        <div class="min-w-0 flex-1 truncate">
-          <span class="text-error" v-if="error">{{ error }}</span>
-          <span class="text-base-content/60 inline-flex items-center gap-2" v-else-if="state === 'initializing'">
+        <p class="text-base-content/45 min-w-0 truncate text-xs">
+          <span class="inline-flex items-center gap-2" v-if="state === 'initializing'">
             <span class="loading loading-spinner loading-xs"></span>{{ $t("analytics.creating_table") }}
           </span>
-          <span class="text-base-content/60 inline-flex items-center gap-2" v-else-if="state === 'downloading'">
+          <span class="inline-flex items-center gap-2" v-else-if="state === 'downloading'">
             <span class="loading loading-spinner loading-xs"></span
             >{{ $t("analytics.downloading", { size: formatBytes(bytes, { decimals: 1 }) }) }}
           </span>
-          <span class="text-base-content/60 inline-flex items-center gap-2" v-else-if="evaluating">
+          <span class="inline-flex items-center gap-2" v-else-if="evaluating">
             <span class="loading loading-spinner loading-xs"></span>{{ $t("analytics.evaluating_query") }}
           </span>
-          <span class="text-base-content/60" v-else>
+          <template v-else>
             {{ $t("analytics.total_records", { count: results.numRows.toLocaleString() }) }}
             <template v-if="results.numRows > pageLimit">{{
               $t("analytics.showing_first", { count: page.numRows.toLocaleString() })
             }}</template>
-          </span>
-        </div>
+          </template>
+        </p>
 
         <Popover
-          class="shrink-0"
+          class="ml-auto shrink-0"
           placement="bottom-end"
           panel-class="bg-base-200 rounded-box w-44 p-2 shadow-sm"
           v-if="canExport"
@@ -75,45 +115,12 @@
           </ul>
         </Popover>
       </div>
-    </section>
 
-    <section v-if="state === 'ready' && columns.length" class="flex flex-col gap-2 text-xs">
-      <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
-        <span class="text-base-content/50 font-medium">{{ $t("analytics.examples") }}</span>
-        <button
-          v-for="ex in examples"
-          :key="ex.key"
-          class="badge badge-sm badge-outline hover:border-primary hover:text-primary cursor-pointer"
-          @click="applyExample(ex.sql)"
-        >
-          {{ $t(ex.key, ex.params ?? {}) }}
-        </button>
+      <div class="border-base-content/10 max-h-160 overflow-auto rounded-md border">
+        <SQLTable :table="page" :loading="evaluating || state !== 'ready'" />
       </div>
-
-      <details class="group">
-        <summary
-          class="text-base-content/50 hover:text-base-content/80 flex w-fit cursor-pointer items-center gap-1 font-medium select-none"
-        >
-          <ph:caret-right class="size-3 transition-transform group-open:rotate-90" />
-          {{ $t("analytics.columns") }}
-          <span class="opacity-60">{{ columns.length }}</span>
-        </summary>
-        <div class="mt-2 flex max-h-40 flex-wrap gap-1.5 overflow-y-auto">
-          <button
-            v-for="col in columns"
-            :key="col.name"
-            class="badge badge-sm badge-ghost hover:border-primary hover:text-primary cursor-pointer font-mono"
-            :title="col.type"
-            @click="insertColumn(col.name)"
-          >
-            {{ col.name }}
-          </button>
-        </div>
-      </details>
     </section>
-
-    <SQLTable :table="page" :loading="evaluating || state !== 'ready'" />
-  </aside>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -121,14 +128,26 @@ import { Container } from "@/models/Container";
 import { type Table } from "@apache-arrow/esnext-esm";
 
 const { container } = defineProps<{ container: Container }>();
-const query = ref("SELECT * FROM logs LIMIT 100");
+const defaultQuery = "SELECT * FROM logs LIMIT 100";
+const query = ref(defaultQuery);
 const error = ref<string | null>(null);
 const evaluating = ref(false);
 const pageLimit = 1000;
 const state = ref<"downloading" | "ready" | "initializing">("downloading");
 const bytes = ref(0);
 const columns = ref<{ name: string; type: string }[]>([]);
-const queryEl = useTemplateRef<HTMLTextAreaElement>("queryEl");
+const editorEl = ref<HTMLElement>();
+
+const { setValue, insertAtCursor } = useSQLEditorField(editorEl, {
+  placeholder: defaultQuery,
+  // Read once: the editor owns its content after mount, and re-seeding it on every model
+  // change would fight the user's cursor.
+  initialValue: query.value,
+  // Read lazily so completions pick up the schema the moment DESCRIBE returns.
+  getColumns: () => columns.value,
+  onRun: () => run(),
+  onChange: (v) => (query.value = v),
+});
 
 const runQuery = ref(query.value);
 watchDebounced(query, (v) => (runQuery.value = v), { debounce: 500 });
@@ -216,25 +235,13 @@ function run() {
 }
 
 function applyExample(sql: string) {
-  query.value = sql;
+  setValue(sql);
   nextTick(run);
 }
 
 function insertColumn(name: string) {
-  const text = `"${name}"`;
-  const el = queryEl.value;
-  if (!el) {
-    query.value += text;
-    return;
-  }
-  const start = el.selectionStart ?? query.value.length;
-  const end = el.selectionEnd ?? start;
-  query.value = query.value.slice(0, start) + text + query.value.slice(end);
-  nextTick(() => {
-    el.focus();
-    const pos = start + text.length;
-    el.setSelectionRange(pos, pos);
-  });
+  // Matches what completion applies: bare when it is a legal identifier, quoted otherwise.
+  insertAtCursor(/^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `"${name}"`);
 }
 
 const results = computedAsync(
@@ -314,4 +321,21 @@ function exportResults(format: "csv" | "json") {
   (document.activeElement as HTMLElement | null)?.blur();
 }
 </script>
-<style scoped></style>
+<style scoped>
+@reference "@/main.css";
+
+/* Same label style as LogDetails, so both log drawers give the eye one "this is
+   a label, not content" cue. */
+.field-label {
+  @apply text-base-content/50 text-[0.7rem] font-semibold tracking-wider uppercase;
+}
+
+/* Examples and column names are both "click to put this in the query", so they
+   share one affordance instead of two different daisyUI badge variants. */
+.chip {
+  @apply border-base-content/15 text-base-content/80 cursor-pointer rounded border px-2 py-0.5 text-xs transition-colors;
+}
+.chip:hover {
+  @apply border-primary/50 text-primary;
+}
+</style>

--- a/assets/components/LogViewer/SQLTable.vue
+++ b/assets/components/LogViewer/SQLTable.vue
@@ -1,14 +1,20 @@
 <template>
   <div class="w-full overflow-x-auto" v-if="!loading">
-    <table class="table-zebra table-pin-rows table-md table" v-if="columns.length">
+    <table class="w-full border-collapse text-sm" v-if="columns.length">
       <thead>
         <tr>
-          <th v-for="column in columns" :key="column" class="font-mono">{{ column }}</th>
+          <th
+            v-for="column in columns"
+            :key="column"
+            class="bg-base-100 border-base-content/15 text-base-content/50 sticky top-0 z-10 border-b px-3 py-2 text-left font-mono text-xs font-medium whitespace-nowrap"
+          >
+            {{ column }}
+          </th>
         </tr>
       </thead>
       <tbody>
-        <tr v-for="(row, index) in table" :key="index">
-          <td v-for="column in columns" :key="column" class="max-w-md align-top">
+        <tr v-for="(row, index) in table" :key="index" class="result-row">
+          <td v-for="column in columns" :key="column" class="max-w-md px-3 py-1.5 align-top">
             <span v-if="format(row[column]) === null" class="text-base-content/30 italic">NULL</span>
             <span v-else class="block truncate font-mono" :title="format(row[column]) ?? undefined">{{
               format(row[column])
@@ -22,18 +28,18 @@
       <span>{{ $t("analytics.no_results") }}</span>
     </div>
   </div>
-  <table class="table-md table" v-else>
+  <table class="w-full border-collapse text-sm" v-else>
     <thead>
       <tr>
-        <th v-for="i in 3" :key="i">
-          <div class="bg-base-content/50 h-4 w-20 animate-pulse opacity-50"></div>
+        <th v-for="i in 3" :key="i" class="border-base-content/15 border-b px-3 py-2 text-left">
+          <div class="bg-base-content/50 h-3 w-20 animate-pulse rounded opacity-50"></div>
         </th>
       </tr>
     </thead>
     <tbody>
-      <tr v-for="i in 9" :key="i">
-        <td v-for="j in 3" :key="j">
-          <div class="bg-base-content/50 h-4 w-20 animate-pulse opacity-20"></div>
+      <tr v-for="i in 9" :key="i" class="border-base-content/10 border-b">
+        <td v-for="j in 3" :key="j" class="px-3 py-2">
+          <div class="bg-base-content/50 h-3 w-20 animate-pulse rounded opacity-20"></div>
         </td>
       </tr>
     </tbody>
@@ -62,3 +68,15 @@ function format(value: unknown): string | null {
   return String(value);
 }
 </script>
+<style scoped>
+@reference "@/main.css";
+
+/* Zebra striping fought the drawer's own surfaces; a hairline plus a hover tint
+   reads the same as the field table in LogDetails. */
+.result-row {
+  @apply border-base-content/10 border-b transition-colors;
+}
+.result-row:hover {
+  background-color: color-mix(in oklab, var(--color-base-content) 6%, transparent);
+}
+</style>

--- a/assets/composable/editorTheme.ts
+++ b/assets/composable/editorTheme.ts
@@ -1,0 +1,104 @@
+import type { EditorView as EditorViewType } from "@codemirror/view";
+import type { HighlightStyle as HighlightStyleType } from "@codemirror/language";
+import type { tags as tagsType } from "@lezer/highlight";
+
+/**
+ * The look shared by every CodeMirror field in the app (expression inputs, the SQL
+ * console). CodeMirror is loaded lazily, so the constructors are passed in rather than
+ * imported here — importing them statically would pull the editor into the entry chunk.
+ */
+export function createEditorTheme(EditorView: typeof EditorViewType, { multiline = false } = {}) {
+  return EditorView.theme({
+    "&": {
+      backgroundColor: "transparent",
+      color: "var(--color-base-content)",
+      fontSize: "0.875rem",
+      width: "100%",
+    },
+    "&.cm-editor.cm-focused": {
+      // The wrapping DaisyUI `.input` already draws the focus ring.
+      outline: "none",
+    },
+    ".cm-scroller": {
+      fontFamily: "var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)",
+      lineHeight: "1.6",
+    },
+    ".cm-content": {
+      caretColor: "var(--color-primary)",
+      padding: "0.375rem 0",
+    },
+    ".cm-line": {
+      padding: "0",
+    },
+    ".cm-cursor": {
+      borderLeftColor: "var(--color-primary)",
+      borderLeftWidth: "2px",
+    },
+    ".cm-placeholder": {
+      color: "color-mix(in oklch, var(--color-base-content) 40%, transparent)",
+      fontStyle: "normal",
+    },
+    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection": {
+      backgroundColor: "color-mix(in oklch, var(--color-primary) 25%, transparent)",
+    },
+    ".cm-activeLine": {
+      // A single-line expression field looks broken with a highlighted "active line";
+      // a multi-line query is easier to follow with one.
+      backgroundColor: multiline ? "color-mix(in oklch, var(--color-base-content) 4%, transparent)" : "transparent",
+    },
+    ".cm-tooltip": {
+      backgroundColor: "var(--color-base-200)",
+      border: "1px solid color-mix(in oklch, var(--color-base-content) 15%, transparent)",
+      borderRadius: "var(--radius-box, 0.5rem)",
+      boxShadow: "0 8px 24px rgb(0 0 0 / 0.18)",
+      overflow: "hidden",
+    },
+    ".cm-tooltip.cm-tooltip-autocomplete > ul": {
+      fontFamily: "var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)",
+      fontSize: "0.8125rem",
+      maxHeight: "16rem",
+    },
+    ".cm-tooltip.cm-tooltip-autocomplete > ul > li": {
+      padding: "0.25rem 0.625rem",
+      color: "var(--color-base-content)",
+      display: "flex",
+      alignItems: "baseline",
+      gap: "0.5rem",
+    },
+    ".cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]": {
+      backgroundColor: "var(--color-primary)",
+      color: "var(--color-primary-content)",
+    },
+    ".cm-completionLabel": {
+      flex: "1 1 auto",
+    },
+    ".cm-completionMatchedText": {
+      textDecoration: "none",
+      fontWeight: "600",
+      color: "var(--color-primary)",
+    },
+    "li[aria-selected] .cm-completionMatchedText": {
+      color: "var(--color-primary-content)",
+    },
+    ".cm-completionDetail": {
+      fontStyle: "normal",
+      fontSize: "0.75rem",
+      opacity: "0.6",
+      flex: "0 0 auto",
+    },
+  });
+}
+
+export function createHighlightStyle(HighlightStyle: typeof HighlightStyleType, tags: typeof tagsType) {
+  return HighlightStyle.define([
+    { tag: tags.keyword, color: "var(--color-secondary)", fontWeight: "600" },
+    { tag: tags.operator, color: "color-mix(in oklch, var(--color-base-content) 70%, transparent)" },
+    { tag: tags.string, color: "var(--color-success)" },
+    { tag: tags.number, color: "var(--color-warning)" },
+    { tag: tags.bool, color: "var(--color-warning)" },
+    { tag: tags.propertyName, color: "var(--color-info)" },
+    { tag: tags.variableName, color: "var(--color-base-content)" },
+    { tag: tags.comment, color: "color-mix(in oklch, var(--color-base-content) 45%, transparent)" },
+    { tag: tags.function(tags.variableName), color: "var(--color-secondary)" },
+  ]);
+}

--- a/assets/composable/exprEditor.ts
+++ b/assets/composable/exprEditor.ts
@@ -1,5 +1,6 @@
 import type { Completion, CompletionContext, CompletionSource } from "@codemirror/autocomplete";
 import type { StringStream } from "@codemirror/language";
+import { createEditorTheme, createHighlightStyle } from "@/composable/editorTheme";
 
 export interface ExprEditorOptions {
   parent: HTMLElement;
@@ -237,94 +238,8 @@ export async function createExprEditor(options: ExprEditorOptions) {
     },
   });
 
-  const editorTheme = EditorView.theme({
-    "&": {
-      backgroundColor: "transparent",
-      color: "var(--color-base-content)",
-      fontSize: "0.875rem",
-      width: "100%",
-    },
-    "&.cm-editor.cm-focused": {
-      // The wrapping DaisyUI `.input` already draws the focus ring.
-      outline: "none",
-    },
-    ".cm-scroller": {
-      fontFamily: "var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)",
-      lineHeight: "1.6",
-    },
-    ".cm-content": {
-      caretColor: "var(--color-primary)",
-      padding: "0.375rem 0",
-    },
-    ".cm-line": {
-      padding: "0",
-    },
-    ".cm-cursor": {
-      borderLeftColor: "var(--color-primary)",
-      borderLeftWidth: "2px",
-    },
-    ".cm-placeholder": {
-      color: "color-mix(in oklch, var(--color-base-content) 40%, transparent)",
-      fontStyle: "normal",
-    },
-    "&.cm-focused .cm-selectionBackground, .cm-selectionBackground, ::selection": {
-      backgroundColor: "color-mix(in oklch, var(--color-primary) 25%, transparent)",
-    },
-    ".cm-activeLine": {
-      // A single-line expression field looks broken with a highlighted "active line".
-      backgroundColor: "transparent",
-    },
-    ".cm-tooltip": {
-      backgroundColor: "var(--color-base-200)",
-      border: "1px solid color-mix(in oklch, var(--color-base-content) 15%, transparent)",
-      borderRadius: "var(--radius-box, 0.5rem)",
-      boxShadow: "0 8px 24px rgb(0 0 0 / 0.18)",
-      overflow: "hidden",
-    },
-    ".cm-tooltip.cm-tooltip-autocomplete > ul": {
-      fontFamily: "var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace)",
-      fontSize: "0.8125rem",
-      maxHeight: "16rem",
-    },
-    ".cm-tooltip.cm-tooltip-autocomplete > ul > li": {
-      padding: "0.25rem 0.625rem",
-      color: "var(--color-base-content)",
-      display: "flex",
-      alignItems: "baseline",
-      gap: "0.5rem",
-    },
-    ".cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]": {
-      backgroundColor: "var(--color-primary)",
-      color: "var(--color-primary-content)",
-    },
-    ".cm-completionLabel": {
-      flex: "1 1 auto",
-    },
-    ".cm-completionMatchedText": {
-      textDecoration: "none",
-      fontWeight: "600",
-      color: "var(--color-primary)",
-    },
-    "li[aria-selected] .cm-completionMatchedText": {
-      color: "var(--color-primary-content)",
-    },
-    ".cm-completionDetail": {
-      fontStyle: "normal",
-      fontSize: "0.75rem",
-      opacity: "0.6",
-      flex: "0 0 auto",
-    },
-  });
-
-  const highlightStyle = HighlightStyle.define([
-    { tag: tags.keyword, color: "var(--color-secondary)", fontWeight: "600" },
-    { tag: tags.operator, color: "color-mix(in oklch, var(--color-base-content) 70%, transparent)" },
-    { tag: tags.string, color: "var(--color-success)" },
-    { tag: tags.number, color: "var(--color-warning)" },
-    { tag: tags.bool, color: "var(--color-warning)" },
-    { tag: tags.propertyName, color: "var(--color-info)" },
-    { tag: tags.variableName, color: "var(--color-base-content)" },
-  ]);
+  const editorTheme = createEditorTheme(EditorView);
+  const highlightStyle = createHighlightStyle(HighlightStyle, tags);
 
   const state = EditorState.create({
     doc: options.initialValue,

--- a/assets/composable/sqlEditor.ts
+++ b/assets/composable/sqlEditor.ts
@@ -1,0 +1,240 @@
+import type { Completion, CompletionContext, CompletionSource } from "@codemirror/autocomplete";
+import type { StringStream } from "@codemirror/language";
+import { createEditorTheme, createHighlightStyle } from "@/composable/editorTheme";
+
+export interface SQLColumn {
+  name: string;
+  type: string;
+}
+
+export interface SQLEditorOptions {
+  parent: HTMLElement;
+  placeholder: string;
+  initialValue: string;
+  /** Read lazily: the table only exists once the logs have been loaded into DuckDB. */
+  getColumns: () => SQLColumn[];
+  /** Bound to Cmd/Ctrl+Enter. */
+  onRun?: () => void;
+  onChange?: (value: string) => void;
+}
+
+const sqlKeywords = [
+  "SELECT",
+  "FROM",
+  "WHERE",
+  "GROUP BY",
+  "ORDER BY",
+  "HAVING",
+  "LIMIT",
+  "OFFSET",
+  "AS",
+  "DISTINCT",
+  "AND",
+  "OR",
+  "NOT",
+  "IS NULL",
+  "IS NOT NULL",
+  "IN",
+  "LIKE",
+  "ILIKE",
+  "BETWEEN",
+  "CASE",
+  "WHEN",
+  "THEN",
+  "ELSE",
+  "END",
+  "ASC",
+  "DESC",
+  "WITH",
+  "UNION ALL",
+  "JOIN",
+  "ON",
+  "USING",
+];
+
+// DuckDB functions that actually earn their place against log data: counting,
+// bucketing by time, and pulling values out of text.
+const sqlFunctions: [string, string][] = [
+  ["count(*)", "row count"],
+  ["count(DISTINCT )", "distinct values"],
+  ["sum()", "sum"],
+  ["avg()", "average"],
+  ["min()", "minimum"],
+  ["max()", "maximum"],
+  ["median()", "median"],
+  ["quantile_cont(, 0.95)", "95th percentile"],
+  ["approx_count_distinct()", "cheap distinct count"],
+  ["epoch_ms()", "millis to timestamp"],
+  ["to_timestamp()", "seconds to timestamp"],
+  ["date_trunc('minute', )", "bucket by minute"],
+  ["strftime(, '%H:%M')", "format a timestamp"],
+  ["regexp_matches(, '')", "regex test"],
+  ["regexp_extract(, '')", "regex capture"],
+  ["lower()", "lowercase"],
+  ["coalesce(, )", "first non-null"],
+  ["cast( AS VARCHAR)", "cast a value"],
+];
+
+/** DuckDB only accepts a bare identifier for `foo`; `log.level` or `@timestamp` need quoting. */
+function quoteColumn(name: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : `"${name}"`;
+}
+
+function createAutocomplete(getColumns: () => SQLColumn[]): CompletionSource {
+  return (context: CompletionContext) => {
+    // Quotes and @ are part of a column name here, so a half-typed `"log.` still matches.
+    const word = context.matchBefore(/[\w"@.$]+/);
+    if (!word && !context.explicit) return null;
+
+    const typed = word ? word.text.replace(/^"/, "").toLowerCase() : "";
+
+    const options: Completion[] = [
+      ...getColumns().map((column): Completion => ({
+        label: column.name,
+        apply: quoteColumn(column.name),
+        detail: column.type,
+        type: "property",
+        boost: 20,
+      })),
+      { label: "logs", detail: "table", type: "class", boost: 10 },
+      ...sqlFunctions.map(([label, detail]): Completion => ({ label, detail, type: "function" })),
+      ...sqlKeywords.map((label): Completion => ({ label, type: "keyword" })),
+    ];
+
+    const filtered = typed ? options.filter((o) => o.label.toLowerCase().includes(typed)) : options;
+    return { from: word ? word.from : context.pos, options: filtered };
+  };
+}
+
+const keywordSet = new Set(sqlKeywords.flatMap((k) => k.split(" ")));
+const typeSet = new Set(["VARCHAR", "BIGINT", "INTEGER", "DOUBLE", "BOOLEAN", "TIMESTAMP", "DATE", "JSON", "STRUCT"]);
+const literalSet = new Set(["TRUE", "FALSE", "NULL"]);
+
+/**
+ * Minimal SQL tokenizer. Same reasoning as the expr one: without a language attached
+ * CodeMirror never assigns highlight tags and the query renders as flat text.
+ */
+function tokenizeSQL(stream: StringStream): string | null {
+  if (stream.eatSpace()) return null;
+
+  if (stream.match("--")) {
+    stream.skipToEnd();
+    return "comment";
+  }
+
+  if (stream.match("/*")) {
+    while (!stream.eol()) {
+      if (stream.match("*/")) break;
+      stream.next();
+    }
+    return "comment";
+  }
+
+  const char = stream.peek();
+  if (char === undefined) {
+    stream.next();
+    return null;
+  }
+
+  // Single quotes are string literals; double quotes are quoted identifiers.
+  if (char === "'" || char === '"') {
+    const quote = stream.next();
+    let ch: string | void;
+    while ((ch = stream.next()) !== undefined) {
+      if (ch === quote) {
+        // '' inside a string is an escaped quote, not the end of it.
+        if (stream.peek() === quote) {
+          stream.next();
+          continue;
+        }
+        break;
+      }
+    }
+    return quote === "'" ? "string" : "propertyName";
+  }
+
+  if (stream.match(/^\d+(\.\d+)?/)) return "number";
+
+  if (stream.match(/^[@$]?[A-Za-z_][\w]*/)) {
+    const word = stream.current().toUpperCase();
+    if (literalSet.has(word)) return "bool";
+    if (keywordSet.has(word) || typeSet.has(word)) return "keyword";
+    // A word followed by "(" is a call, everything else is a column reference.
+    return stream.peek() === "(" ? "function" : "propertyName";
+  }
+
+  if (stream.match(/^(<>|!=|>=|<=|\|\||[=<>+\-*/%,;()])/)) return "operator";
+
+  stream.next();
+  return null;
+}
+
+export async function createSQLEditor(options: SQLEditorOptions) {
+  const [
+    { EditorView, keymap, placeholder, drawSelection, highlightActiveLine },
+    { EditorState, Prec },
+    { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap },
+    { HighlightStyle, syntaxHighlighting, StreamLanguage, indentOnInput, bracketMatching },
+    { history, historyKeymap, defaultKeymap },
+    { tags },
+  ] = await Promise.all([
+    import("@codemirror/view"),
+    import("@codemirror/state"),
+    import("@codemirror/autocomplete"),
+    import("@codemirror/language"),
+    import("@codemirror/commands"),
+    import("@lezer/highlight"),
+  ]);
+
+  const sqlLanguage = StreamLanguage.define({
+    name: "sql",
+    token: tokenizeSQL,
+    languageData: {
+      commentTokens: { line: "--" },
+      closeBrackets: { brackets: ["(", "[", "'", '"'] },
+    },
+  });
+
+  const state = EditorState.create({
+    doc: options.initialValue,
+    extensions: [
+      EditorView.lineWrapping,
+      sqlLanguage,
+      history(),
+      drawSelection(),
+      highlightActiveLine(),
+      bracketMatching(),
+      closeBrackets(),
+      indentOnInput(),
+      placeholder(options.placeholder),
+      autocompletion({
+        override: [createAutocomplete(options.getColumns)],
+        activateOnTyping: true,
+        icons: false,
+      }),
+      // Above the default keymap so Cmd/Ctrl+Enter runs the query instead of
+      // inserting a newline. Plain Enter still breaks the line.
+      Prec.high(
+        keymap.of([
+          {
+            key: "Mod-Enter",
+            run: () => {
+              options.onRun?.();
+              return true;
+            },
+          },
+        ]),
+      ),
+      keymap.of([...closeBracketsKeymap, ...completionKeymap, ...historyKeymap, ...defaultKeymap]),
+      createEditorTheme(EditorView, { multiline: true }),
+      syntaxHighlighting(createHighlightStyle(HighlightStyle, tags)),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged && options.onChange) {
+          options.onChange(update.view.state.doc.toString());
+        }
+      }),
+    ],
+  });
+
+  return new EditorView({ state, parent: options.parent });
+}

--- a/assets/composable/useSQLEditorField.ts
+++ b/assets/composable/useSQLEditorField.ts
@@ -1,0 +1,51 @@
+import { createSQLEditor } from "@/composable/sqlEditor";
+
+type SQLEditorOptions = Parameters<typeof createSQLEditor>[0];
+
+/** Mount/teardown wrapper around createSQLEditor. Mirrors useExprEditorField. */
+export function useSQLEditorField(editorRef: Ref<HTMLElement | undefined>, options: Omit<SQLEditorOptions, "parent">) {
+  let editorView: Awaited<ReturnType<typeof createSQLEditor>> | undefined;
+  // CodeMirror loads lazily, so a setValue that lands before it is ready (an example
+  // chip clicked on a fast connection) is applied once it mounts.
+  let pending: string | undefined;
+
+  onMounted(async () => {
+    if (editorRef.value) {
+      editorView = await createSQLEditor({ parent: editorRef.value, ...options });
+      if (pending !== undefined) {
+        const value = pending;
+        pending = undefined;
+        setValue(value);
+      }
+    }
+  });
+
+  onScopeDispose(() => editorView?.destroy());
+
+  /** Replaces the editor's content, e.g. when an example is picked. */
+  function setValue(value: string) {
+    if (!editorView) {
+      pending = value;
+      options.onChange?.(value);
+      return;
+    }
+    editorView.dispatch({
+      changes: { from: 0, to: editorView.state.doc.length, insert: value },
+      selection: { anchor: value.length },
+    });
+    editorView.focus();
+  }
+
+  /** Inserts text at the cursor, e.g. a column name from the column list. */
+  function insertAtCursor(text: string) {
+    if (!editorView) return;
+    const { from, to } = editorView.state.selection.main;
+    editorView.dispatch({
+      changes: { from, to, insert: text },
+      selection: { anchor: from + text.length },
+    });
+    editorView.focus();
+  }
+
+  return { setValue, insertAtCursor };
+}

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"cmp"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -8,7 +9,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -216,7 +217,10 @@ func (h *handler) fetchLogsBetweenDates(w http.ResponseWriter, r *http.Request) 
 
 		for event := range events {
 			if everything {
-				if _, ok := event.Message.(string); onlyComplex && ok {
+				// Grouped events carry a []string message, so filtering on "not a
+				// string" still lets arrays through and breaks struct inference for
+				// consumers like the SQL analytics view.
+				if onlyComplex && event.Type != container.LogTypeComplex {
 					continue
 				}
 				if regex != nil && inverse == support_web.Search(regex, event) {
@@ -460,17 +464,23 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 			defer func() {
 				send(searchStatus{ScannedTo: to, Matches: found, Done: true, Reason: reason})
 			}()
+			// Resolved once, not per scan window: for an agent host FindContainer is
+			// a gRPC round-trip, and the walk below re-visits every container on each
+			// widening pass. Container metadata doesn't change under us mid-scan.
+			services := make([]*container_support.ContainerService, 0, len(existingContainers))
+			for _, c := range existingContainers {
+				containerService, err := h.hostService.FindContainer(c.Host, c.ID, userLabels)
+				if err != nil {
+					log.Error().Err(err).Msg("error while finding container")
+					return
+				}
+				services = append(services, containerService)
+			}
+
 			for minimum > 0 {
 				events := make([]*container.LogEvent, 0)
 				stillRunning := false
-				for _, container := range existingContainers {
-					containerService, err := h.hostService.FindContainer(container.Host, container.ID, userLabels)
-
-					if err != nil {
-						log.Error().Err(err).Msg("error while finding container")
-						return
-					}
-
+				for _, containerService := range services {
 					if to.Before(containerService.Container.Created) {
 						continue
 					}
@@ -500,8 +510,10 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 				delta *= 2
 				minimum -= len(events)
 				found += len(events)
-				sort.Slice(events, func(i, j int) bool {
-					return events[i].Timestamp < events[j].Timestamp
+				// Stable so that events sharing a timestamp keep the per-container
+				// order they were collected in rather than shuffling between passes.
+				slices.SortStableFunc(events, func(a, b *container.LogEvent) int {
+					return cmp.Compare(a.Timestamp, b.Timestamp)
 				})
 				if len(events) > 0 {
 					select {
@@ -517,15 +529,12 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 		}()
 	}
 
-	streamLogs := func(c container.Container) {
-		containerService, err := h.hostService.FindContainer(c.Host, c.ID, userLabels)
-		if err != nil {
-			log.Error().Err(err).Msg("error while finding container")
-			return
-		}
-		c = containerService.Container
+	streamLogsFor := func(containerService *container_support.ContainerService) {
+		c := containerService.Container
 		start := utils.Max(absoluteTime, c.StartedAt)
-		err = containerService.StreamLogs(r.Context(), start, stdTypes, liveLogs)
+		// Must stay a local: one of these runs per container, and the handler's
+		// own `err` is shared by all of them.
+		err := containerService.StreamLogs(r.Context(), start, stdTypes, liveLogs)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				log.Debug().Str("container", c.ID).Msg("streaming ended")
@@ -552,6 +561,15 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 		}
 	}
 
+	streamLogs := func(c container.Container) {
+		containerService, err := h.hostService.FindContainer(c.Host, c.ID, userLabels)
+		if err != nil {
+			log.Error().Err(err).Msg("error while finding container")
+			return
+		}
+		streamLogsFor(containerService)
+	}
+
 	for _, container := range existingContainers {
 		go streamLogs(container)
 	}
@@ -560,6 +578,7 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 	h.hostService.SubscribeContainersStarted(r.Context(), newContainers, containerFilter)
 
 	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
 	sseWriter.Ping()
 loop:
 	for {
@@ -572,7 +591,9 @@ loop:
 			support_web.EscapeHTMLValues(logEvent)
 			sseWriter.Message(logEvent)
 		case c := <-newContainers:
-			if _, err := h.hostService.FindContainer(c.Host, c.ID, userLabels); err == nil {
+			// The lookup doubles as the ACL check, so hand the resolved service
+			// straight to the streamer instead of resolving the same container twice.
+			if containerService, err := h.hostService.FindContainer(c.Host, c.ID, userLabels); err == nil {
 				// Written straight to the client instead of pushed through `events`.
 				// This case runs on the same goroutine that drains `events`, so a send
 				// here waits on a reader that is this very statement: with the buffer
@@ -584,7 +605,7 @@ loop:
 				if err := sseWriter.Event("container-event", event); err != nil {
 					log.Error().Err(err).Msg("error encoding container event")
 				}
-				go streamLogs(c)
+				go streamLogsFor(containerService)
 			}
 
 		case event := <-events:

--- a/internal/web/logs_test.go
+++ b/internal/web/logs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/url"
@@ -448,6 +449,117 @@ func Test_handler_between_dates_with_everything_complex(t *testing.T) {
 	reader := strings.NewReader(regexp.MustCompile(`"time":"[^"]*"`).ReplaceAllString(rr.Body.String(), `"time":"<removed>"`))
 	abide.AssertReader(t, t.Name(), reader)
 	mockedClient.AssertExpectations(t)
+}
+
+// jsonOnly feeds the SQL analytics view, which builds a DuckDB table with
+// `unnest(m)`. That only works when every `m` is an object, so anything that is
+// not a complex event has to be dropped here. Filtering on "the message is not a
+// string" is not enough: grouped events carry a []string, which makes DuckDB
+// infer the column as JSON and fails the whole table with a binder error.
+func Test_handler_between_dates_everything_jsonOnly(t *testing.T) {
+	// A single line, a two line group (an ERROR followed by an unlevelled
+	// continuation close in time), and a complex JSON line.
+	data := concatMessages(
+		"2020-05-13T18:55:37.772853839Z INFO Testing stdout logs...\n",
+		"2020-05-13T18:55:38.772853839Z ERROR something blew up\n",
+		"2020-05-13T18:55:38.782853839Z     at foo.bar(baz.go:1)\n",
+		"2020-05-13T18:56:37.772853839Z {\"msg\":\"a complex log message\"}\n",
+	)
+
+	tests := []struct {
+		name      string
+		jsonOnly  bool
+		wantTypes []container.LogType
+	}{
+		{
+			name:      "jsonOnly keeps complex events only",
+			jsonOnly:  true,
+			wantTypes: []container.LogType{container.LogTypeComplex},
+		},
+		{
+			name:     "without jsonOnly every event is sent",
+			jsonOnly: false,
+			wantTypes: []container.LogType{
+				container.LogTypeSingle,
+				container.LogTypeGroup,
+				container.LogTypeComplex,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			events := fetchEverything(t, data, tt.jsonOnly)
+
+			types := make([]container.LogType, 0, len(events))
+			for _, event := range events {
+				types = append(types, event.Type)
+			}
+			assert.Equal(t, tt.wantTypes, types)
+
+			for _, event := range events {
+				if !tt.jsonOnly {
+					continue
+				}
+				// unnest(m) rejects anything that is not a struct, so every
+				// message the analytics view sees must decode to an object.
+				assert.IsType(t, map[string]any{}, event.Message)
+			}
+		})
+	}
+}
+
+// fetchEverything runs the between-dates handler over data with everything=true
+// and returns the decoded events it wrote.
+func fetchEverything(t *testing.T, data []byte, jsonOnly bool) []*container.LogEvent {
+	t.Helper()
+
+	id := "123456"
+	req, err := http.NewRequest("GET", "/api/hosts/localhost/containers/"+id+"/logs", nil)
+	require.NoError(t, err, "NewRequest should not return an error.")
+
+	q := req.URL.Query()
+	q.Add("stdout", "true")
+	q.Add("stderr", "true")
+	q.Add("everything", "true")
+	if jsonOnly {
+		q.Add("jsonOnly", "true")
+	}
+	req.URL.RawQuery = q.Encode()
+
+	mockedClient := new(MockedClient)
+	mockedClient.On("ContainerLogsBetweenDates", mock.Anything, id, mock.Anything, mock.Anything, container.STDALL).
+		Return(io.NopCloser(bytes.NewReader(data)), nil).
+		Once()
+	mockedClient.On("FindContainer", mock.Anything, id).Return(container.Container{ID: id}, nil)
+	mockedClient.On("Host").Return(container.Host{ID: "localhost"})
+	mockedClient.On("ListContainers", mock.Anything, mock.Anything).Return([]container.Container{
+		{ID: id, Name: "test", Host: "localhost", State: "running"},
+	}, nil)
+	mockedClient.On("ContainerEvents", mock.Anything, mock.AnythingOfType("chan<- container.ContainerEvent")).Return(nil)
+
+	rr := httptest.NewRecorder()
+	createDefaultHandler(mockedClient).ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+	mockedClient.AssertExpectations(t)
+
+	var events []*container.LogEvent
+	decoder := json.NewDecoder(rr.Body)
+	for decoder.More() {
+		event := &container.LogEvent{}
+		require.NoError(t, decoder.Decode(event))
+		events = append(events, event)
+	}
+
+	return events
+}
+
+func concatMessages(messages ...string) []byte {
+	var data []byte
+	for _, message := range messages {
+		data = append(data, makeMessage(message, container.STDOUT)...)
+	}
+	return data
 }
 
 func Test_matchesFilter_inverse(t *testing.T) {

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -314,6 +314,9 @@ analytics:
   export: Eksporter
   export_csv: Download CSV
   export_json: Download JSON
+  query: Forespørgsel
+  run: Kør
+  results: Resultater
 drawer:
   maximize: Maksimer
   restore: Gendan

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -314,6 +314,9 @@ analytics:
   export: Exportieren
   export_csv: CSV herunterladen
   export_json: JSON herunterladen
+  query: Abfrage
+  run: Ausführen
+  results: Ergebnisse
 drawer:
   maximize: Maximieren
   restore: Wiederherstellen

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -374,6 +374,9 @@ analytics:
   export: Export
   export_csv: Download CSV
   export_json: Download JSON
+  query: Query
+  run: Run
+  results: Results
 drawer:
   maximize: Maximize
   restore: Restore

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -364,6 +364,9 @@ analytics:
   export: Exportar
   export_csv: Descargar CSV
   export_json: Descargar JSON
+  query: Consulta
+  run: Ejecutar
+  results: Resultados
 drawer:
   maximize: Maximizar
   restore: Restaurar

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -314,6 +314,9 @@ analytics:
   export: Exporter
   export_csv: Télécharger le CSV
   export_json: Télécharger le JSON
+  query: Requête
+  run: Exécuter
+  results: Résultats
 drawer:
   maximize: Agrandir
   restore: Restaurer

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -326,6 +326,9 @@ analytics:
   export: Ekspor
   export_csv: Unduh CSV
   export_json: Unduh JSON
+  query: Kueri
+  run: Jalankan
+  results: Hasil
 drawer:
   maximize: Maksimalkan
   restore: Pulihkan

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -314,6 +314,9 @@ analytics:
   export: Esporta
   export_csv: Scarica CSV
   export_json: Scarica JSON
+  query: Query
+  run: Esegui
+  results: Risultati
 drawer:
   maximize: Massimizza
   restore: Ripristina

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -318,6 +318,9 @@ analytics:
   export: 내보내기
   export_csv: CSV 다운로드
   export_json: JSON 다운로드
+  query: 쿼리
+  run: 실행
+  results: 결과
 drawer:
   maximize: 최대화
   restore: 복원

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -315,6 +315,9 @@ analytics:
   export: Exporteren
   export_csv: CSV downloaden
   export_json: JSON downloaden
+  query: Query
+  run: Uitvoeren
+  results: Resultaten
 drawer:
   maximize: Maximaliseren
   restore: Herstellen

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -317,6 +317,9 @@ analytics:
   export: Eksportuj
   export_csv: Pobierz CSV
   export_json: Pobierz JSON
+  query: Zapytanie
+  run: Uruchom
+  results: Wyniki
 drawer:
   maximize: Maksymalizuj
   restore: Przywróć

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -314,6 +314,9 @@ analytics:
   export: Exportar
   export_csv: Baixar CSV
   export_json: Baixar JSON
+  query: Consulta
+  run: Executar
+  results: Resultados
 drawer:
   maximize: Maximizar
   restore: Restaurar

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -314,6 +314,9 @@ analytics:
   export: Экспорт
   export_csv: Скачать CSV
   export_json: Скачать JSON
+  query: Запрос
+  run: Выполнить
+  results: Результаты
 drawer:
   maximize: Развернуть
   restore: Восстановить

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -320,6 +320,9 @@ analytics:
   export: Izvozi
   export_csv: Prenesi CSV
   export_json: Prenesi JSON
+  query: Poizvedba
+  run: Zaženi
+  results: Rezultati
 drawer:
   maximize: Maksimiraj
   restore: Obnovi

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -318,6 +318,9 @@ analytics:
   export: Dışa aktar
   export_csv: CSV indir
   export_json: JSON indir
+  query: Sorgu
+  run: Çalıştır
+  results: Sonuçlar
 drawer:
   maximize: Büyüt
   restore: Geri yükle

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -317,6 +317,9 @@ analytics:
   export: 匯出
   export_csv: 下載 CSV
   export_json: 下載 JSON
+  query: 查詢
+  run: 執行
+  results: 結果
 drawer:
   maximize: 最大化
   restore: 還原

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -314,6 +314,9 @@ analytics:
   export: 导出
   export_csv: 下载 CSV
   export_json: 下载 JSON
+  query: 查询
+  run: 运行
+  results: 结果
 drawer:
   maximize: 最大化
   restore: 还原


### PR DESCRIPTION
Opening SQL Analytics on a container that emits both JSON logs and multi-line stack traces fails outright:

```
Binder Error: UNNEST() can only be applied to lists, structs and NULL, not JSON
LINE 1: CREATE TABLE logs AS SELECT unnest(m) FROM read_json(...
```

The panel builds its DuckDB table with `unnest(m)`, so every `m` has to be an object. `jsonOnly` filtered on "the message is not a string", which lets grouped events through, and those carry a `[]string`. Mixing arrays and objects in one column makes DuckDB infer it as JSON and the table never gets created.

Filters on `event.Type != LogTypeComplex` instead. `logs_test.go` covers both directions (jsonOnly on, jsonOnly off) with a single line, a two line group and a JSON line, asserting the exact type sequence and that every message decodes to an object. It fails on the old filter with `[]LogType{"group", "complex"}`.

## Also in here

The toolbar menu label for SQL Analytics was hardcoded English. It uses `analytics.title` now.

The drawer is restyled to match `LogDetails`, the sibling log drawer: shared label style, one chip affordance instead of two badge variants, a wrapping error box (binder errors put the useful half at the end, and the old one truncated to a single line), and bordered results with a sticky header.

The query box is a CodeMirror editor with completion. Completions cover the live DuckDB schema (boosted above keywords), the `logs` table, DuckDB functions and SQL keywords. Column names apply quoted when they are not legal bare identifiers, so `log.level` and `@timestamp` insert correctly. Cmd/Ctrl+Enter runs the query. The 80 line editor theme moves to `editorTheme.ts` and is shared with the expr editor rather than duplicated. No new dependencies, CodeMirror was already here for the alert expression fields.

Three keys added (`analytics.query`, `run`, `results`), translated into all 16 locales.

## logs.go

The filtered backfill walk called `FindContainer` for every container on every widening pass. For an agent host that is a gRPC round-trip, so 30 containers over 10 passes was 300 round-trips for metadata that cannot change mid-scan. Resolved once now. The container-started case had the same shape: it looked a container up for its ACL check, then handed the id to `streamLogs`, which looked it up again.

`sort.Slice` becomes `slices.SortStableFunc` (no reflection, and events sharing a timestamp stop shuffling between passes), plus a missing `defer ticker.Stop()`.

Splitting `streamLogs` surfaced a race the detector caught. `err = containerService.StreamLogs(...)` had been writing through a shadowed local, so with the shadow gone every per-container goroutine wrote the handler's shared `err`. It is a local now.

Two things left alone. `liveLogs` is unbuffered, so a slow client backpressures the Docker readers, which seems right and I did not want to change without measuring. And `fetchLogsBetweenDates` re-reads the whole scanned range on each widening pass, but the doubling delta keeps that around 2x minimal rather than quadratic, and unwinding it means reworking the ring buffer's newest-N semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbtSpt9FCaxa2sEYYrwNeT
