### PR TITLE
fix(sse): reconnect streams the browser has given up on

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -384,6 +384,7 @@ declare global {
   const useSorted: typeof import('@vueuse/core').useSorted
   const useSpeechRecognition: typeof import('@vueuse/core').useSpeechRecognition
   const useSpeechSynthesis: typeof import('@vueuse/core').useSpeechSynthesis
+  const useSseReconnect: typeof import('./composable/sseReconnect').useSseReconnect
   const useStackStream: typeof import('./composable/eventStreams').useStackStream
   const useStaleUI: typeof import('./composable/staleUI').useStaleUI
   const useStepper: typeof import('@vueuse/core').useStepper
@@ -876,6 +877,7 @@ declare module 'vue' {
     readonly useSorted: UnwrapRef<typeof import('@vueuse/core')['useSorted']>
     readonly useSpeechRecognition: UnwrapRef<typeof import('@vueuse/core')['useSpeechRecognition']>
     readonly useSpeechSynthesis: UnwrapRef<typeof import('@vueuse/core')['useSpeechSynthesis']>
+    readonly useSseReconnect: UnwrapRef<typeof import('./composable/sseReconnect')['useSseReconnect']>
     readonly useStackStream: UnwrapRef<typeof import('./composable/eventStreams')['useStackStream']>
     readonly useStaleUI: UnwrapRef<typeof import('./composable/staleUI')['useStaleUI']>
     readonly useStepper: UnwrapRef<typeof import('@vueuse/core')['useStepper']>

--- a/assets/composable/eventStreams.ts
+++ b/assets/composable/eventStreams.ts
@@ -182,6 +182,7 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
     },
   });
   let es: EventSource | null = null;
