### PR TITLE
feat(ui): put pinned columns in the URL

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -348,6 +348,7 @@ declare global {
   const useParentElement: typeof import('@vueuse/core').useParentElement
   const usePerformanceObserver: typeof import('@vueuse/core').usePerformanceObserver
   const usePermission: typeof import('@vueuse/core').usePermission
+  const usePinnedColumnsInUrl: typeof import('./composable/pinnedColumns').usePinnedColumnsInUrl
   const usePinnedLogsStore: typeof import('./stores/pinned').usePinnedLogsStore
   const usePointer: typeof import('@vueuse/core').usePointer
   const usePointerLock: typeof import('@vueuse/core').usePointerLock
@@ -841,6 +842,7 @@ declare module 'vue' {
     readonly useParentElement: UnwrapRef<typeof import('@vueuse/core')['useParentElement']>
     readonly usePerformanceObserver: UnwrapRef<typeof import('@vueuse/core')['usePerformanceObserver']>
     readonly usePermission: UnwrapRef<typeof import('@vueuse/core')['usePermission']>
+    readonly usePinnedColumnsInUrl: UnwrapRef<typeof import('./composable/pinnedColumns')['usePinnedColumnsInUrl']>
     readonly usePinnedLogsStore: UnwrapRef<typeof import('./stores/pinned')['usePinnedLogsStore']>
     readonly usePointer: UnwrapRef<typeof import('@vueuse/core')['usePointer']>
     readonly usePointerLock: UnwrapRef<typeof import('@vueuse/core')['usePointerLock']>

--- a/assets/composable/pinnedColumns.spec.ts
+++ b/assets/composable/pinnedColumns.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { createPinia, setActivePinia } from "pinia";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createMemoryHistory, createRouter } from "vue-router";
+import { defineComponent } from "vue";
+
+import { usePinnedColumnsInUrl } from "./pinnedColumns";
+import { usePinnedLogsStore } from "@/stores/pinned";
+
+// @ts-ignore
+import EventSource from "eventsourcemock";
+
+vi.mock("@/stores/config", () => ({
+  __esModule: true,
+  default: { base: "", hosts: [], enableActions: true },
+  withBase: (path: string) => path,
+}));
+
+const Blank = defineComponent({ template: "<div/>" });
+
+const Layout = defineComponent({
+  setup() {
+    usePinnedColumnsInUrl();
+  },
+  template: "<div/>",
+});
+
+async function mountLayout(initial: string) {
+  // The pinned store pulls in the container store, which opens its event stream on creation.
+  global.EventSource = EventSource;
+
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/container/:id", component: Blank },
+      { path: "/stack/:name", component: Blank },
+    ],
+  });
+  await router.replace(initial);
+  await router.isReady();
+
+  mount(Layout, { global: { plugins: [router] } });
+  await flushPromises();
+
+  return { router, store: usePinnedLogsStore() };
+}
+
+describe("pinned columns in the url", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  test("seeds the pinned columns from ?columns=", async () => {
+    const { store } = await mountLayout("/container/aaa?columns=bbb|ccc");
+
+    expect(store.pinnedContainerIds).toEqual(["bbb", "ccc"]);
+  });
+
+  test("writes a pinned container into the query", async () => {
+    const { router, store } = await mountLayout("/container/aaa");
+
+    store.pinContainer({ id: "bbb" });
+    await flushPromises();
+    expect(router.currentRoute.value.fullPath).toBe("/container/aaa?columns=bbb");
+
+    store.pinContainer({ id: "ccc" });
+    await flushPromises();
+    expect(router.currentRoute.value.query.columns).toBe("bbb|ccc");
+  });
+
+  test("drops the query once the last column is closed", async () => {
+    const { router, store } = await mountLayout("/container/aaa?columns=bbb&hideMenu=");
+
+    store.unPinContainer({ id: "bbb" });
+    await flushPromises();
+    expect(router.currentRoute.value.query.columns).toBeUndefined();
+    expect(router.currentRoute.value.query.hideMenu).toBe("");
+  });
+
+  test("carries the columns onto the next route", async () => {
+    const { router, store } = await mountLayout("/container/aaa?columns=bbb");
+
+    await router.push("/stack/api");
+    await flushPromises();
+    expect(router.currentRoute.value.fullPath).toBe("/stack/api?columns=bbb");
+    expect(store.pinnedContainerIds).toEqual(["bbb"]);
+  });
+
+  test("a route that carries its own columns wins", async () => {
+    const { router, store } = await mountLayout("/container/aaa?columns=bbb");
+
+    await router.push("/container/ddd?columns=eee|fff");
+    await flushPromises();
+    expect(store.pinnedContainerIds).toEqual(["eee", "fff"]);
+    expect(router.currentRoute.value.fullPath).toBe("/container/ddd?columns=eee|fff");
+  });
+
+  test("pinning the same container twice keeps one column", async () => {
+    const { router, store } = await mountLayout("/container/aaa?columns=bbb");
+
+    store.pinContainer({ id: "bbb" });
+    await flushPromises();
+    expect(store.pinnedContainerIds).toEqual(["bbb"]);
+    expect(router.currentRoute.value.query.columns).toBe("bbb");
+  });
+});

