### PR TITLE
docs: redraw the hero mock against today's UI

### DIFF
--- a/docs/.vitepress/theme/components/HeroDemo.vue
+++ b/docs/.vitepress/theme/components/HeroDemo.vue
@@ -5,13 +5,32 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 // The app's own logo, not a copy, so the hero can never drift from the product.
 import logo from "../../../../assets/logo.svg";
 
+// The same artwork the app bundles for container rows, imported from the same
+// place, so the sidebar here shows exactly what a real install shows.
+import bazarr from "../../../../assets/icons/apps/bazarr.svg";
+import jellyfin from "../../../../assets/icons/apps/jellyfin.svg";
+import lidarr from "../../../../assets/icons/apps/lidarr.webp";
+import overseerr from "../../../../assets/icons/apps/overseerr.svg";
+import prowlarr from "../../../../assets/icons/apps/prowlarr.svg";
+import qbittorrent from "../../../../assets/icons/apps/qbittorrent.svg";
+import radarr from "../../../../assets/icons/apps/radarr.svg";
+import sabnzbd from "../../../../assets/icons/apps/sabnzbd.svg";
+import sonarr from "../../../../assets/icons/apps/sonarr.svg";
+import traefik from "../../../../assets/icons/apps/traefik.svg";
+
 // Entries are taller and vary in height, so the overscan is generous.
-const ROWS = 28;
+const ROWS = 26;
 const TICK_MS = 1100;
+const CHAT_DELAY_MS = 2000;
 
 type Kind = "raw" | "num" | "link";
 type Pair = [key: string, value: string, kind?: Kind];
-type Entry = { level: "info" | "warn" | "error"; pairs: Pair[] };
+type Entry = {
+  level: "info" | "warn" | "error";
+  pairs: Pair[];
+  /** Renders the bell in place of the level dot: an alert rule matched this line. */
+  alert?: boolean;
+};
 
 // Cycled deterministically so the server and the client render the same first
 // paint. Nothing here reads the clock or Math.random for the same reason.