+  const reconnect = useSseReconnect({ connect: () => connect({ clear: true }), source: () => es });
 
   function close() {
     if (es) {
@@ -256,8 +257,13 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
     };
     es.onerror = () => {
       error.value = true;
+      // CLOSED means the browser has stopped retrying, so the log view would sit empty
+      // until a manual reload. Reconnecting drops and refetches rather than resuming,
+      // since the backfill the server replays would otherwise duplicate what is on screen.
+      reconnect.onError();
     };
     es.onopen = () => {
+      reconnect.onOpen();
       loading.value = false;
       opened.value = true;
       error.value = false;
@@ -266,7 +272,10 @@ function useLogStream(url: Ref<string>, container?: Ref<Container>) {
 
   watch(urlWithParams, () => connect(), { immediate: true });
 
-  onScopeDispose(() => close());
+  onScopeDispose(() => {
+    reconnect.dispose();
+    close();
+  });
 
   watch(messages, () => {
     if (messages.value.length > 1) {

--- a/assets/composable/sseReconnect.spec.ts
+++ b/assets/composable/sseReconnect.spec.ts
@@ -1,0 +1,158 @@
+/** @vitest-environment jsdom */
+import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
+
+// jsdom has no EventSource, and the readyState constants are all this needs
+class FakeEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+}
+const { CONNECTING, OPEN, CLOSED } = FakeEventSource;
+
+import { useSseReconnect } from "./sseReconnect";
+
+describe("useSseReconnect", () => {
+  let source: { readyState: number } | null;
+
+  const setVisibility = (state: DocumentVisibilityState) => {
+    Object.defineProperty(document, "visibilityState", { value: state, configurable: true });
+  };
+
+  const setOnline = (online: boolean) => {
+    Object.defineProperty(navigator, "onLine", { value: online, configurable: true });
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    global.EventSource = FakeEventSource as unknown as typeof EventSource;
+    source = { readyState: CLOSED };
+    setVisibility("visible");
+    setOnline(true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("retries a closed source with backoff", () => {
+    const connect = vi.fn();
+    const reconnect = useSseReconnect({ connect, source: () => source as unknown as EventSource });
+
+    reconnect.onError();
+    expect(connect).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1000);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    // second failure waits twice as long
+    reconnect.onError();
+    vi.advanceTimersByTime(1000);
+    expect(connect).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1000);
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    reconnect.dispose();
+  });
+
+  test("ignores an error while the browser is still retrying on its own", () => {
+    const connect = vi.fn();
+    source = { readyState: CONNECTING };
+    const reconnect = useSseReconnect({ connect, source: () => source as unknown as EventSource });
+
+    reconnect.onError();
+    vi.advanceTimersByTime(60_000);
+    expect(connect).not.toHaveBeenCalled();
+
+    reconnect.dispose();
+  });
+
+  test("a successful open resets the backoff", () => {
+    const connect = vi.fn();
+    const reconnect = useSseReconnect({ connect, source: () => source as unknown as EventSource });
+
+    reconnect.onError();
+    vi.advanceTimersByTime(1000);
+    reconnect.onError();
+    reconnect.onOpen();
+
+    vi.advanceTimersByTime(60_000);
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    reconnect.onError();
+    vi.advanceTimersByTime(1000);
+    expect(connect).toHaveBeenCalledTimes(2);
+
+    reconnect.dispose();
+  });
+
+  test("reconnects a closed source as soon as the tab is visible again", () => {
+    const connect = vi.fn();
+    const reconnect = useSseReconnect({ connect, source: () => source as unknown as EventSource });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    reconnect.dispose();
+  });
+
+  test("leaves a healthy source alone on wake", () => {
+    const connect = vi.fn();
+    source = { readyState: OPEN };
+    const reconnect = useSseReconnect({
+      connect,
+      source: () => source as unknown as EventSource,
+      staleAfter: 60_000,
+    });
+
+    reconnect.onOpen();
+    vi.advanceTimersByTime(30_000);
+    reconnect.onActivity();
+    window.dispatchEvent(new Event("online"));
+    expect(connect).not.toHaveBeenCalled();
+
+    reconnect.dispose();
+  });
+
+  test("reconnects an open but silent source once the heartbeat is missed", () => {
+    const connect = vi.fn();
+    source = { readyState: OPEN };
+    const reconnect = useSseReconnect({
+      connect,
+      source: () => source as unknown as EventSource,
+      staleAfter: 60_000,
+    });
+
+    reconnect.onOpen();
+    vi.advanceTimersByTime(61_000);
+    window.dispatchEvent(new Event("online"));
+    expect(connect).toHaveBeenCalledTimes(1);
+
+    reconnect.dispose();
+  });
+
+  test("waits for the network before retrying", () => {
+    const connect = vi.fn();
+    setOnline(false);
+    const reconnect = useSseReconnect({ connect, source: () => source as unknown as EventSource });
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(connect).not.toHaveBeenCalled();
+
+    reconnect.dispose();
+  });
+
+  test("dispose stops a pending retry", () => {
+    const connect = vi.fn();
+    const reconnect = useSseReconnect({ connect, source: () => source as unknown as EventSource });
+
+    reconnect.onError();
+    reconnect.dispose();
+    vi.advanceTimersByTime(60_000);
+    expect(connect).not.toHaveBeenCalled();
+
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(connect).not.toHaveBeenCalled();
+  });
+});

--- a/assets/composable/sseReconnect.ts
+++ b/assets/composable/sseReconnect.ts
@@ -1,0 +1,94 @@
+const BASE_DELAY = 1_000;
+const MAX_DELAY = 30_000;
+
+type Options = {
+  /** Opens a brand new EventSource. Must replace whatever `source()` returns. */
+  connect: () => void;
+  /** The EventSource currently held by the caller, or null before the first connect. */
+  source: () => EventSource | null;
+  /**
+   * Milliseconds of silence after which an OPEN connection is assumed dead. Only useful
+   * for a stream with an observable heartbeat; leave unset otherwise.
+   */
+  staleAfter?: number;
+};
+
+/**
+ * Keeps an EventSource alive across the failures the browser does not handle itself.
+ *
+ * A browser retries a dropped stream only while the source is CONNECTING. The moment it
+ * reaches CLOSED — any non-2xx response, a wrong content type, an auth redirect, which is
+ * what a reverse proxy returns on a 502/504 or a restart — it gives up permanently and the
+ * stream stays dead until the page is reloaded. That is the case this retries.
+ */
+export function useSseReconnect({ connect, source, staleAfter }: Options) {
+  let attempt = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastActivity = Date.now();
+
+  const cancel = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  const scheduleReconnect = () => {
+    if (timer !== null) return;
+    // jittered so a proxy coming back up isn't hit by every open tab at once
+    const delay = Math.min(BASE_DELAY * 2 ** attempt, MAX_DELAY) + Math.random() * 500;
+    attempt++;
+    timer = setTimeout(() => {
+      timer = null;
+      connect();
+    }, delay);
+  };
+
+  const reconnectNow = () => {
+    cancel();
+    attempt = 0;
+    lastActivity = Date.now();
+    connect();
+  };
+
+  /**
+   * A machine waking from sleep leaves a socket that is still OPEN but dead: no error
+   * fires and nothing arrives. Coming back to the tab or regaining network is the moment
+   * to notice, so both are checked against the heartbeat.
+   */
+  const wake = () => {
+    if (document.visibilityState !== "visible" || !navigator.onLine) return;
+    const es = source();
+    const stale = staleAfter !== undefined && Date.now() - lastActivity > staleAfter;
+    if (!es || es.readyState === EventSource.CLOSED || stale) {
+      reconnectNow();
+    }
+  };
+
+  document.addEventListener("visibilitychange", wake);
+  window.addEventListener("online", wake);
+
+  return {
+    /** Call from the source's `error` handler. */
+    onError() {
+      if (source()?.readyState === EventSource.CLOSED) {
+        scheduleReconnect();
+      }
+    },
+    /** Call from the source's `open` handler. */
+    onOpen() {
+      cancel();
+      attempt = 0;
+      lastActivity = Date.now();
+    },
+    /** Call whenever the stream delivers anything, heartbeats included. */
+    onActivity() {
+      lastActivity = Date.now();
+    },
+    dispose() {
+      cancel();
+      document.removeEventListener("visibilitychange", wake);
+      window.removeEventListener("online", wake);
+    },
+  };
+}

--- a/assets/stores/container.ts
+++ b/assets/stores/container.ts
@@ -35,12 +35,19 @@ export const useContainerStore = defineStore("container", () => {
 
   let errorTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // the server heartbeats every 20s, so three misses means the connection is gone even if
+  // the browser still calls it OPEN
+  const reconnect = useSseReconnect({ connect: () => connect(), source: () => es, staleAfter: 60_000 });
+
   function connect() {
     es?.close();
     ready.value = false;
     es = new EventSource(withBase("/api/events/stream"));
     es.addEventListener("error", (e) => {
-      if (es?.readyState === EventSource.CONNECTING && errorTimer === null) {
+      reconnect.onError();
+      // the browser retries on its own while CONNECTING; give it a few goes before saying
+      // anything, since a single hiccup resolves itself well inside this window
+      if (errorTimer === null && es?.readyState !== EventSource.OPEN) {
         errorTimer = setTimeout(() => {
           errorTimer = null;
           showToast(
@@ -52,9 +59,11 @@ export const useContainerStore = defineStore("container", () => {
             },
             { once: true },
           );
-        }, 5000);
+        }, 10000);
       }
     });
+
+    es.addEventListener("ping", () => reconnect.onActivity());
 
     es.addEventListener("server-version", (e) => {
       const { version } = parseEventData<{ version: string }>(e);
@@ -126,6 +135,7 @@ export const useContainerStore = defineStore("container", () => {
     });
 
     es.onopen = () => {
+      reconnect.onOpen();
       if (errorTimer !== null) {
         clearTimeout(errorTimer);
         errorTimer = null;

--- a/assets/stores/container.ts
+++ b/assets/stores/container.ts
@@ -75,6 +75,9 @@ export const useContainerStore = defineStore("container", () => {
     es.addEventListener("containers-changed", (e) => {
       updateContainers(parseEventData<ContainerJson[]>(e));
       ready.value = true;
+      // the load-time notice below may have fired against a slow first list; the
+      // containers are here now, so it no longer describes anything
+      removeToast("events-timeout");
     });
     es.addEventListener("container-stat", (e) => {
       const stat = parseEventData<ContainerStat>(e);

--- a/internal/support/web/sse.go
+++ b/internal/support/web/sse.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"net/http"
 )
@@ -67,6 +68,14 @@ func (s *SSEWriter) Write(data []byte) (int, error) {
 	s.f.Flush()
 
 	return written, nil
+}
+
+// Retry sets how long the browser waits before reconnecting a dropped stream. Browsers
+// pick their own default otherwise (Chrome ~3s, Firefox ~5s), and it is reset on every
+// reconnect, so it is sent again at the top of each stream.
+func (s *SSEWriter) Retry(d time.Duration) error {
+	_, err := s.Write([]byte(fmt.Sprintf("retry: %d", d.Milliseconds())))
+	return err
 }
 
 func (s *SSEWriter) Ping() error {

--- a/internal/web/__snapshots__/web.snapshot
+++ b/internal/web/__snapshots__/web.snapshot
@@ -129,6 +129,8 @@ Content-Security-Policy: default-src 'self' 'wasm-unsafe-eval' blob: https://cdn
 Content-Type: text/event-stream
 X-Accel-Buffering: no
 
+retry: 3000
+
 event: server-version
 data: {"version":""}
 
@@ -153,6 +155,8 @@ Connection: keep-alive
 Content-Security-Policy: default-src 'self' 'wasm-unsafe-eval' blob: https://cdn.jsdelivr.net https://*.duckdb.org; style-src 'self' 'unsafe-inline' blob:; img-src 'self' data:; font-src 'self' data:;
 Content-Type: text/event-stream
 X-Accel-Buffering: no
+
+retry: 3000
 
 event: server-version
 data: {"version":""}
@@ -179,7 +183,11 @@ X-Content-Type-Options: nosniff
 error finding container
 
 /* snapshot: Test_handler_streamLogs_error_reading */
-:ping
+retry: 3000
+
+:ping 
+
+
 
 /* snapshot: Test_handler_streamLogs_error_std */
 HTTP/1.1 400 Bad Request
@@ -191,6 +199,8 @@ X-Content-Type-Options: nosniff
 stdout or stderr is required
 
 /* snapshot: Test_handler_streamLogs_happy */
+retry: 3000
+
 :ping 
 
 data: {"t":"single","m":"INFO Testing logs...\n","ts":0,"id":3835490584,"l":"info","s":"stdout","c":"123456"}
@@ -199,13 +209,23 @@ data: {"t":"single","m":"INFO Testing logs...\n","ts":0,"id":3835490584,"l":"inf
 event: container-event
 data: {"name":"container-stopped","host":"localhost","actorId":"123456","time":"<removed>"}
 
+
+
+
 /* snapshot: Test_handler_streamLogs_happy_container_stopped */
+retry: 3000
+
 :ping 
 
 event: container-event
 data: {"name":"container-stopped","host":"localhost","actorId":"123456","time":"<removed>"}
 
+
+
+
 /* snapshot: Test_handler_streamLogs_happy_with_id */
+retry: 3000
+
 :ping 
 
 data: {"t":"single","m":"INFO Testing logs...","rm":"INFO Testing logs...","ts":1589396137772,"id":2908612274,"l":"info","s":"stdout","c":"123456"}

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -18,6 +18,10 @@ const (
 	statBufferSize  = 128
 	// minimum gap between retries of a host whose container list failed to refresh
 	staleHostRetryInterval = 5 * time.Second
+	// keeps proxies from closing an otherwise silent stream
+	keepAliveInterval = 20 * time.Second
+	// how long the browser waits before reconnecting a dropped stream
+	reconnectDelay = 3 * time.Second
 )
 
 func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
@@ -28,6 +32,11 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer sseWriter.Close()
+
+	if err := sseWriter.Retry(reconnectDelay); err != nil {
+		log.Debug().Err(err).Msg("error writing retry to event stream")
+		return
+	}
 
 	// buffered so a momentarily slow client can't stall the shared per-host store loop,
 	// which broadcasts to every subscriber with a blocking send
@@ -140,8 +149,20 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 
 	go sendBeaconEvent(h, r, len(allContainers))
 
+	// a host whose containers are all filtered out or stopped emits no stats, so without
+	// this the stream is silent and an idle proxy timeout (nginx defaults to 60s) drops it
+	ticker := time.NewTicker(keepAliveInterval)
+	defer ticker.Stop()
+
 	for {
 		select {
+		case <-ticker.C:
+			// a named event rather than a comment, so the UI can tell a connection that a
+			// sleeping machine left half-open from one that is merely quiet
+			if err := sseWriter.Event("ping", struct{}{}); err != nil {
+				log.Debug().Err(err).Msg("error writing keep-alive to event stream")
+				return
+			}
 		case host := <-availableHosts:
 			// an agent that reconnected has no visible set yet; its first traffic fills it
 			if _, ok := visibleByHost[host.ID]; host.Available && !ok {

--- a/internal/web/logs.go
+++ b/internal/web/logs.go
@@ -579,6 +579,7 @@ func (h *handler) streamLogsForContainers(w http.ResponseWriter, r *http.Request
 
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
+	sseWriter.Retry(reconnectDelay)
 	sseWriter.Ping()
 loop:
 	for {


### PR DESCRIPTION
The "Dozzle UI wasn't able to connect to API" toast shows up and never clears, because nothing ever reconnects.

A browser retries an EventSource on its own only while it is CONNECTING. Once it hits CLOSED (any non-2xx, a wrong content type, an auth redirect, so a proxy 502/504 or a restart) it gives up permanently and the stream stays dead until the page is reloaded. The error handler in `container.ts` only covered CONNECTING, so that case just popped a toast and sat there. Same in `eventStreams.ts`.

## Changes

- `assets/composable/sseReconnect.ts` (new): jittered 1s to 30s backoff when the source is CLOSED, reset on open, plus `visibilitychange` / `online` handlers that reconnect immediately when the source is closed or the heartbeat has been silent for more than 60s. That last one covers the socket a sleeping machine leaves OPEN but dead, where no error ever fires. Waits for `navigator.onLine` before retrying.
- `internal/web/events.go`: 20s keepalive on `/api/events/stream`. `logs.go` already had one, this did not, so a host whose containers are all stopped or filtered out went silent and nginx (60s default `proxy_read_timeout`) dropped it. Sent as a named `ping` event rather than a `:comment`, since comments dispatch nothing in the browser and the UI needs an observable heartbeat.
- `internal/support/web/sse.go`: `Retry()`, so both long-lived streams send `retry: 3000` and the reconnect delay is the same across browsers instead of 3s in Chrome and 5s in Firefox.
- `container.ts`: toast delay 5s to 10s, and it now covers CLOSED rather than only CONNECTING. Native retry is ~3s, so one hiccup was enough to pop it.

Log stream reconnects clear and refetch rather than resume, since the server ignores `Last-Event-ID` and the backfill it replays would duplicate what is already on screen. Honoring `Last-Event-ID` would let a reconnect keep scroll position, but that is a bigger change.

8 unit tests for the backoff, wake and dispose paths. Snapshot updated for the `retry:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbogSBGmdXvCz2vDmRS6aC