--- a/assets/composable/pinnedColumns.ts
+++ b/assets/composable/pinnedColumns.ts
@@ -1,0 +1,61 @@
+import type { RouteLocationNormalizedLoaded } from "vue-router";
+
+// A pipe reads better than a comma in a URL and does not collide with the comma that
+// /merged/[ids] already uses for the containers merged into a single pane.
+const SEPARATOR = "|";
+const QUERY_KEY = "columns";
+
+const parseColumns = (value: unknown) => (typeof value === "string" ? value.split(SEPARATOR).filter(Boolean) : []);
+
+/**
+ * Keeps the pinned columns and the `?columns=a|b|c` query in step, in both directions.
+ *
+ * Call it once, from the layout that renders the columns, and before anything reads the store:
+ * the first thing it does is seed the store from the URL. It cannot live in the store itself,
+ * since reaching the router singleton from there closes an import cycle through the generated
+ * layouts, and a store has no component context to inject the router from.
+ */
+export const usePinnedColumnsInUrl = () => {
+  const router = useRouter();
+  const { pinnedContainerIds } = storeToRefs(usePinnedLogsStore());
+
+  const columnsInUrl = (route: RouteLocationNormalizedLoaded = router.currentRoute.value) =>
+    parseColumns(route.query[QUERY_KEY]);
+  const pinned = () => pinnedContainerIds.value.join(SEPARATOR);
+
+  const writeToUrl = (route: RouteLocationNormalizedLoaded = router.currentRoute.value) => {
+    const { [QUERY_KEY]: _, ...query } = route.query;
+    const columns = pinned();
+    router.replace({
+      path: route.path,
+      hash: route.hash,
+      query: columns ? { ...query, [QUERY_KEY]: columns } : query,
+    });
+  };
+
+  pinnedContainerIds.value = columnsInUrl();
+
+  // Deep, because pinning and unpinning mutate the array in place.
+  watch(
+    pinnedContainerIds,
+    () => {
+      if (columnsInUrl().join(SEPARATOR) !== pinned()) writeToUrl();
+    },
+    { deep: true },
+  );
+
+  // Columns outlive a navigation, so a route that lands without them gets them written back.
+  // A route carrying its own set (a shared link, back/forward) wins instead, and replaying it
+  // into the store leaves the URL already correct, so the watcher above stops there.
+  const stopCarryingColumns = router.afterEach((to: RouteLocationNormalizedLoaded) => {
+    const columns = columnsInUrl(to).join(SEPARATOR);
+    if (columns === pinned()) return;
+    if (columns) {
+      pinnedContainerIds.value = columnsInUrl(to);
+    } else {
+      writeToUrl(to);
+    }
+  });
+
+  onScopeDispose(stopCarryingColumns);
+};

--- a/assets/layouts/default.vue
+++ b/assets/layouts/default.vue
@@ -56,6 +56,7 @@ import { Splitpanes, Pane } from "splitpanes";
 import { collapseNav } from "@/stores/settings";
 import SideDrawer from "@/components/common/SideDrawer.vue";
 
+usePinnedColumnsInUrl();
 const pinnedLogsStore = usePinnedLogsStore();
 const { pinnedLogs } = storeToRefs(pinnedLogsStore);
 

--- a/assets/stores/pinned.ts
+++ b/assets/stores/pinned.ts
@@ -4,17 +4,29 @@ import { Ref } from "vue";
 export const usePinnedLogsStore = defineStore("pinnedLogs", () => {
   const containerStore = useContainerStore();
   const { allContainersById } = storeToRefs(containerStore);
+  // Seeded from `?columns=` by usePinnedColumnsInUrl(), which the layout calls before it
+  // renders the columns.
   const pinnedContainerIds: Ref<string[]> = ref([]);
 
-  const pinnedLogs = computed(() => pinnedContainerIds.value.map((id) => allContainersById.value[id]));
+  // An id stays pinned even while unknown: on a cold load the containers arrive over SSE after
+  // the first render, so dropping it here would silently discard a shared link's columns.
+  const pinnedLogs = computed(() =>
+    pinnedContainerIds.value.map((id) => allContainersById.value[id]).filter((container) => container),
+  );
 
-  const pinContainer = ({ id }: { id: string }) => pinnedContainerIds.value.push(id);
-  const unPinContainer = ({ id }: { id: string }) =>
-    pinnedContainerIds.value.splice(pinnedContainerIds.value.indexOf(id), 1);
+  const pinContainer = ({ id }: { id: string }) => {
+    if (!pinnedContainerIds.value.includes(id)) pinnedContainerIds.value.push(id);
+  };
+
+  const unPinContainer = ({ id }: { id: string }) => {
+    const index = pinnedContainerIds.value.indexOf(id);
+    if (index !== -1) pinnedContainerIds.value.splice(index, 1);
+  };
 
   const isPinned = ({ id }: { id: string }) => pinnedContainerIds.value.includes(id);
 
   return {
+    pinnedContainerIds,
     pinnedLogs,
     isPinned,
     pinContainer,


### PR DESCRIPTION
Pinned log columns now show up in the address bar as `?columns=aaa|bbb|ccc`, so a side-by-side layout survives a reload and can be shared as a link.

```
/container/abc123?columns=def456|ghi789
/stack/api?columns=def456
```

The sync runs both ways:

- pinning or closing a column rewrites the query with `router.replace` (no history spam), dropping the key when the last column closes and leaving other params like `hideMenu` alone
- a route that lands without the param gets it written back, so columns outlive a navigation
- a route that arrives carrying its own set (shared link, back/forward) wins over the current state

Ids stay in the URL while unknown. On a cold load the containers arrive over SSE after the first render, so dropping them at parse time would silently discard a shared link's columns. `pinnedLogs` filters unresolved ids for rendering instead.

Pipe as the separator, since `/merged/[ids]` already uses a comma for containers merged into a single pane.

The sync lives in `usePinnedColumnsInUrl()` rather than the store: importing the router singleton from a store closes an import cycle through the generated layouts, and a store has no component context to inject the router from.

6 new tests in `assets/composable/pinnedColumns.spec.ts` cover seeding, write-back, clearing, carry-over, precedence and duplicate pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AF3wba7R7GSiZwJUa4E4FR