@@ -59,6 +78,7 @@ const ENTRIES: Entry[] = [
   },
   {
     level: "error",
+    alert: true,
     pairs: [
       ["level", "error"],
       ["error", "dial tcp 10.0.1.7:8080: connection refused"],
@@ -145,6 +165,7 @@ const ENTRIES: Entry[] = [
   },
   {
     level: "warn",
+    alert: true,
     pairs: [
       ["level", "warn"],
       ["indexer", "1337x"],
@@ -188,29 +209,37 @@ function entryAt(index: number) {
   return { ...entry, id: index, date: `08/09/2026 ${time}` };
 }
 
-type Item = { name: string; active?: boolean; healthy?: boolean };
+type Status = "running" | "healthy" | "unhealthy";
+type Item = { name: string; icon: string; status: Status; active?: boolean };
 type Group = { icon: "pin" | "stack" | "box"; label: string; items: Item[] };
 
 const GROUPS: Group[] = [
   {
     icon: "pin",
     label: "Pinned",
-    items: [{ name: "media_sonarr.1", active: true }, { name: "media_jellyfin.1" }],
+    items: [
+      { name: "media_sonarr.1", icon: sonarr, status: "healthy", active: true },
+      { name: "media_jellyfin.1", icon: jellyfin, status: "running" },
+    ],
   },
   {
     icon: "stack",
     label: "media",
     items: [
-      { name: "media_bazarr.1" },
-      { name: "media_lidarr.1" },
-      { name: "media_overseerr.1", healthy: true },
-      { name: "media_prowlarr.1", healthy: true },
-      { name: "media_qbittorrent.1" },
-      { name: "media_radarr.1" },
-      { name: "media_sabnzbd.1" },
+      { name: "media_bazarr.1", icon: bazarr, status: "running" },
+      { name: "media_lidarr.1", icon: lidarr, status: "running" },
+      { name: "media_overseerr.1", icon: overseerr, status: "healthy" },
+      { name: "media_prowlarr.1", icon: prowlarr, status: "healthy" },
+      { name: "media_qbittorrent.1", icon: qbittorrent, status: "unhealthy" },
+      { name: "media_radarr.1", icon: radarr, status: "running" },
+      { name: "media_sabnzbd.1", icon: sabnzbd, status: "running" },
     ],
   },
-  { icon: "box", label: "Running Containers", items: [{ name: "traefik_traefik.1" }] },
+  {
+    icon: "box",
+    label: "Running Containers",
+    items: [{ name: "traefik_traefik.1", icon: traefik, status: "healthy" }],
+  },
 ];
 
 const cursor = ref(ROWS);
@@ -249,12 +278,24 @@ const netRx = computed(() => rate(at(NET_SERIES, stat.value + 37) * 4.6));
 const diskRx = computed(() => rate(at(NET_SERIES, stat.value + 91) * 0.7));
 
 const list = ref<HTMLElement>();
+// The panel is the last thing to arrive, so the stream is what the eye lands on
+// first and the answer reads as something that happened rather than chrome that
+// was always there. Closed on the server too, so hydration matches.
+const chatOpen = ref(false);
 const reducedMotion = usePreferredReducedMotion();
 let timer: ReturnType<typeof setInterval> | undefined;
 let statTimer: ReturnType<typeof setInterval> | undefined;
+let chatTimer: ReturnType<typeof setTimeout> | undefined;
 
 onMounted(() => {
-  if (reducedMotion.value === "reduce") return;
+  if (reducedMotion.value === "reduce") {
+    // Nothing animates, so there is nothing to wait for.
+    chatOpen.value = true;
+    return;
+  }
+
+  chatTimer = setTimeout(() => (chatOpen.value = true), CHAT_DELAY_MS);
+
   timer = setInterval(async () => {
     // The list is bottom-anchored, so appending an entry shifts everything up by
     // the height of the entry dropping off the top. Measure it before the
@@ -275,6 +316,7 @@ onMounted(() => {
 onBeforeUnmount(() => {
   clearInterval(timer);
   clearInterval(statTimer);
+  clearTimeout(chatTimer);
 });
 
 const alt = "The Dozzle interface streaming container logs in real time";
@@ -289,51 +331,69 @@ const alt = "The Dozzle interface streaming container logs in real time";
           <span class="wordmark">Dozzle</span>
         </div>
 
-        <div class="crumbs">
-          <span class="crumb-link">Hosts</span>
-          <span class="crumb-sep">›</span>
-          <span class="host-pill"><i class="i-merge" />nas</span>
-          <span class="crumb-more">⋮</span>
+        <div class="rule"></div>
+
+        <!-- A segmented control rather than dots: with a handful of sections,
+             naming them is cheaper to read than a caption. -->
+        <div class="tabs">
+          <span class="tab on">Hosts</span>
+          <span class="tab">Services</span>
+        </div>
+
+        <div class="nav-head">
+          <i class="i i-chevron-left nav-back" />
+          <i class="i i-box nav-host-icon" />
+          <span class="nav-host">nas</span>
+          <span class="head-btn"><i class="i i-merge" /></span>
+          <span class="head-btn"><i class="i i-dots" /></span>
         </div>
 
         <div class="group" v-for="group in GROUPS" :key="group.label">
           <div class="group-head">
-            <i class="i-group" :class="`i-${group.icon}`" />
-            <span class="group-label">{{ group.label }} ({{ group.items.length }})</span>
-            <span class="merge-btn"><i class="i-merge" /></span>
-            <span class="chevron">⌃</span>
+            <i class="i i-chevron-right group-caret" />
+            <i class="i" :class="`i-${group.icon}`" />
+            <span class="group-label">{{ group.label }}</span>
+            <span class="group-count">{{ group.items.length }}</span>
           </div>
-          <div class="item" v-for="item in group.items" :key="item.name" :class="{ active: item.active }">
-            <span class="dot" />
-            <span class="item-name">{{ item.name }}</span>
-            <span class="health" v-if="item.healthy">✓</span>
+          <div class="items">
+            <div class="item" v-for="item in group.items" :key="item.name" :class="{ active: item.active }">
+              <span class="app-icon">
+                <img :src="item.icon" alt="" />
+                <span v-if="item.status === 'healthy'" class="badge glyph healthy"><i class="i i-check" /></span>
+                <span v-else-if="item.status === 'unhealthy'" class="badge glyph unhealthy"
+                  ><i class="i i-alert"
+                /></span>
+                <span v-else class="badge dot running" />
+              </span>
+              <span class="item-name">{{ item.name }}</span>
+            </div>
           </div>
         </div>
       </div>
 
-      <div class="main" aria-hidden="true">
+      <div class="stage" aria-hidden="true">
         <div class="topbar">
-          <span class="star">★</span>
-          <span class="name-btn">media_sonarr.1 <span class="caret">▾</span></span>
-          <span class="health topbar-health">✓</span>
-          <span class="image-tag">
-            <span class="image-name">lscr.io/linuxserver/sonarr:4.0.15</span>
-            <span class="copy">⧉</span>
-          </span>
+          <span class="title">media_sonarr.1</span>
+          <i class="i i-pin pin" />
+          <i class="i i-check health" />
+          <span class="image-name">lscr.io/linuxserver/sonarr:4.0.15</span>
 
-          <div class="cards">
-            <div class="io-card">
-              <span class="io-icon">◇</span>
-              <span class="up">↑</span><span class="io-num">{{ netTx }}</span> <span class="down">↓</span
-              ><span class="io-num">{{ netRx }}</span>
-              <span class="io-icon">▤</span>
-              <span class="up">↑</span><span class="io-num">0B/s</span> <span class="down">↓</span
-              ><span class="io-num">{{ diskRx }}</span>
+          <!-- One surface, hairline separated, the way the toolbar draws it now:
+               the sparklines are the only colour so the numbers lead. -->
+          <div class="stats">
+            <div class="io">
+              <span class="io-label">NET</span>
+              <i class="i i-arrow-up io-arrow" /><span class="io-num">{{ netTx }}</span>
+              <i class="i i-arrow-down io-arrow" /><span class="io-num">{{ netRx }}</span>
+              <span class="io-label">DISK</span>
+              <i class="i i-arrow-up io-arrow" /><span class="io-num idle">0B/s</span>
+              <i class="i i-arrow-down io-arrow" /><span class="io-num">{{ diskRx }}</span>
             </div>
 
             <div class="stat-card cpu">
               <div class="stat-head">
-                <span class="stat-icon">▢</span><b>{{ cpuPct }}%</b><span class="stat-sub">/ 2 CPU</span>
+                <span class="stat-label">CPU</span>
+                <b>{{ cpuPct }}%</b><span class="stat-sub">/ 2</span>
               </div>
               <div class="chart">
                 <i v-for="(h, i) in cpuBars" :key="i" :style="{ height: `${h}%` }" />
@@ -342,20 +402,33 @@ const alt = "The Dozzle interface streaming container logs in real time";
 
             <div class="stat-card mem">
               <div class="stat-head">
-                <span class="stat-icon">▤</span><b>{{ memUsed }}M</b><span class="stat-sub">/ 1.9G</span>
+                <span class="stat-label">MEM</span>
+                <b>{{ memUsed }}M</b><span class="stat-sub">/ 1.9G</span>
               </div>
               <div class="chart">
                 <i v-for="(h, i) in memBars" :key="i" :style="{ height: `${h}%` }" />
               </div>
             </div>
           </div>
+
+          <span class="std-btn"><i class="std stderr" /><i class="std stdout" /></span>
         </div>
 
         <div class="logs">
           <div class="log-list" ref="list">
-            <div v-for="row in rows" :key="row.id" class="row" :class="{ zebra: row.id % 2 === 0 }">
+            <div
+              v-for="row in rows"
+              :key="row.id"
+              class="row"
+              :class="{ zebra: row.id % 2 === 0 }"
+              :data-level="row.level"
+            >
               <span class="date">{{ row.date }}</span>
-              <span class="level" :class="row.level" />
+              <!-- A matched rule takes the level marker over rather than adding a
+                   second glyph beside it, so one mark says "this fired" and what
+                   level it was. -->
+              <i v-if="row.alert" class="i i-bell alert-badge" :class="row.level" />
+              <span v-else class="level" :class="row.level" />
               <span class="pairs">
                 <span class="pair" v-for="[key, value, kind] in row.pairs" :key="key">
                   <span class="key">{{ key }}=</span><span class="value" :class="kind ?? 'string'">{{ value }}</span>
@@ -364,6 +437,61 @@ const alt = "The Dozzle interface streaming container logs in real time";
             </div>
           </div>
         </div>
+      </div>
+
+      <!-- The rail's chat panel: what the assistant can answer about the view
+           already on screen, sitting beside it rather than over it. -->
+      <div class="panel" :class="{ open: chatOpen }" aria-hidden="true">
+        <div class="panel-inner">
+          <div class="panel-head">
+            <i class="i i-message panel-icon" />
+            <span class="panel-title">Ask Dozzle</span>
+            <span class="panel-by"><i class="i i-cloud" />Dozzle Cloud</span>
+            <span class="panel-close">×</span>
+          </div>
+
+          <div class="thread">
+            <div class="ask">
+              <p>why does qbittorrent keep dropping?</p>
+              <div class="ctx"><i class="i i-eye" />media_sonarr.1 · last 30 min</div>
+            </div>
+
+            <div class="answer">
+              <p>
+                <b>media_qbittorrent.1</b> has failed its health check 3 times since 12:31 PM, and it is the same
+                failure each time.
+              </p>
+              <ul>
+                <li>
+                  Memory held at <b>122M</b> of its <b>128M</b> limit for the last hour, then the process was OOM killed
+                  and restarted.
+                </li>
+                <li>sonarr logged <b>connection refused</b> to 10.0.1.7:8080 fourteen times in the same window.</li>
+              </ul>
+              <p>Raising the memory limit, or capping the disk cache, stops the restarts.</p>
+              <span class="answer-action"><i class="i i-arrow-out" />Show me the lines</span>
+            </div>
+          </div>
+
+          <div class="composer-wrap">
+            <div class="ctx"><i class="i i-eye" />media_sonarr.1 · 400 lines</div>
+            <div class="composer">
+              <span class="composer-hint">Ask about this view…</span>
+              <span class="send"><i class="i i-send" /></span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- The cloud rail: a strip on the right edge with the panels it opens,
+           mounted only where Dozzle Cloud is linked. -->
+      <div class="rail" aria-hidden="true">
+        <span class="cloud-mark"><i class="i i-cloud" /></span>
+        <div class="rail-rule"></div>
+        <span class="rail-btn" :class="{ on: chatOpen }"><i class="i i-message" /></span>
+        <span class="rail-btn"><i class="i i-chart" /></span>
+        <span class="rail-btn"><i class="i i-bell" /><span class="rail-dot" /></span>
+        <span class="rail-btn rail-hide"><i class="i i-chevron-right" /></span>
       </div>
     </div>
   </div>
@@ -431,126 +559,26 @@ const alt = "The Dozzle interface streaming container logs in real time";
   --zebra: oklch(70.7% 0.022 261.3 / 0.07);
 }
 
-/* Sidebar
-   -------------------------------------------------------------------------- */
+/* Icons
+   --------------------------------------------------------------------------
+   Drawn as masks rather than glyphs: at this scale a font character loses its
+   shape, and the stroke weight has to match the app's. */
 
-.sidebar {
-  display: flex;
-  flex: 0 0 calc(228 * var(--u));
-  flex-direction: column;
-  padding: calc(12 * var(--u));
-  border-right: 1px solid color-mix(in oklab, var(--content) 10%, transparent);
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: calc(10 * var(--u));
-}
-
-.logo {
-  width: calc(34 * var(--u));
-  height: calc(34 * var(--u));
-}
-
-.wordmark {
-  font-family:
-    ui-sans-serif,
-    system-ui,
-    -apple-system,
-    "Segoe UI",
-    Roboto,
-    sans-serif;
-  font-size: calc(34 * var(--u));
-  font-weight: 100;
-  line-height: 1;
-}
-
-.crumbs {
-  display: flex;
-  align-items: center;
-  gap: calc(6 * var(--u));
-  margin-top: calc(18 * var(--u));
-  font-size: calc(11.5 * var(--u));
-}
-
-.crumb-link {
-  color: var(--primary);
-}
-
-.crumb-sep {
-  opacity: 0.4;
-}
-
-.host-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: calc(4 * var(--u));
-  padding: calc(2 * var(--u)) calc(7 * var(--u));
-  border: 1px solid var(--primary);
-  border-radius: calc(4 * var(--u));
-  color: var(--primary);
-  font-size: calc(10 * var(--u));
-}
-
-.crumb-more {
-  margin-left: auto;
-  opacity: 0.5;
-}
-
-.group {
-  margin-top: calc(14 * var(--u));
-}
-
-.group-head {
-  display: flex;
-  align-items: center;
-  gap: calc(7 * var(--u));
-  padding: calc(2 * var(--u)) calc(4 * var(--u));
-  color: color-mix(in oklab, var(--content) 80%, transparent);
-  font-size: calc(11.5 * var(--u));
-  font-weight: 300;
-}
-
-.group-label {
-  white-space: nowrap;
-}
-
-.merge-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: calc(15 * var(--u));
-  height: calc(15 * var(--u));
-  border: 1px solid var(--primary);
-  border-radius: calc(3 * var(--u));
-  color: var(--primary);
-}
-
-.chevron {
-  margin-left: auto;
-  opacity: 0.45;
-  font-size: calc(9 * var(--u));
-}
-
-/* ph:arrows-merge, drawn small enough that a glyph would not survive. */
-.i-merge {
-  width: calc(9 * var(--u));
-  height: calc(9 * var(--u));
-  background: currentColor;
-  mask: no-repeat center / contain
-    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M12 21V11m0 0L6 5m6 6 6-6'/%3E%3C/svg%3E");
-}
-
-.i-group {
+.i {
+  display: inline-block;
   width: calc(12 * var(--u));
   height: calc(12 * var(--u));
+  flex: none;
   background: currentColor;
   mask: no-repeat center / contain var(--glyph);
 }
 
+.i-merge {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M12 21V11m0 0L6 5m6 6 6-6'/%3E%3C/svg%3E");
+}
+
 .i-pin {
-  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M12 22v-8m0 0a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z'/%3E%3C/svg%3E");
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M12 21.5s7-6.2 7-11a7 7 0 1 0-14 0c0 4.8 7 11 7 11Z'/%3E%3Ccircle cx='12' cy='10.5' r='2.6' fill='none' stroke='%23000' stroke-width='2'/%3E%3C/svg%3E");
 }
 
 .i-stack {
@@ -561,34 +589,282 @@ const alt = "The Dozzle interface streaming container logs in real time";
   --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M3 7h18v10H3zM7 7v10m10-10v10'/%3E%3C/svg%3E");
 }
 
+.i-chevron-right {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round' d='m9 5 7 7-7 7'/%3E%3C/svg%3E");
+}
+
+.i-chevron-left {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round' d='m15 5-7 7 7 7'/%3E%3C/svg%3E");
+}
+
+.i-check {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='9.2' fill='none' stroke='%23000' stroke-width='2.6'/%3E%3Cpath fill='none' stroke='%23000' stroke-width='2.6' stroke-linecap='round' stroke-linejoin='round' d='m7.8 12.3 2.9 2.9 5.5-5.7'/%3E%3C/svg%3E");
+}
+
+.i-alert {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='9.2' fill='none' stroke='%23000' stroke-width='2.6'/%3E%3Cpath fill='none' stroke='%23000' stroke-width='2.6' stroke-linecap='round' d='M12 7.2v5.4m0 3.4v.6'/%3E%3C/svg%3E");
+}
+
+.i-arrow-up {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round' d='M12 19V5m0 0-6 6m6-6 6 6'/%3E%3C/svg%3E");
+}
+
+.i-arrow-down {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round' d='M12 5v14m0 0-6-6m6 6 6-6'/%3E%3C/svg%3E");
+}
+
+.i-bell {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M12 2.5a5.6 5.6 0 0 0-5.6 5.6c0 5.4-2.2 7-2.2 7h15.6s-2.2-1.6-2.2-7A5.6 5.6 0 0 0 12 2.5Zm2 14.6h-4a2 2 0 0 0 4 0Z'/%3E%3C/svg%3E");
+}
+
+.i-cloud {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M17.6 19H6.8A4.3 4.3 0 0 1 6.2 10.4 6 6 0 0 1 17.9 9.8a4.6 4.6 0 0 1-.3 9.2Z'/%3E%3C/svg%3E");
+}
+
+.i-message {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linejoin='round' d='M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2Z'/%3E%3C/svg%3E");
+}
+
+.i-dots {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M12 4.6a1.7 1.7 0 1 0 0 3.4 1.7 1.7 0 0 0 0-3.4Zm0 5.7a1.7 1.7 0 1 0 0 3.4 1.7 1.7 0 0 0 0-3.4Zm0 5.7a1.7 1.7 0 1 0 0 3.4 1.7 1.7 0 0 0 0-3.4Z'/%3E%3C/svg%3E");
+}
+
+.i-eye {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M2.5 12S6.5 5.5 12 5.5 21.5 12 21.5 12 17.5 18.5 12 18.5 2.5 12 2.5 12Z'/%3E%3Ccircle cx='12' cy='12' r='3' fill='none' stroke='%23000' stroke-width='2'/%3E%3C/svg%3E");
+}
+
+.i-send {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23000' d='M2.5 21 22 12 2.5 3l4.4 7.2 9.1 1.8-9.1 1.8Z'/%3E%3C/svg%3E");
+}
+
+.i-arrow-out {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M7 17 17 7m0 0H8.5M17 7v8.5'/%3E%3C/svg%3E");
+}
+
+.i-chart {
+  --glyph: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' d='M3 3v18h18M7 15l4-5 3 3 5-7'/%3E%3C/svg%3E");
+}
+
+/* Sidebar
+   -------------------------------------------------------------------------- */
+
+.sidebar {
+  display: flex;
+  flex: 0 0 calc(232 * var(--u));
+  flex-direction: column;
+  gap: calc(10 * var(--u));
+  padding: calc(12 * var(--u));
+  border-right: 1px solid color-mix(in oklab, var(--content) 10%, transparent);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: calc(8 * var(--u));
+}
+
+.logo {
+  width: calc(30 * var(--u));
+  height: calc(30 * var(--u));
+}
+
+/* A brand mark, not a heading you read twice: it gives the space back to the
+   tree underneath. */
+.wordmark {
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  font-size: calc(24 * var(--u));
+  font-weight: 300;
+  letter-spacing: -0.01em;
+  line-height: 1;
+}
+
+.tabs {
+  display: flex;
+  gap: calc(2 * var(--u));
+  padding: calc(1.5 * var(--u));
+  border-radius: calc(5 * var(--u));
+  background: color-mix(in oklab, var(--content) 6%, transparent);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: calc(10.5 * var(--u));
+  font-weight: 500;
+  /* VitePress sets a 24px line-height on body, which this inherits: without a
+     line-height of its own the strip came out half again as tall as the app's. */
+  line-height: 1;
+}
+
+.tab {
+  flex: 1;
+  padding: calc(4 * var(--u)) calc(5 * var(--u));
+  border-radius: calc(3.5 * var(--u));
+  color: color-mix(in oklab, var(--content) 50%, transparent);
+  text-align: center;
+}
+
+.tab.on {
+  background: var(--base-100);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 0.06);
+  color: var(--content);
+}
+
+.rule {
+  height: 1px;
+  background: color-mix(in oklab, var(--content) 10%, transparent);
+}
+
+.nav-head {
+  display: flex;
+  align-items: center;
+  gap: calc(6 * var(--u));
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}
+
+.nav-back,
+.nav-host-icon {
+  width: calc(14 * var(--u));
+  height: calc(14 * var(--u));
+  color: color-mix(in oklab, var(--content) 50%, transparent);
+}
+
+.nav-host {
+  font-size: calc(13 * var(--u));
+  font-weight: 500;
+}
+
+.head-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(16 * var(--u));
+  height: calc(16 * var(--u));
+  border-radius: calc(3 * var(--u));
+  color: color-mix(in oklab, var(--content) 45%, transparent);
+}
+
+.head-btn:first-of-type {
+  margin-left: auto;
+}
+
+.head-btn .i {
+  width: calc(12 * var(--u));
+  height: calc(12 * var(--u));
+}
+
+/* Deliberately quieter than an item row: the group is scaffolding, the
+   containers under it are the content. */
+.group-head {
+  display: flex;
+  align-items: center;
+  gap: calc(5 * var(--u));
+  height: calc(24 * var(--u));
+  padding-left: calc(2 * var(--u));
+  color: color-mix(in oklab, var(--content) 55%, transparent);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: calc(11.5 * var(--u));
+  font-weight: 600;
+}
+
+.group-caret {
+  width: calc(11 * var(--u));
+  height: calc(11 * var(--u));
+  transform: rotate(90deg);
+}
+
+.group-head .i {
+  width: calc(12 * var(--u));
+  height: calc(12 * var(--u));
+}
+
+.group-label {
+  white-space: nowrap;
+}
+
+.group-count {
+  font-weight: 400;
+  opacity: 0.6;
+}
+
+.items {
+  margin-left: calc(10 * var(--u));
+  padding-left: calc(4 * var(--u));
+  border-left: 1px solid color-mix(in oklab, var(--content) 10%, transparent);
+}
+
 .item {
   display: flex;
   align-items: center;
   gap: calc(8 * var(--u));
   height: calc(28 * var(--u));
-  padding: 0 calc(10 * var(--u));
+  padding: 0 calc(7 * var(--u));
   border-radius: calc(5 * var(--u));
-  font-size: calc(12 * var(--u));
+  color: color-mix(in oklab, var(--content) 85%, transparent);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: calc(12.5 * var(--u));
 }
 
+/* Tinted rather than filled: a solid block on the selected row shouted over the
+   app icon and status badge sitting inside it. */
 .item.active {
-  background: linear-gradient(
-    100deg,
-    color-mix(in oklab, var(--primary) 85%, transparent),
-    color-mix(in oklab, var(--primary) 55%, transparent)
-  );
-  color: oklch(20% 0 0);
+  background: color-mix(in oklab, var(--primary) 15%, transparent);
+  color: var(--primary);
+  font-weight: 500;
 }
 
-.dot {
-  width: calc(6 * var(--u));
-  height: calc(6 * var(--u));
+.app-icon {
+  position: relative;
+  display: inline-flex;
+  flex: none;
+  width: calc(19 * var(--u));
+  height: calc(19 * var(--u));
+}
+
+.app-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+/* Overhangs the logo's corner, filled and ringed in the page colour so the glyph
+   stays legible on busy artwork. */
+.badge {
+  position: absolute;
+  top: calc(-3 * var(--u));
+  right: calc(-3 * var(--u));
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(10 * var(--u));
+  height: calc(10 * var(--u));
   border-radius: 999px;
-  background: var(--green);
+  background: var(--page);
+  box-shadow: 0 0 0 calc(1.2 * var(--u)) var(--page);
 }
 
-.item.active .dot {
-  background: oklch(30% 0.08 158);
+.badge .i {
+  width: 100%;
+  height: 100%;
+}
+
+.badge.dot {
+  width: calc(7 * var(--u));
+  height: calc(7 * var(--u));
+}
+
+.badge.healthy {
+  color: var(--green);
+}
+
+.badge.unhealthy {
+  color: var(--red);
+}
+
+.badge.running {
+  background: var(--green);
 }
 
 .item-name {
@@ -597,166 +873,134 @@ const alt = "The Dozzle interface streaming container logs in real time";
   white-space: nowrap;
 }
 
-.health {
-  margin-left: auto;
-  color: var(--green);
-  font-size: calc(10 * var(--u));
-}
-
-.item.active .health {
-  color: oklch(25% 0.06 158);
-}
-
 /* Main panel
-   -------------------------------------------------------------------------- */
+   --------------------------------------------------------------------------
+   Named .stage, not .main: VitePress styles a global `.main` and its padding
+   left a dead gutter between the stream and the rail. */
 
-.main {
+.stage {
   display: flex;
   flex: 1;
   flex-direction: column;
   min-width: 0;
+  padding: 0;
 }
 
 .topbar {
   display: flex;
-  flex: 0 0 calc(46 * var(--u));
+  flex: 0 0 calc(48 * var(--u));
   align-items: center;
-  gap: calc(8 * var(--u));
+  gap: calc(7 * var(--u));
   padding: 0 calc(12 * var(--u));
 }
 
-.star {
-  color: var(--secondary);
+/* The name is the page title, so it carries no button frame of its own. */
+.title {
   font-size: calc(13 * var(--u));
-}
-
-.name-btn {
-  display: inline-flex;
-  align-items: center;
-  height: calc(22 * var(--u));
-  gap: calc(5 * var(--u));
-  padding: 0 calc(8 * var(--u));
-  border-radius: calc(4 * var(--u));
-  background: var(--chip);
-  font-size: calc(11 * var(--u));
-  line-height: 1;
-}
-
-.caret {
-  font-size: calc(8 * var(--u));
-  opacity: 0.7;
-}
-
-.topbar-health {
-  margin-left: 0;
-}
-
-.image-tag {
-  display: inline-flex;
-  overflow: hidden;
-  align-items: center;
-  min-width: 0;
-  height: calc(20 * var(--u));
-  gap: calc(6 * var(--u));
   white-space: nowrap;
-  padding: 0 calc(4 * var(--u)) 0 calc(8 * var(--u));
-  border-radius: calc(3 * var(--u));
-  background: var(--chip);
-  font-size: calc(10.5 * var(--u));
-  line-height: 1;
 }
 
+.pin {
+  width: calc(13 * var(--u));
+  height: calc(13 * var(--u));
+  color: color-mix(in oklab, var(--content) 40%, transparent);
+}
+
+.health {
+  width: calc(13 * var(--u));
+  height: calc(13 * var(--u));
+  color: var(--green);
+}
+
+/* The image is reference material, not a control: dimmed text keeps it out of
+   the name's way. */
 .image-name {
   overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.copy {
-  display: inline-flex;
-  flex: none;
-  align-items: center;
-  justify-content: center;
-  width: calc(14 * var(--u));
-  height: calc(14 * var(--u));
-  border-radius: calc(3 * var(--u));
-  background: color-mix(in oklab, var(--content) 10%, transparent);
   color: color-mix(in oklab, var(--content) 45%, transparent);
-  font-size: calc(9 * var(--u));
+  font-size: calc(11 * var(--u));
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.cards {
+.stats {
   display: flex;
   flex: none;
   align-items: stretch;
-  gap: calc(10 * var(--u));
   margin-left: auto;
-  padding-left: calc(10 * var(--u));
+  border-radius: calc(6 * var(--u));
+  background: color-mix(in oklab, var(--content) 5.5%, transparent);
 }
 
-.io-card {
-  display: grid;
+.stats > * + * {
+  border-left: 1px solid color-mix(in oklab, var(--content) 10%, transparent);
+}
+
+/* The app drops this card once the column gets narrow, and an open panel is
+   exactly that. */
+.io {
+  display: none;
   align-items: center;
-  gap: calc(3 * var(--u)) calc(6 * var(--u));
-  grid-template-columns: auto auto calc(44 * var(--u)) auto calc(44 * var(--u));
-  padding: calc(4 * var(--u)) calc(8 * var(--u));
-  border-radius: calc(5 * var(--u));
-  background: color-mix(in oklab, var(--content) 6%, transparent);
-  font-size: calc(10.5 * var(--u));
+  gap: calc(5 * var(--u)) calc(5 * var(--u));
+  grid-template-columns: auto auto calc(46 * var(--u)) auto calc(46 * var(--u));
+  padding: calc(6 * var(--u)) calc(10 * var(--u));
+  font-size: calc(11 * var(--u));
+  font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 
-.io-icon {
-  color: color-mix(in oklab, var(--content) 60%, transparent);
+.io-label {
+  color: color-mix(in oklab, var(--content) 40%, transparent);
+  font-size: calc(9.5 * var(--u));
+  font-weight: 500;
+  letter-spacing: 0.06em;
+}
+
+.io-arrow {
+  width: calc(9 * var(--u));
+  height: calc(9 * var(--u));
+  color: color-mix(in oklab, var(--content) 35%, transparent);
 }
 
 .io-num {
   text-align: right;
-  font-variant-numeric: tabular-nums;
 }
 
-.up {
-  color: var(--primary);
-}
-
-.down {
-  color: var(--secondary);
+.io-num.idle {
+  color: color-mix(in oklab, var(--content) 40%, transparent);
 }
 
 .stat-card {
   display: flex;
   flex-direction: column;
-  gap: calc(2 * var(--u));
-  width: calc(196 * var(--u));
-  padding: calc(4 * var(--u)) calc(8 * var(--u));
-  border-radius: calc(5 * var(--u));
-}
-
-.cpu {
-  background: color-mix(in oklab, var(--primary) 12%, transparent);
-}
-
-.mem {
-  background: color-mix(in oklab, var(--secondary) 12%, transparent);
+  justify-content: center;
+  gap: calc(4 * var(--u));
+  width: calc(168 * var(--u));
+  padding: calc(6 * var(--u)) calc(10 * var(--u));
 }
 
 .stat-head {
   display: flex;
-  align-items: center;
-  gap: calc(6 * var(--u));
-  font-size: calc(10.5 * var(--u));
+  align-items: baseline;
+  gap: calc(5 * var(--u));
+  font-size: calc(13 * var(--u));
+  font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 
-.cpu .stat-icon {
-  color: var(--primary);
+.stat-head b {
+  font-weight: 600;
 }
 
-.mem .stat-icon {
-  color: var(--secondary);
+.stat-label {
+  color: color-mix(in oklab, var(--content) 40%, transparent);
+  font-size: calc(9.5 * var(--u));
+  font-weight: 500;
+  letter-spacing: 0.06em;
 }
 
 .stat-sub {
   color: color-mix(in oklab, var(--content) 45%, transparent);
+  font-size: calc(11 * var(--u));
 }
 
 .chart {
@@ -771,7 +1015,7 @@ const alt = "The Dozzle interface streaming container logs in real time";
   min-height: 1px;
   transition: height 200ms linear;
   border-radius: calc(2 * var(--u)) calc(2 * var(--u)) 0 0;
-  opacity: 0.8;
+  opacity: 0.7;
 }
 
 .cpu .chart i {
@@ -780,6 +1024,29 @@ const alt = "The Dozzle interface streaming container logs in real time";
 
 .mem .chart i {
   background: var(--secondary);
+}
+
+/* The stdout/stderr toggle, the one control that is always on the row. */
+.std-btn {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: calc(3 * var(--u));
+  padding: 0 calc(2 * var(--u));
+}
+
+.std {
+  width: calc(7 * var(--u));
+  height: calc(7 * var(--u));
+  border-radius: 999px;
+}
+
+.std.stderr {
+  background: var(--red);
+}
+
+.std.stdout {
+  background: var(--blue);
 }
 
 /* Log stream
@@ -815,20 +1082,30 @@ const alt = "The Dozzle interface streaming container logs in real time";
   background: var(--zebra);
 }
 
+/* A level tint beats the zebra: warn and error rows are findable while
+   scrolling past, without a saturated block for every line. */
+.row[data-level="warn"] {
+  background: color-mix(in oklab, var(--orange) 8%, transparent);
+}
+
+.row[data-level="error"] {
+  background: color-mix(in oklab, var(--red) 9%, transparent);
+}
+
+/* Unboxed: in a wall of monospace the timestamp is a reference, not content, so
+   it reads as a quiet left column. */
 .date {
   flex: none;
-  padding: calc(1 * var(--u)) calc(7 * var(--u));
-  border-radius: calc(3 * var(--u));
-  background: var(--chip);
-  color: var(--blue);
+  color: color-mix(in oklab, var(--content) 45%, transparent);
+  font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
 .level {
   flex: none;
-  width: calc(9 * var(--u));
-  height: calc(9 * var(--u));
-  margin-top: calc(4 * var(--u));
+  width: calc(5 * var(--u));
+  height: calc(5 * var(--u));
+  margin-top: calc(6 * var(--u));
   border-radius: 999px;
 }
 
@@ -842,6 +1119,24 @@ const alt = "The Dozzle interface streaming container logs in real time";
 
 .level.error {
   background: var(--red);
+}
+
+.alert-badge {
+  width: calc(11 * var(--u));
+  height: calc(11 * var(--u));
+  margin-top: calc(3 * var(--u));
+}
+
+.alert-badge.info {
+  color: var(--green);
+}
+
+.alert-badge.warn {
+  color: var(--orange);
+}
+
+.alert-badge.error {
+  color: var(--red);
 }
 
 .pairs {
@@ -878,16 +1173,288 @@ const alt = "The Dozzle interface streaming container logs in real time";
   text-underline-offset: calc(3 * var(--u));
 }
 
-/* Narrow hero: drop the sidebar and the stat cards, and scale the type against a
-   smaller design width so the entries stay legible instead of collapsing into
-   texture. */
+/* Chat panel
+   -------------------------------------------------------------------------- */
+
+.panel {
+  display: flex;
+  /* Slides open from the edge two seconds in. The width animates on the
+     wrapper while the column inside holds its own, so the answer arrives
+     already laid out instead of reflowing on the way in. */
+  flex: 0 0 0;
+  overflow: hidden;
+  border-left: 1px solid transparent;
+  background: var(--base-100);
+  transition:
+    flex-basis 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    border-color 420ms linear;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+}
+
+.panel.open {
+  flex-basis: calc(372 * var(--u));
+  border-left-color: color-mix(in oklab, var(--content) 10%, transparent);
+}
+
+.panel-inner {
+  display: flex;
+  flex-direction: column;
+  width: calc(372 * var(--u));
+  margin-left: auto;
+}
+
+.panel-head {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: calc(7 * var(--u));
+  padding: calc(11 * var(--u)) calc(14 * var(--u));
+  border-bottom: 1px solid color-mix(in oklab, var(--content) 10%, transparent);
+}
+
+.panel-icon {
+  width: calc(14 * var(--u));
+  height: calc(14 * var(--u));
+  color: color-mix(in oklab, var(--content) 60%, transparent);
+}
+
+.panel-title {
+  font-size: calc(13 * var(--u));
+  font-weight: 600;
+}
+
+/* Who answered. Muted, because the reader needs it once to trust the panel and
+   never again while reading it. */
+.panel-by {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(4 * var(--u));
+  color: color-mix(in oklab, var(--content) 40%, transparent);
+  font-size: calc(11 * var(--u));
+}
+
+.panel-by .i {
+  width: calc(12 * var(--u));
+  height: calc(12 * var(--u));
+  color: color-mix(in oklab, var(--blue) 70%, transparent);
+}
+
+.panel-close {
+  margin-left: auto;
+  color: color-mix(in oklab, var(--content) 45%, transparent);
+  font-size: calc(15 * var(--u));
+  line-height: 1;
+}
+
+.thread {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  /* Everything hugs the composer: centred, a short thread floats half a panel
+     away from the box you type into. */
+  justify-content: flex-end;
+  gap: calc(14 * var(--u));
+  min-height: 0;
+  padding: calc(14 * var(--u));
+  font-size: calc(12.5 * var(--u));
+  line-height: 1.55;
+}
+
+/* The question is a neutral panel; the answer is the pane itself. */
+.ask {
+  padding: calc(10 * var(--u)) calc(11 * var(--u));
+  border: 1px solid color-mix(in oklab, var(--content) 15%, transparent);
+  border-radius: calc(8 * var(--u));
+  background: color-mix(in oklab, var(--base-200) 40%, transparent);
+}
+
+.ctx {
+  display: flex;
+  align-items: center;
+  gap: calc(5 * var(--u));
+  margin-top: calc(7 * var(--u));
+  color: color-mix(in oklab, var(--content) 40%, transparent);
+  font-size: calc(11 * var(--u));
+}
+
+.ctx .i {
+  width: calc(11 * var(--u));
+  height: calc(11 * var(--u));
+}
+
+.answer p + p,
+.answer ul + p,
+.answer ul {
+  margin-top: calc(9 * var(--u));
+}
+
+.answer ul {
+  display: flex;
+  flex-direction: column;
+  gap: calc(5 * var(--u));
+  padding-left: calc(14 * var(--u));
+  list-style: disc;
+}
+
+.answer b {
+  font-weight: 600;
+}
+
+/* Never a link out: driving the stream on screen to the window an answer
+   describes is the whole reason this panel lives in Dozzle. */
+.answer-action {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(5 * var(--u));
+  margin-top: calc(11 * var(--u));
+  padding: calc(4 * var(--u)) calc(8 * var(--u));
+  border-radius: calc(5 * var(--u));
+  background: color-mix(in oklab, var(--content) 8%, transparent);
+  font-size: calc(11.5 * var(--u));
+  font-weight: 500;
+}
+
+.answer-action .i {
+  width: calc(12 * var(--u));
+  height: calc(12 * var(--u));
+  color: color-mix(in oklab, var(--content) 50%, transparent);
+}
+
+/* Sticky, opaque and full bleed, like every other footer in the app. */
+.composer-wrap {
+  flex: none;
+  padding: calc(11 * var(--u)) calc(14 * var(--u));
+  border-top: 1px solid color-mix(in oklab, var(--content) 10%, transparent);
+}
+
+.composer-wrap .ctx {
+  margin-top: 0;
+  margin-bottom: calc(8 * var(--u));
+}
+
+.composer {
+  display: flex;
+  align-items: center;
+  height: calc(38 * var(--u));
+  padding: 0 calc(5 * var(--u)) 0 calc(12 * var(--u));
+  border: 1px solid color-mix(in oklab, var(--content) 20%, transparent);
+  border-radius: calc(7 * var(--u));
+}
+
+.composer-hint {
+  color: color-mix(in oklab, var(--content) 40%, transparent);
+  font-size: calc(12.5 * var(--u));
+}
+
+.send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(28 * var(--u));
+  height: calc(28 * var(--u));
+  margin-left: auto;
+  border-radius: 999px;
+  background: var(--primary);
+  color: oklch(20% 0 0);
+}
+
+.send .i {
+  width: calc(13 * var(--u));
+  height: calc(13 * var(--u));
+}
+
+/* Cloud rail
+   -------------------------------------------------------------------------- */
+
+.rail {
+  display: flex;
+  flex: 0 0 calc(48 * var(--u));
+  flex-direction: column;
+  align-items: center;
+  gap: calc(4 * var(--u));
+  padding: calc(12 * var(--u)) 0;
+  border-left: 1px solid color-mix(in oklab, var(--content) 10%, transparent);
+  background: color-mix(in oklab, var(--base-200) 40%, transparent);
+}
+
+/* Says once where the answers come from, so no panel has to carry a slogan. */
+.cloud-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(28 * var(--u));
+  height: calc(28 * var(--u));
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--blue) 12%, transparent);
+  color: var(--blue);
+}
+
+.cloud-mark .i {
+  width: calc(17 * var(--u));
+  height: calc(17 * var(--u));
+}
+
+.rail-rule {
+  width: calc(24 * var(--u));
+  height: 1px;
+  margin: calc(6 * var(--u)) 0;
+  background: color-mix(in oklab, var(--content) 12%, transparent);
+}
+
+.rail-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(28 * var(--u));
+  height: calc(28 * var(--u));
+  border-radius: calc(5 * var(--u));
+  color: color-mix(in oklab, var(--content) 60%, transparent);
+}
+
+.rail-btn.on {
+  background: var(--base-300);
+  color: var(--content);
+}
+
+.rail-btn .i {
+  width: calc(17 * var(--u));
+  height: calc(17 * var(--u));
+}
+
+.rail-dot {
+  position: absolute;
+  top: calc(4 * var(--u));
+  right: calc(4 * var(--u));
+  width: calc(5 * var(--u));
+  height: calc(5 * var(--u));
+  border-radius: 999px;
+  background: var(--orange);
+}
+
+.rail-hide {
+  margin-top: auto;
+  color: color-mix(in oklab, var(--content) 40%, transparent);
+}
+
+/* Narrow hero: drop the sidebar, the stat cards and the rail, and scale the
+   type against a smaller design width so the entries stay legible instead of
+   collapsing into texture. */
 @container (max-width: 620px) {
   .hero-demo {
     --u: calc(100cqw / 520);
   }
 
   .sidebar,
-  .cards {
+  .stats,
+  .panel,
+  .rail {
     display: none;
   }
 
@@ -900,7 +1467,8 @@ const alt = "The Dozzle interface streaming container logs in real time";
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chart i {
+  .chart i,
+  .panel {
     transition: none;
   }
 }


### PR DESCRIPTION
The homepage mock had drifted from the app. It was still drawing solid gradient nav rows, boxed blue timestamps, three tinted stat cards and a star for pinning. This redraws it against what master renders.

- sidebar: Hosts/Services tabs, the host row, groups with a count, bundled app icons carrying status as a corner badge, and the primary-tinted active row
- title bar: name leads, map pin, health check, image as dimmed text
- stats: one hairline-divided surface (CPU, MEM) instead of three tinted cards
- stream: unboxed timestamps, dot level markers, warn/error row tints over the zebra, and the bell on lines an alert rule matched
- the cloud rail, with its chat panel sliding in two seconds after load so the stream is what you land on first

App icons are imported from `assets/icons/apps/`, the same artwork the app ships, so that part can't drift again.

Two bugs came out of it, both styles leaking in from VitePress. A global `.main` was padding the stream 41px short of the rail, and the body's 24px line-height made the Hosts/Services strip half again as tall as the app's.

Checked in light and dark, at 1440px and at 420px where the sidebar, stats and panel drop out. `vitepress build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ak9Hxdc8qLoVFJDJzmkS8q