### PR TITLE
fix(ui): make the rail work on mobile, and quiet the focus ring

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -25,6 +25,7 @@ declare global {
   const autoResetRef: typeof import('@vueuse/core').autoResetRef
   const automaticRedirect: typeof import('./stores/settings').automaticRedirect
   const buildViewContext: typeof import('./composable/viewContext').buildViewContext
+  const canHover: typeof import('./composable/media').canHover
   const collapseCloudRail: typeof import('./stores/settings').collapseCloudRail
   const collapseNav: typeof import('./stores/settings').collapseNav
   const colorize: typeof import('./utils/index').colorize
@@ -561,6 +562,7 @@ declare module 'vue' {
     readonly autoResetRef: UnwrapRef<typeof import('@vueuse/core')['autoResetRef']>
     readonly automaticRedirect: UnwrapRef<typeof import('./stores/settings')['automaticRedirect']>
     readonly buildViewContext: UnwrapRef<typeof import('./composable/viewContext')['buildViewContext']>
+    readonly canHover: UnwrapRef<typeof import('./composable/media')['canHover']>
     readonly collapseCloudRail: UnwrapRef<typeof import('./stores/settings')['collapseCloudRail']>
     readonly collapseNav: UnwrapRef<typeof import('./stores/settings')['collapseNav']>
     readonly colorize: UnwrapRef<typeof import('./utils/index')['colorize']>

--- a/assets/components/CloudRail/CloudRail.vue
+++ b/assets/components/CloudRail/CloudRail.vue
@@ -10,12 +10,16 @@
     Everything on it is Cloud, which the mark at the top says once so no panel
     has to carry a slogan. It is mounted only where cloud is linked, so the mark
     is a statement of where the answers come from and never an advert.
+
+    A phone has no room for a permanent strip, and a 550px column beside a 390px
+    screen is not a column. There the strip is gone and the panel is the screen,
+    opened from the toolbar or the palette and closed with the same X.
   -->
-  <div class="fixed inset-y-0 right-0 z-30 flex">
+  <div class="fixed z-30 flex" :class="sheet ? 'pt-safe bg-base-100 inset-0 z-40' : 'inset-y-0 right-0'">
     <section
       v-if="panel"
-      class="border-base-content/10 bg-base-100 flex flex-col border-l"
-      :style="{ width: `${panelWidth}px` }"
+      class="border-base-content/10 bg-base-100 flex min-w-0 flex-1 flex-col border-l"
+      :style="sheet ? undefined : { width: `${panelWidth}px`, flex: 'none' }"
     >
       <header class="border-base-content/10 flex shrink-0 items-center gap-2 border-b px-4 py-3">
         <component :is="active.icon" class="text-base-content/60 size-4 shrink-0" />
@@ -26,14 +30,28 @@
           <mdi:cloud class="text-info/70 size-3.5" />
           {{ $t("cloud.title") }}
         </span>
-        <button
-          type="button"
-          class="btn btn-ghost btn-xs btn-square ml-auto"
-          :aria-label="$t('cloud-rail.close')"
-          @click="closeRail()"
-        >
-          <mdi:close class="size-4" />
-        </button>
+        <div class="ml-auto flex shrink-0 items-center gap-1">
+          <!-- A thread that has run its course is in the way of the next one,
+               and the only way out of it used to be a reload. -->
+          <button
+            v-if="panel === 'chat' && messages.length"
+            type="button"
+            class="btn btn-ghost btn-xs btn-square"
+            :title="$t('cloud-chat.clear')"
+            :aria-label="$t('cloud-chat.clear')"
+            @click="resetChat()"
+          >
+            <octicon:trash-24 class="size-4" />
+          </button>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs btn-square"
+            :aria-label="$t('cloud-rail.close')"
+            @click="closeRail()"
+          >
+            <mdi:close class="size-4" />
+          </button>
+        </div>
       </header>
 
       <div class="min-h-0 flex-1 overflow-hidden">
@@ -43,13 +61,15 @@
       </div>
     </section>
 
+    <!-- Kept on the sheet too: on a phone it is the only way to move between the
+         three panels, and the only way to put it away. -->
     <nav
-      class="border-base-content/10 bg-base-200/40 flex flex-col items-center gap-1 border-l py-3"
+      class="border-base-content/10 bg-base-200/40 flex shrink-0 flex-col items-center gap-1 border-l py-3"
       :style="{ width: `${RAIL_WIDTH}px` }"
       :aria-label="$t('cloud-rail.title')"
     >
       <router-link
-        to="/settings/cloud"
+        :to="{ name: '/settings', hash: '#cloud' }"
         class="bg-info/10 text-info rounded-full p-1.5 transition-opacity hover:opacity-80"
         :title="$t('cloud.title')"
         :aria-label="$t('cloud.title')"
@@ -77,13 +97,14 @@
       </button>
 
       <!-- Bottom of the strip, mirroring the nav's collapse on the other edge.
-           Hiding is remembered, and the tab on the edge brings it back. -->
+           Hiding is remembered, and the tab on the edge brings it back. A sheet
+           has no collapsed resting state to hide to, so there it just closes. -->
       <button
         type="button"
         class="icon-btn btn btn-ghost btn-square btn-sm text-base-content/40 mt-auto"
-        :title="$t('cloud-rail.hide')"
-        :aria-label="$t('cloud-rail.hide')"
-        @click="hideRail()"
+        :title="sheet ? $t('cloud-rail.close') : $t('cloud-rail.hide')"
+        :aria-label="sheet ? $t('cloud-rail.close') : $t('cloud-rail.hide')"
+        @click="sheet ? closeRail() : hideRail()"
       >
         <mdi:chevron-right class="size-5" />
       </button>
@@ -100,7 +121,8 @@ import mdiBellOutline from "~icons/mdi/bell-outline";
 // Carries markdown-it, and nobody who never asks a question should download it.
 const ChatPane = defineAsyncComponent(() => import("@/components/CloudChat/ChatPane.vue"));
 
-const { panel, panelWidth, closeRail, toggleRail, hideRail } = useCloudRail();
+const { panel, panelWidth, sheet, closeRail, toggleRail, hideRail } = useCloudRail();
+const { messages, reset: resetChat } = useCloudChat();
 const { unseen: unseenAlerts } = useRecentAlerts();
 const { t } = useI18n();
 

--- a/assets/components/CloudRail/RailMetrics.vue
+++ b/assets/components/CloudRail/RailMetrics.vue
@@ -73,6 +73,11 @@ type MetricPoint = { ts: number; cpu: number; memory: number; memoryUsage: numbe
 const { t } = useI18n();
 const view = useViewContext();
 const store = useContainerStore();
+const { isPro, ensureCloudStatus } = useCloudConfig();
+
+// The plan decides whether the week is on offer, so the panel needs the status
+// even on a page where nothing else has asked for it. Shared and cached.
+onMounted(ensureCloudStatus);
 
 // One container at a time: a merged view is many histories, and stacking them
 // in a 550px column reads as noise. The first in view is the one on screen.
@@ -84,12 +89,24 @@ const source = computed(() =>
   container.value ? `/api/cloud/hosts/${container.value.host}/containers/${container.value.id}/metrics` : "",
 );
 
+// A day is the question this panel is actually for: the live chart already
+// covers the last few minutes, so opening on an hour showed a slower copy of
+// what is on screen. A week is retention rather than a wider chart, so it is
+// only offered where the plan keeps that much.
 const windows = computed(() => [
   { value: "1h", label: t("cloud-rail.window-1h") },
   { value: "6h", label: t("cloud-rail.window-6h") },
   { value: "24h", label: t("cloud-rail.window-24h") },
+  // Go parses hours, not days, so the week travels as 168h.
+  ...(isPro.value ? [{ value: "168h", label: t("cloud-rail.window-7d") }] : []),
 ]);
-const window = ref("1h");
+const window = ref("24h");
+
+// Losing pro (or the status arriving late) must not leave the tabs pointing at
+// a window that is no longer on offer.
+watch(windows, (options) => {
+  if (!options.some((o) => o.value === window.value)) window.value = "24h";
+});
 
 const points = ref<MetricPoint[]>([]);
 const bucket = ref(0);
@@ -151,8 +168,17 @@ const charts = computed(() => [
 
 // Follows the reader's own clock preference, like every other time in the app.
 const hourCycle = computed(() => (hourStyle.value === "12" ? "h12" : hourStyle.value === "24" ? "h23" : undefined));
+// Past a day the clock alone is ambiguous: "09:14" on a week of bars could be
+// any of seven mornings, so the date comes along.
 const clock = computed(
-  () => new Intl.DateTimeFormat(undefined, { hour: "2-digit", minute: "2-digit", hourCycle: hourCycle.value }),
+  () =>
+    new Intl.DateTimeFormat(undefined, {
+      month: window.value === "1h" || window.value === "6h" ? undefined : "short",
+      day: window.value === "1h" || window.value === "6h" ? undefined : "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: hourCycle.value,
+    }),
 );
 
 // The bars are buckets of the series, so the hovered one covers a span of

--- a/assets/components/Notification/CloudDestinationForm.vue
+++ b/assets/components/Notification/CloudDestinationForm.vue
@@ -2,137 +2,137 @@
   <div class="flex min-h-full flex-1 flex-col">
     <!--
       Linked. Nothing here is editable, so the drawer stops pretending to be a form:
-      no fieldset legend, no disabled input holding a key you cannot change. It is one
-      account panel built from the same parts as the cloud popover and the settings
-      card (identity row, hairline dividers, meter, link rows) so the three read as one
-      surface at three widths.
+      no fieldset legend, no disabled input holding a key you cannot change. Same parts
+      as the cloud popover and the settings card (identity row, hairline dividers,
+      meter, link rows) so the three read as one surface at three widths.
+
+      Full bleed rather than a bordered card: a rounded panel inset inside a drawer that
+      is already a panel draws a box around the drawer's only content and leaves a margin
+      of nothing around it. The rows run to the edges the way the footer below does, and
+      the dividers alone carry the grouping.
     -->
-    <div v-if="destination?.prefix" class="pb-8">
-      <div class="border-base-content/15 bg-base-200/40 divide-base-content/10 divide-y rounded-lg border">
-        <!--
-          Identity leads with the account rather than the product name: the drawer
-          header two lines up already says Dozzle Cloud, and what you cannot tell
-          from there is which account this key belongs to.
-        -->
-        <div class="flex items-center gap-3 p-4">
-          <div class="shrink-0 rounded-full p-2" :class="accent.tint">
-            <mdi:alert-circle-outline v-if="cloudStatusError === 'auth'" class="size-6" />
-            <mdi:cloud-off-outline v-else-if="cloudStatusError === 'unavailable'" class="size-6" />
-            <mdi:cloud v-else class="size-6" />
+    <div v-if="destination?.prefix" class="divide-base-content/10 border-base-content/10 -mx-4 divide-y border-y">
+      <!--
+        Identity leads with the account rather than the product name: the drawer
+        header two lines up already says Dozzle Cloud, and what you cannot tell
+        from there is which account this key belongs to.
+      -->
+      <div class="flex items-center gap-3 p-4">
+        <div class="shrink-0 rounded-full p-2" :class="accent.tint">
+          <mdi:alert-circle-outline v-if="cloudStatusError === 'auth'" class="size-6" />
+          <mdi:cloud-off-outline v-else-if="cloudStatusError === 'unavailable'" class="size-6" />
+          <mdi:cloud v-else class="size-6" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center gap-1.5">
+            <span class="truncate font-semibold">{{ cloudStatus?.user.email ?? $t("cloud.title") }}</span>
+            <span class="size-1.5 shrink-0 rounded-full" :class="accent.dot" :title="statusLabel"></span>
           </div>
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-1.5">
-              <span class="truncate font-semibold">{{ cloudStatus?.user.email ?? $t("cloud.title") }}</span>
-              <span class="size-1.5 shrink-0 rounded-full" :class="accent.dot" :title="statusLabel"></span>
-            </div>
-            <!-- An error says its piece in the body below at full length; repeating a
-                 truncated copy of it here would only lose half the sentence. -->
-            <div v-if="!cloudStatusError" class="text-base-content/60 truncate text-sm">{{ statusLabel }}</div>
-          </div>
-          <span v-if="cloudStatus" class="status-pill status-pill-primary shrink-0 capitalize">
-            {{ cloudStatus.plan.name }}
-          </span>
+          <!-- An error says its piece in the body below at full length; repeating a
+               truncated copy of it here would only lose half the sentence. -->
+          <div v-if="!cloudStatusError" class="text-base-content/60 truncate text-sm">{{ statusLabel }}</div>
         </div>
+        <span v-if="cloudStatus" class="status-pill status-pill-primary shrink-0 capitalize">
+          {{ cloudStatus.plan.name }}
+        </span>
+      </div>
 
-        <!-- The key is a fact about the link, not an input: label left, masked value right. -->
-        <div class="flex items-center justify-between gap-4 p-4">
-          <span class="text-base-content/60 text-sm">{{ $t("notifications.destination-form.api-key") }}</span>
-          <span class="truncate font-mono text-sm">
-            {{ destination.prefix }}<span class="text-base-content/30 tracking-widest">••••••••••••</span>
-          </span>
-        </div>
+      <!-- The key is a fact about the link, not an input: label left, masked value right. -->
+      <div class="flex items-center justify-between gap-4 p-4">
+        <span class="text-base-content/60 text-sm">{{ $t("notifications.destination-form.api-key") }}</span>
+        <span class="truncate font-mono text-sm">
+          {{ destination.prefix }}<span class="text-base-content/30 tracking-widest">••••••••••••</span>
+        </span>
+      </div>
 
-        <!-- The identity row already says the check is running, so this is just a placeholder
-             holding the meter's height so the panel does not jump when it arrives. -->
-        <div v-if="isLoadingCloudStatus" class="flex items-center justify-center p-4">
-          <span class="loading loading-spinner loading-sm"></span>
-        </div>
+      <!-- The identity row already says the check is running, so this is just a placeholder
+           holding the meter's height so the panel does not jump when it arrives. -->
+      <div v-if="isLoadingCloudStatus" class="flex items-center justify-center p-4">
+        <span class="loading loading-spinner loading-sm"></span>
+      </div>
 
-        <!--
-          Severity rides on the icon above and the message here; the surface stays
-          neutral, which keeps the text at full contrast instead of washed onto a
-          saturated bar the width of the drawer.
-        -->
-        <div v-else-if="cloudStatusError" class="flex flex-col items-start gap-3 p-4">
-          <p class="text-sm">
-            {{
-              cloudStatusError === "auth"
-                ? $t("notifications.destination-form.cloud-relink")
-                : $t("notifications.destination-form.cloud-unavailable")
-            }}
-          </p>
-          <a v-if="cloudStatusError === 'auth'" :href="cloudLinkUrl" class="btn btn-primary btn-sm">
-            <mdi:link-variant class="text-base" />
-            {{ $t("cloud.relink-instance") }}
-          </a>
-          <button v-else class="btn btn-sm" @click="fetchCloudStatus">
-            <mdi:refresh class="text-base" />
-            {{ $t("button.retry") }}
-          </button>
-        </div>
+      <!--
+        Severity rides on the icon above and the message here; the surface stays
+        neutral, which keeps the text at full contrast instead of washed onto a
+        saturated bar the width of the drawer.
+      -->
+      <div v-else-if="cloudStatusError" class="flex flex-col items-start gap-3 p-4">
+        <p class="text-sm">
+          {{
+            cloudStatusError === "auth"
+              ? $t("notifications.destination-form.cloud-relink")
+              : $t("notifications.destination-form.cloud-unavailable")
+          }}
+        </p>
+        <a v-if="cloudStatusError === 'auth'" :href="cloudLinkUrl" class="btn btn-primary btn-sm">
+          <mdi:link-variant class="text-base" />
+          {{ $t("cloud.relink-instance") }}
+        </a>
+        <button v-else class="btn btn-sm" @click="fetchCloudStatus">
+          <mdi:refresh class="text-base" />
+          {{ $t("button.retry") }}
+        </button>
+      </div>
 
-        <div v-else-if="cloudStatus" class="p-4">
-          <CloudUsage :usage="cloudStatus.usage" />
-        </div>
+      <div v-else-if="cloudStatus" class="p-4">
+        <CloudUsage :usage="cloudStatus.usage" />
+      </div>
 
-        <!-- Managed channels live on the cloud side, so the drawer ends in a way out to them. -->
-        <div class="p-2">
-          <a
-            :href="cloudSettingsUrl"
-            target="_blank"
-            rel="noreferrer noopener"
-            class="hover:bg-base-300 flex items-center gap-2 rounded-md px-2 py-2 text-sm transition-colors"
-          >
-            <mdi:cog-outline class="size-4 opacity-60" />
-            <span class="flex-1">{{ $t("notifications.destination-form.cloud-settings-link") }}</span>
-            <mdi:open-in-new class="size-3.5 opacity-40" />
-          </a>
-          <a
-            :href="cloudUrl"
-            target="_blank"
-            rel="noreferrer noopener"
-            class="hover:bg-base-300 flex items-center gap-2 rounded-md px-2 py-2 text-sm transition-colors"
-          >
-            <mdi:view-dashboard-outline class="size-4 opacity-60" />
-            <span class="flex-1">{{ $t("cloud.dashboard") }}</span>
-            <mdi:open-in-new class="size-3.5 opacity-40" />
-          </a>
-        </div>
+      <!-- Managed channels live on the cloud side, so the drawer ends in a way out to them. -->
+      <div class="p-2">
+        <a
+          :href="cloudSettingsUrl"
+          target="_blank"
+          rel="noreferrer noopener"
+          class="hover:bg-base-300 flex items-center gap-2 rounded-md px-2 py-2 text-sm transition-colors"
+        >
+          <mdi:cog-outline class="size-4 opacity-60" />
+          <span class="flex-1">{{ $t("notifications.destination-form.cloud-settings-link") }}</span>
+          <mdi:open-in-new class="size-3.5 opacity-40" />
+        </a>
+        <a
+          :href="cloudUrl"
+          target="_blank"
+          rel="noreferrer noopener"
+          class="hover:bg-base-300 flex items-center gap-2 rounded-md px-2 py-2 text-sm transition-colors"
+        >
+          <mdi:view-dashboard-outline class="size-4 opacity-60" />
+          <span class="flex-1">{{ $t("cloud.dashboard") }}</span>
+          <mdi:open-in-new class="size-3.5 opacity-40" />
+        </a>
       </div>
     </div>
 
     <!--
-      Not linked. Same panel shell as the linked state, so linking does not reshuffle
-      the drawer: the pitch rows are replaced by the key and the meter. The header
-      above already carries the title and the pitch sentence, so this branch opens on
-      the three concrete things you get rather than restating them.
+      Not linked. Same shell as the linked state, so linking does not reshuffle the
+      drawer: the pitch rows are replaced by the key and the meter. The header above
+      already carries the title and the pitch sentence, so this branch opens on the
+      three concrete things you get rather than restating them.
     -->
-    <div v-else class="pb-8">
-      <div class="border-base-content/15 bg-base-200/40 divide-base-content/10 divide-y rounded-lg border">
-        <ul class="text-base-content/70 space-y-2.5 p-4 text-sm">
-          <li class="flex items-start gap-2">
-            <mdi:robot-outline class="text-info mt-0.5 size-4 shrink-0" />
-            <span>{{ $t("cloud.pitch.findings") }}</span>
-          </li>
-          <li class="flex items-start gap-2">
-            <mdi:bell-ring-outline class="text-info mt-0.5 size-4 shrink-0" />
-            <span>{{ $t("cloud.pitch.alerts") }}</span>
-          </li>
-          <li class="flex items-start gap-2">
-            <mdi:remote class="text-info mt-0.5 size-4 shrink-0" />
-            <span>{{ $t("cloud.pitch.control") }}</span>
-          </li>
-        </ul>
+    <div v-else class="divide-base-content/10 border-base-content/10 -mx-4 divide-y border-y">
+      <ul class="text-base-content/70 space-y-2.5 p-4 text-sm">
+        <li class="flex items-start gap-2">
+          <mdi:robot-outline class="text-info mt-0.5 size-4 shrink-0" />
+          <span>{{ $t("cloud.pitch.findings") }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <mdi:bell-ring-outline class="text-info mt-0.5 size-4 shrink-0" />
+          <span>{{ $t("cloud.pitch.alerts") }}</span>
+        </li>
+        <li class="flex items-start gap-2">
+          <mdi:remote class="text-info mt-0.5 size-4 shrink-0" />
+          <span>{{ $t("cloud.pitch.control") }}</span>
+        </li>
+      </ul>
 
-        <div class="flex gap-2 p-4">
-          <a :href="cloudUrl" target="_blank" rel="noreferrer noopener" class="btn btn-sm">
-            {{ $t("cloud.learn-more") }}
-          </a>
-          <a :href="cloudLinkUrl" class="btn btn-primary btn-sm">
-            <mdi:link-variant class="text-base" />
-            {{ $t("notifications.destination-form.link-cloud-button") }}
-          </a>
-        </div>
+      <div class="flex gap-2 p-4">
+        <a :href="cloudUrl" target="_blank" rel="noreferrer noopener" class="btn btn-sm">
+          {{ $t("cloud.learn-more") }}
+        </a>
+        <a :href="cloudLinkUrl" class="btn btn-primary btn-sm">
+          <mdi:link-variant class="text-base" />
+          {{ $t("notifications.destination-form.link-cloud-button") }}
+        </a>
       </div>
     </div>
 

--- a/assets/components/common/AlertDot.vue
+++ b/assets/components/common/AlertDot.vue
@@ -6,16 +6,51 @@
     nothing local remembers a fire-and-forget notification. With Cloud's database
     behind it the same alert is still on the container tomorrow. Severity rides
     the dot and the row behind it stays neutral, so a long table stays scannable.
+
+    A `title` attribute was all a row had to say what the dot meant: unstyleable,
+    a second late, gone on touch, and with nowhere to put the one thing the
+    reader actually wants next, which is the lines. This is a real panel instead.
   -->
-  <button
+  <Popover
     v-if="alert"
-    type="button"
-    class="size-1.5 shrink-0 rounded-full transition-colors"
-    :class="tone"
-    :title="alert.headline"
-    :aria-label="alert.headline"
-    @click.stop.prevent="showLines"
-  ></button>
+    class="flex shrink-0 items-center"
+    placement="bottom-start"
+    panel-class="rounded-box bg-base-200 border-base-content/10 w-72 border p-3 shadow-lg"
+    @click.stop
+  >
+    <template #trigger>
+      <button
+        type="button"
+        class="size-1.5 shrink-0 rounded-full transition-colors"
+        :class="tone"
+        :aria-label="alert.headline"
+      ></button>
+    </template>
+
+    <template #default="{ close }">
+      <div class="flex items-start gap-2.5">
+        <div class="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full" :class="tint">
+          <mdi:alert-circle-outline class="size-4" />
+        </div>
+        <div class="min-w-0 flex-1">
+          <p class="text-sm font-semibold">{{ alert.headline }}</p>
+          <div class="text-base-content/60 mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+            <span class="status-pill" :class="pill">{{ alert.level || "info" }}</span>
+            <RelativeTime :date="firedAt" />
+            <span class="font-mono">{{ $t("notifications.history.events", { n: alert.eventCount }) }}</span>
+          </div>
+          <p v-if="alert.summary" class="text-base-content/60 mt-2 text-sm">{{ alert.summary }}</p>
+        </div>
+      </div>
+
+      <!-- The one move Dozzle can make that Cloud cannot, so it is the only
+           action here and it is the primary one. -->
+      <button type="button" class="btn btn-primary btn-sm mt-3 w-full" @click="showLines(close)">
+        <mdi:text-search class="size-4" />
+        {{ $t("notifications.history.show-lines") }}
+      </button>
+    </template>
+  </Popover>
 </template>
 
 <script lang="ts" setup>
@@ -28,6 +63,7 @@ const { jumpTo } = useLogJump();
 onMounted(() => fetchRecentAlerts());
 
 const alert = computed(() => byContainer.value.get(containerId));
+const firedAt = computed(() => new Date((alert.value?.ts ?? 0) / 1e6));
 
 const tone = computed(() => {
   switch (alert.value?.level) {
@@ -41,8 +77,35 @@ const tone = computed(() => {
   }
 });
 
-function showLines() {
+// Same tinted circle and chip the alert rows use, so one alert looks like
+// itself wherever it is shown.
+const tint = computed(() => {
+  switch (alert.value?.level) {
+    case "error":
+    case "fatal":
+      return "bg-error/10 text-error";
+    case "warn":
+      return "bg-warning/10 text-warning";
+    default:
+      return "bg-info/10 text-info";
+  }
+});
+
+const pill = computed(() => {
+  switch (alert.value?.level) {
+    case "error":
+    case "fatal":
+      return "status-pill-error";
+    case "warn":
+      return "status-pill-warning";
+    default:
+      return "status-pill-neutral";
+  }
+});
+
+function showLines(close: () => void) {
   if (!alert.value) return;
+  close();
   jumpTo({
     containerId: alert.value.containerId,
     date: new Date(alert.value.ts / 1e6),

--- a/assets/components/common/Popover.vue
+++ b/assets/components/common/Popover.vue
@@ -3,7 +3,7 @@
     ref="anchor"
     v-bind="$attrs"
     class="popover-anchor"
-    @click="hover || toggle()"
+    @click="hoverable || toggle()"
     @pointerenter="onEnter"
     @pointerleave="onLeave"
   >
@@ -42,7 +42,8 @@ const {
   panelClass = "",
 } = defineProps<{
   placement?: PopoverPlacement;
-  /** Opens on pointer enter instead of click. Touch taps fire it too. */
+  /** Opens on pointer enter instead of click. Ignored on a touch screen,
+   * where a tap fires enter then leave and the menu would close itself. */
   hover?: boolean;
   /** Close when a row is picked. Rows inside a nested <details> submenu never close. */
   closeOnSelect?: boolean;
@@ -51,13 +52,18 @@ const {
 
 const emit = defineEmits<{ open: []; close: [] }>();
 
+// A tap sends pointerenter on touch-down and pointerleave on touch-up, so a
+// hover menu on a phone opened and shut itself and the trigger looked dead.
+// Without a hovering pointer the trigger is a plain click toggle.
+const hoverable = computed(() => hover && canHover.value);
+
 const anchor = useTemplateRef<HTMLElement>("anchor");
 const panel = useTemplateRef<HTMLElement>("panel");
 
 const { isOpen, onBeforeToggle, onToggle, show, hide, toggle } = useAnchoredPopover(anchor, panel, {
   placement: () => placement,
   // Hover menus have to be reachable across the gap, so keep it tight.
-  gap: () => (hover ? 2 : 4),
+  gap: () => (hoverable.value ? 2 : 4),
 });
 
 watch(isOpen, (value) => (value ? emit("open") : emit("close")));
@@ -66,12 +72,12 @@ watch(isOpen, (value) => (value ? emit("open") : emit("close")));
 // to be bridged instead of relying on a single hover region.
 let timer: ReturnType<typeof setTimeout> | undefined;
 function onEnter() {
-  if (!hover) return;
+  if (!hoverable.value) return;
   clearTimeout(timer);
   show();
 }
 function onLeave() {
-  if (!hover) return;
+  if (!hoverable.value) return;
   clearTimeout(timer);
   timer = setTimeout(hide, 150);
 }

--- a/assets/composable/cloudChat.ts
+++ b/assets/composable/cloudChat.ts
@@ -56,6 +56,15 @@ export function useCloudChat() {
     focused.value = undefined;
   }
 
+  /** Start over. The thread is the only thing the assistant remembers, so this
+   *  is also how you tell it to stop carrying an answer that went nowhere. */
+  function reset() {
+    messages.value = [];
+    focused.value = undefined;
+    status.value = "";
+    activity.value = "";
+  }
+
   function closePane() {
     // The thread survives. Reopening into a blank box loses whatever you were
     // half way through.
@@ -136,5 +145,5 @@ export function useCloudChat() {
     }
   }
 
-  return { messages, status, activity, streaming, focused, ask, askAboutLine, clearFocus, openPane, closePane };
+  return { messages, status, activity, streaming, focused, ask, askAboutLine, clearFocus, reset, openPane, closePane };
 }

--- a/assets/composable/cloudRail.ts
+++ b/assets/composable/cloudRail.ts
@@ -27,21 +27,38 @@ export function useCloudRail() {
   // Every panel is about the logs on screen, so the rail belongs where there
   // are logs on screen. On the home page or in settings it would be a strip of
   // icons about nothing in particular.
-  const available = computed(() => linked.value && !isMobile.value && viewing.value);
+  const available = computed(() => linked.value && viewing.value);
+
+  /**
+   * A phone has no room for a permanent strip beside the stream, and a 550px
+   * column next to a 390px screen is not a column. There the rail is an overlay
+   * instead: it has no resting state, opens over the logs when something asks
+   * for a panel, and takes the screen with it.
+   */
+  const sheet = computed(() => available.value && isMobile.value);
 
   // Hidden is a preference, not a state: the strip is always there to bring
   // back, the way the nav collapses on the other edge. Closing the last panel
   // does not hide it, because then the icons would vanish on a click that was
-  // about the panel.
-  const visible = computed(() => available.value && !collapseCloudRail.value);
+  // about the panel. A sheet has nothing to collapse, so it is on screen for
+  // exactly as long as a panel is open.
+  const mounted = computed(() => {
+    if (!available.value) return false;
+    return sheet.value ? !!panel.value : !collapseCloudRail.value;
+  });
+
+  /** The tab on the edge that brings a collapsed rail back. Only the strip
+   *  collapses, so a sheet never has one. */
+  const collapsed = computed(() => available.value && !sheet.value && collapseCloudRail.value);
 
   // 550px is the width the assistant's paragraphs were written for. On a
   // smaller window the logs matter more than the panel, so it gives way.
   const panelWidth = computed(() => Math.min(550, Math.max(320, windowWidth.value * 0.45)));
 
-  /** What the page has to keep clear on its right. */
+  /** What the page has to keep clear on its right. Nothing under a sheet, which
+   *  covers the stream rather than sitting beside it. */
   const railOffset = computed(() => {
-    if (!visible.value) return 0;
+    if (!mounted.value || sheet.value) return 0;
     return RAIL_WIDTH + (panel.value ? panelWidth.value : 0);
   });
 
@@ -66,8 +83,24 @@ export function useCloudRail() {
   }
 
   function toggleRail(next: RailPanel) {
+    // Same reasoning as openRail: ⇧⌘K asking for the assistant must not land on
+    // a rail that was collapsed an hour ago and quietly do nothing.
+    collapseCloudRail.value = false;
     panel.value = panel.value === next ? undefined : next;
   }
 
-  return { panel, panelWidth, railOffset, visible, available, openRail, closeRail, toggleRail, hideRail, showRail };
+  return {
+    panel,
+    panelWidth,
+    railOffset,
+    sheet,
+    mounted,
+    collapsed,
+    available,
+    openRail,
+    closeRail,
+    toggleRail,
+    hideRail,
+    showRail,
+  };
 }

--- a/assets/composable/media.ts
+++ b/assets/composable/media.ts
@@ -1,1 +1,6 @@
 export const isMobile = useMediaQuery("(max-width: 770px)");
+
+/** True where a pointer can actually rest on something. Touch screens report
+ *  `none`, and there a hover menu opens on tap-down and closes again on
+ *  tap-up, which reads as a button that does nothing. */
+export const canHover = useMediaQuery("(hover: hover)");

--- a/assets/layouts/default.vue
+++ b/assets/layouts/default.vue
@@ -40,8 +40,8 @@
       <mdi:chevron-left class="swap-off" />
     </label>
   </div>
-  <CloudRail v-if="railVisible" />
-  <CloudRailHandle v-else-if="railAvailable" />
+  <CloudRail v-if="railMounted" />
+  <CloudRailHandle v-else-if="railCollapsed" />
   <dialog ref="modal" class="modal bg-base-300/50! items-start backdrop-blur-md transition-none!" @close="closeSearch">
     <div class="modal-box max-w-2xl overflow-visible! bg-transparent pt-20 shadow-none">
       <FuzzySearchModal @close="closeSearch" v-if="open" />
@@ -81,7 +81,7 @@ import { useFuzzySearch } from "@/composable/fuzzySearch";
 // Pulls fuse.js (~48 KB) with it, and the palette only renders once the user opens it.
 const FuzzySearchModal = defineAsyncComponent(() => import("@/components/FuzzySearchModal.vue"));
 
-const { railOffset, visible: railVisible, available: railAvailable, toggleRail } = useCloudRail();
+const { railOffset, mounted: railMounted, collapsed: railCollapsed, toggleRail } = useCloudRail();
 
 const modal = ref<HTMLDialogElement>();
 const { open, openSearch: showFuzzySearch, closeSearch } = useFuzzySearch();

--- a/assets/main.css
+++ b/assets/main.css
@@ -19,6 +19,9 @@
     "Liberation Mono", monospace;
 }
 
+/* Sets padding-top outright, and is emitted after the core spacing utilities, so
+ * it BEATS `pt-*`/`py-*` on the same element and collapses the padding to 0 where
+ * there is no inset. Put it on a wrapper instead of next to a padding utility. */
 @utility pt-safe {
   padding-top: env(safe-area-inset-top);
 }
@@ -204,6 +207,19 @@
 }
 
 @layer base {
+  /* One focus ring for the whole app.
+   *
+   * The UA default is a hard blue that belongs to no theme, and on a nav row
+   * already tinted for the active route a second, differently coloured box
+   * around it reads as a second kind of selection rather than as focus.
+   *
+   * Neutral on purpose: an accent ring would be the same colour the active row
+   * is already wearing, which is exactly the confusion being fixed. */
+  :focus-visible {
+    outline: 2px solid color-mix(in oklab, var(--color-base-content) 40%, transparent);
+    outline-offset: 1px;
+  }
+
   /* Popover panels come with UA chrome (a border, padding, centering inset) meant for a
    * standalone dialog. Resetting it in the base layer lets a component's own utilities style
    * the panel without fighting the reset for source order. */

--- a/assets/modules/router.ts
+++ b/assets/modules/router.ts
@@ -6,6 +6,11 @@ import { setupLayouts } from "virtual:generated-layouts";
 export const router = createRouter({
   history: createWebHistory(withBase("/")),
   routes: setupLayouts([...routes]),
+  // Only hashes that name something on the page are honoured. Everything else
+  // keeps the browser's own behaviour, which is what the log views want: they
+  // restore their own scroll position. `#cloudLinked` is a signal to the cloud
+  // popover rather than an anchor, so it has to fall through rather than warn.
+  scrollBehavior: (to) => (to.hash && document.querySelector(to.hash) ? { el: to.hash } : undefined),
 });
 
 // After an upgrade the hashed chunks of the old build are gone, so a route this tab has not

--- a/assets/pages/settings.vue
+++ b/assets/pages/settings.vue
@@ -71,7 +71,7 @@
     </section>
 
     <!-- CLOUD -->
-    <section class="flex flex-col gap-4" v-if="config.enableCloud && config.canLinkCloud">
+    <section id="cloud" class="flex scroll-mt-4 flex-col gap-4" v-if="config.enableCloud && config.canLinkCloud">
       <div>
         <h2 class="text-2xl font-semibold tracking-tight">{{ $t("cloud.title") }}</h2>
         <p class="text-base-content/60 mt-1 text-sm">{{ $t("settings.cloud-desc") }}</p>

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -656,9 +656,11 @@ cloud-rail:
   window-1h: 1t
   window-6h: 6t
   window-24h: 24t
+  window-7d: 7 d
 cloud-chat:
   title: Spørg Dozzle
   close: Luk
+  clear: Ryd chatten
   empty: Spørg om det du kigger på. Assistenten kan se denne visning og læse disse logs.
   thinking: Tænker…
   doing:

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -656,9 +656,11 @@ cloud-rail:
   window-1h: 1 Std
   window-6h: 6 Std
   window-24h: 24 Std
+  window-7d: 7 T
 cloud-chat:
   title: Dozzle fragen
   close: Schließen
+  clear: Chat leeren
   empty: Frag zu dem, was du gerade siehst. Der Assistent kennt diese Ansicht und liest diese Logs.
   thinking: Denkt nach…
   doing:

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -237,9 +237,11 @@ cloud-rail:
   window-1h: 1h
   window-6h: 6h
   window-24h: 24h
+  window-7d: 7d
 cloud-chat:
   title: Ask Dozzle
   close: Close
+  clear: Clear chat
   empty: Ask about what you're looking at. The assistant can see this view and read these logs.
   thinking: Thinking…
   doing:

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -229,9 +229,11 @@ cloud-rail:
   window-1h: 1 h
   window-6h: 6 h
   window-24h: 24 h
+  window-7d: 7 d
 cloud-chat:
   title: Preguntar a Dozzle
   close: Cerrar
+  clear: Borrar el chat
   empty: Pregunta sobre lo que estás viendo. El asistente ve esta vista y lee estos logs.
   thinking: Pensando…
   doing:

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -656,9 +656,11 @@ cloud-rail:
   window-1h: 1 h
   window-6h: 6 h
   window-24h: 24 h
+  window-7d: 7 j
 cloud-chat:
   title: Demander à Dozzle
   close: Fermer
+  clear: Effacer la conversation
   empty: Posez une question sur ce que vous regardez. L'assistant voit cette vue et lit ces logs.
   thinking: Réflexion…
   doing:

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -668,9 +668,11 @@ cloud-rail:
   window-1h: 1j
   window-6h: 6j
   window-24h: 24j
+  window-7d: 7 hr
 cloud-chat:
   title: Tanya Dozzle
   close: Tutup
+  clear: Hapus obrolan
   empty: Tanyakan tentang yang sedang kamu lihat. Asisten bisa melihat tampilan ini dan membaca log-nya.
   thinking: Berpikir…
   doing:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -656,9 +656,11 @@ cloud-rail:
   window-1h: 1 h
   window-6h: 6 h
   window-24h: 24 h
+  window-7d: 7 g
 cloud-chat:
   title: Chiedi a Dozzle
   close: Chiudi
+  clear: Cancella la chat
   empty: Chiedi di quello che stai guardando. L'assistente vede questa vista e legge questi log.
   thinking: Sto pensando…
   doing:

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -660,9 +660,11 @@ cloud-rail:
   window-1h: 1시간
   window-6h: 6시간
   window-24h: 24시간
+  window-7d: 7일
 cloud-chat:
   title: Dozzle에 질문
   close: 닫기
+  clear: 대화 지우기
   empty: 지금 보고 있는 것에 대해 물어보세요. 어시스턴트가 이 화면과 로그를 함께 봅니다.
   thinking: 생각 중…
   doing:

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -657,9 +657,11 @@ cloud-rail:
   window-1h: 1u
   window-6h: 6u
   window-24h: 24u
+  window-7d: 7 d
 cloud-chat:
   title: Vraag het Dozzle
   close: Sluiten
+  clear: Chat wissen
   empty: Stel een vraag over wat je ziet. De assistent kent deze weergave en leest deze logs.
   thinking: Aan het denken…
   doing:

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -659,9 +659,11 @@ cloud-rail:
   window-1h: 1 godz
   window-6h: 6 godz
   window-24h: 24 godz
+  window-7d: 7 dni
 cloud-chat:
   title: Zapytaj Dozzle
   close: Zamknij
+  clear: Wyczyść czat
   empty: Zapytaj o to, na co patrzysz. Asystent widzi ten widok i czyta te logi.
   thinking: Myślę…
   doing:

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -656,9 +656,11 @@ cloud-rail:
   window-1h: 1 h
   window-6h: 6 h
   window-24h: 24 h
+  window-7d: 7 d
 cloud-chat:
   title: Perguntar ao Dozzle
   close: Fechar
+  clear: Limpar a conversa
   empty: Pergunta sobre o que estás a ver. O assistente vê esta vista e lê estes logs.
   thinking: A pensar…
   doing:

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -656,9 +656,11 @@ cloud-rail:
   window-1h: 1 ч
   window-6h: 6 ч
   window-24h: 24 ч
+  window-7d: 7 д
 cloud-chat:
   title: Спросить Dozzle
   close: Закрыть
+  clear: Очистить чат
   empty: Спросите о том, что видите. Ассистент видит этот экран и читает эти логи.
   thinking: Думает…
   doing:

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -662,9 +662,11 @@ cloud-rail:
   window-1h: 1 h
   window-6h: 6 h
   window-24h: 24 h
+  window-7d: 7 d
 cloud-chat:
   title: Vprašaj Dozzle
   close: Zapri
+  clear: Počisti klepet
   empty: Vprašaj o tem, kar gledaš. Pomočnik vidi ta pogled in bere te dnevnike.
   thinking: Razmišljam…
   doing:

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -660,9 +660,11 @@ cloud-rail:
   window-1h: 1 sa
   window-6h: 6 sa
   window-24h: 24 sa
+  window-7d: 7 g
 cloud-chat:
   title: Dozzle'a sor
   close: Kapat
+  clear: Sohbeti temizle
   empty: Baktığın şeyi sor. Asistan bu görünümü görüyor ve bu logları okuyor.
   thinking: Düşünüyor…
   doing:

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -659,9 +659,11 @@ cloud-rail:
   window-1h: 1 小時
   window-6h: 6 小時
   window-24h: 24 小時
+  window-7d: 7 天
 cloud-chat:
   title: 問 Dozzle
   close: 關閉
+  clear: 清除對話
   empty: 就眼前看到的內容提問。助手能看到這個檢視，也能讀這些日誌。
   thinking: 思考中…
   doing:

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -656,9 +656,11 @@ cloud-rail:
   window-1h: 1 小时
   window-6h: 6 小时
   window-24h: 24 小时
+  window-7d: 7 天
 cloud-chat:
   title: 问 Dozzle
   close: 关闭
+  clear: 清除对话
   empty: 就眼前看到的内容提问。助手能看到这个视图，也能读这些日志。
   thinking: 思考中…
   doing:


### PR DESCRIPTION
A round of UI fixes, mostly around the cloud rail and touch.

### Alert dot

The dot on a container row explained itself with a `title` attribute: unstyleable, a second late, and gone entirely on touch. It's a real `Popover` now, carrying the severity glyph, level pill, time, event count, summary, and a primary "show me the lines" button. Click triggered, so it works on a phone.

### Hover menus on touch

A tap fires `pointerenter` on touch-down and `pointerleave` on touch-up, so a hover menu opened and closed itself and the container toolbar button looked dead. `Popover` ignores `hover` where `(hover: hover)` doesn't match and falls back to a click toggle.

### The rail on mobile

The rail was hard-gated on `!isMobile`, so "Ask Dozzle" in the toolbar and the ask row in the palette did nothing there. On mobile it opens as a full screen sheet, keeping the icon strip so you can still switch panels and put it away.

Two bugs fell out of that:

- `toggleRail` never cleared the collapse flag the way `openRail` does, so `shift+cmd+k` on a collapsed rail set a panel that was never mounted. Fixed, and strip vs sheet is now an explicit mode rather than something inferred from `visible` being false.
- `pt-safe` sets `padding-top` outright and is emitted after the core spacing utilities, so stacked on `py-3` it won the cascade and collapsed the header and strip padding to `env(safe-area-inset-top)`, which is 0 on desktop. It lives on the sheet's own wrapper now. Comment added on the utility since it's a silent trap.

### Metrics

Opens on 24h rather than 1h. The live chart already covers the last few minutes, so an hour was a slower copy of what's on screen. Pro gets 7d, sent as `168h` because Go parses hours and not days. The hover readout picks up the date past 6h so a week of bars isn't ambiguous.

### Broken settings link

The cloud mark on the strip pointed at `/settings/cloud`, which doesn't exist. Now `/settings#cloud`, with a `scrollBehavior` that only honours a hash naming a real element, so `#cloudLinked` still falls through to the popover that reads it.

### Cloud drawer

Dropped the inset bordered card. A rounded panel inside a drawer that is already a panel draws a box around the drawer's only content. Rows run full bleed to the edges like the footer already did.

### Focus ring

One neutral `base-content/40` ring app wide instead of the UA blue. Deliberately not the accent: an accent ring is the same colour the active nav row already wears, which is what read as a second kind of selection.

### Chat

Added a clear button, so a thread that has run its course doesn't need a reload to get rid of.

---

`cloud-chat.clear` and `cloud-rail.window-7d` are translated across every file in `locales/`.

Typecheck, 333 frontend tests and the build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RujQFNAMffbnmXXgULM2ck
