### PR TITLE
fix(cloud): make the chat sheet a phone surface, not a narrow desktop rail

### DIFF
--- a/assets/components/cloud/chat/ChatPane.vue
+++ b/assets/components/cloud/chat/ChatPane.vue
@@ -10,32 +10,45 @@
           v-for="suggestion in suggestions"
           :key="suggestion"
           type="button"
-          class="hover:bg-base-300 flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
+          class="hover:bg-info/10 hover:text-info flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors"
           @click="ask(suggestion, view)"
         >
-          <mdi:arrow-top-right class="size-4 shrink-0 opacity-40" />
+          <mdi:arrow-top-right class="text-info/60 size-4 shrink-0" />
           <span class="min-w-0 flex-1">{{ suggestion }}</span>
         </button>
       </div>
 
       <div v-else class="mt-auto space-y-4">
         <div v-for="(message, i) in messages" :key="i">
-          <!-- The question is a neutral panel; the answer is the pane itself.
-               Two facing bubbles in a 550px column spend half the width on
-               borders that say nothing the alignment does not. -->
+          <!-- The question is a panel and the answer is the pane itself. Two
+               facing bubbles in a 550px column spend half the width on borders
+               that say nothing the alignment does not. What the two turns do get
+               is a colour each, because in a wall of grey text the only thing a
+               reader ever has to find again is where their own question ended:
+               a primary wash on the question, a cloud glyph on the answer. -->
           <template v-if="message.role === 'user'">
-            <div class="border-base-content/15 bg-base-200/40 rounded-lg border p-3">
+            <div class="border-primary/25 bg-primary/5 rounded-lg border p-3">
               <ChatFocusedLine v-if="message.view?.focused" :line="message.view.focused" class="mb-2" />
               <p class="text-sm whitespace-pre-wrap">{{ message.text }}</p>
               <ChatViewContext v-if="message.view" :view="message.view" compact class="mt-2" />
             </div>
           </template>
           <template v-else>
-            <InlineNotice v-if="message.error" type="error">{{ message.text }}</InlineNotice>
-            <ChatMarkdown v-else-if="message.text" :text="message.text" class="text-sm leading-relaxed" />
-            <div v-else class="text-base-content/60 flex items-center gap-2 text-sm">
-              <span class="loading loading-dots loading-xs"></span>
-              {{ working }}
+            <div class="flex gap-2">
+              <span
+                class="bg-info/10 text-info mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-full"
+                aria-hidden="true"
+              >
+                <mdi:cloud class="size-3.5" />
+              </span>
+              <div class="min-w-0 flex-1">
+                <InlineNotice v-if="message.error" type="error">{{ message.text }}</InlineNotice>
+                <ChatMarkdown v-else-if="message.text" :text="message.text" class="text-sm leading-relaxed" />
+                <div v-else class="text-base-content/60 flex items-center gap-2 text-sm">
+                  <span class="loading loading-dots loading-xs"></span>
+                  {{ working }}
+                </div>
+              </div>
             </div>
           </template>
         </div>

--- a/assets/components/cloud/chat/ChatViewContext.spec.ts
+++ b/assets/components/cloud/chat/ChatViewContext.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { mount } from "@vue/test-utils";
+import { describe, expect, test } from "vitest";
+import { createI18n } from "vue-i18n";
+import type { ViewContext } from "@/composable/logs/viewContext";
+import ChatViewContext from "./ChatViewContext.vue";
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  fallbackLocale: "en",
+  missingWarn: false,
+  fallbackWarn: false,
+  messages: {
+    en: {
+      "cloud-chat": {
+        evidence: "Sent with your question",
+        "lines-in-view": "{n} lines in view",
+        "n-containers": "{n} containers",
+        historical: "historical",
+      },
+    },
+  },
+});
+
+const view: ViewContext = {
+  kind: "container",
+  target: "abc",
+  containers: [{ id: "abc", name: "doligence_postgres.1", host: "localhost" }],
+  hosts: ["localhost"],
+  visibleAt: "2024-01-01T00:00:00Z",
+  historical: false,
+  lines: [{ timestamp: "2024-01-01T00:00:00Z", message: "hello" }],
+};
+
+function mountWith(slot?: string) {
+  return mount(ChatViewContext, {
+    props: { view },
+    slots: slot === undefined ? {} : { default: slot },
+    global: { plugins: [i18n] },
+  });
+}
+
+describe("ChatViewContext", () => {
+  test("names the containers and the window in view", () => {
+    expect(mountWith().text()).toContain("doligence_postgres.1");
+    expect(mountWith().text()).toContain("1 lines in view");
+  });
+
+  test("draws no divider when no slot is passed", () => {
+    expect(mountWith().find(".h-px").exists()).toBe(false);
+  });
+
+  // The composer always writes slot content, and it is a `v-if` on the focused
+  // line. That renders a comment node when nothing is focused, which used to
+  // still draw a hairline with nothing under it.
+  test("draws no divider when the slot renders nothing", () => {
+    expect(mountWith("<!-- v-if -->").find(".h-px").exists()).toBe(false);
+  });
+
+  test("draws a divider when the slot has content", () => {
+    expect(mountWith("<div>this log line</div>").find(".h-px").exists()).toBe(true);
+  });
+});

--- a/assets/components/cloud/chat/ChatViewContext.vue
+++ b/assets/components/cloud/chat/ChatViewContext.vue
@@ -29,7 +29,7 @@
 
     <!-- A line the reader pointed at is evidence as much as the window is, so
          it belongs in this card rather than in a second one under it. -->
-    <template v-if="$slots.default">
+    <template v-if="hasSlotContent()">
       <div class="bg-base-content/10 my-2 h-px"></div>
       <slot />
     </template>
@@ -37,10 +37,28 @@
 </template>
 
 <script lang="ts" setup>
+import { Comment, Fragment, Text, type VNode } from "vue";
 import type { ViewContext } from "@/composable/logs/viewContext";
 
 const { view, compact = false } = defineProps<{ view: ViewContext; compact?: boolean }>();
 const { t } = useI18n();
+const slots = useSlots();
+
+// `$slots.default` is truthy the moment a caller writes slot content at all,
+// even when that content is a single `v-if` that rendered nothing. The composer
+// always passes the focused line, so testing it drew a divider with nothing
+// under it whenever no line was focused. Called from the template so it is
+// re-evaluated, and re-tracked, on every render.
+function hasSlotContent() {
+  return (slots.default?.() ?? []).some(isRendered);
+}
+
+function isRendered(node: VNode): boolean {
+  if (node.type === Comment) return false;
+  if (node.type === Fragment) return (node.children as VNode[] | null)?.some(isRendered) ?? false;
+  if (node.type === Text) return !!String(node.children ?? "").trim();
+  return true;
+}
 
 const parts = computed(() => {
   const out: { key: string; label: string; name?: boolean }[] = [];

--- a/assets/components/cloud/rail/CloudRail.vue
+++ b/assets/components/cloud/rail/CloudRail.vue
@@ -12,24 +12,38 @@
     is a statement of where the answers come from and never an advert.
 
     A phone has no room for a permanent strip, and a 550px column beside a 390px
-    screen is not a column. There the strip is gone and the panel is the screen,
-    opened from the toolbar or the palette and closed with the same X.
+    screen is not a column. There the strip is gone entirely and the panel is the
+    screen, opened from the toolbar or the palette and closed with the same X. A
+    vertical strip of icons down the edge of a 390px screen is a desktop affordance
+    wearing a phone's clothes, so on a sheet the three panels are tabs across the
+    top instead, where a thumb can reach them.
   -->
-  <div class="fixed z-30 flex" :class="sheet ? 'pt-safe bg-base-100 inset-0 z-40' : 'inset-y-0 right-0'">
+  <div class="fixed z-30 flex" :class="sheet ? 'pt-safe pb-safe bg-base-100 inset-0 z-40' : 'inset-y-0 right-0'">
     <section
       v-if="panel"
-      class="border-base-content/10 bg-base-100 flex min-w-0 flex-1 flex-col border-l"
+      class="border-base-content/10 bg-base-100 flex min-w-0 flex-1 flex-col"
+      :class="{ 'border-l': !sheet }"
       :style="sheet ? undefined : { width: `${panelWidth}px`, flex: 'none' }"
     >
       <header class="border-base-content/10 flex shrink-0 items-center gap-2 border-b px-4 py-3">
-        <component :is="active.icon" class="text-base-content/60 size-4 shrink-0" />
-        <span class="text-sm font-semibold">{{ active.label }}</span>
-        <!-- Who answered. Muted, because the reader needs it once to trust the
-             panel and never again while reading it. -->
-        <span class="text-base-content/40 ml-1 flex items-center gap-1 text-xs">
-          <mdi:cloud class="text-info/70 size-3.5" />
-          {{ $t("cloud.title") }}
-        </span>
+        <!-- On a sheet the tabs under this name the panel, so the header says the
+             one thing they cannot: where the answers come from. -->
+        <template v-if="sheet">
+          <span class="bg-info/10 text-info flex size-6 shrink-0 items-center justify-center rounded-full">
+            <mdi:cloud class="size-3.5" />
+          </span>
+          <span class="text-sm font-semibold">{{ $t("cloud.title") }}</span>
+        </template>
+        <template v-else>
+          <component :is="active.icon" class="text-base-content/60 size-4 shrink-0" />
+          <span class="text-sm font-semibold">{{ active.label }}</span>
+          <!-- Who answered. Muted, because the reader needs it once to trust the
+               panel and never again while reading it. -->
+          <span class="text-base-content/40 ml-1 flex items-center gap-1 text-xs">
+            <mdi:cloud class="text-info/70 size-3.5" />
+            {{ $t("cloud.title") }}
+          </span>
+        </template>
         <div class="ml-auto flex shrink-0 items-center gap-1">
           <!-- A thread that has run its course is in the way of the next one,
                and the only way out of it used to be a reload. -->
@@ -54,6 +68,28 @@
         </div>
       </header>
 
+      <!-- The strip's job, laid out for a thumb: same three panels, same dot, and
+           the only way to move between them once the strip is gone. -->
+      <nav
+        v-if="sheet"
+        class="border-base-content/10 flex shrink-0 gap-1 border-b px-2 py-2"
+        :aria-label="$t('cloud-rail.title')"
+      >
+        <button
+          v-for="item in items"
+          :key="item.id"
+          type="button"
+          class="flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-2 text-sm transition-colors"
+          :class="panel === item.id ? 'bg-info/10 text-info font-semibold' : 'text-base-content/60'"
+          :aria-pressed="panel === item.id"
+          @click="toggleRail(item.id)"
+        >
+          <component :is="item.icon" class="size-4 shrink-0" />
+          <span class="truncate">{{ item.label }}</span>
+          <span v-if="item.dot" class="bg-warning size-1.5 shrink-0 rounded-full"></span>
+        </button>
+      </nav>
+
       <div class="min-h-0 flex-1 overflow-hidden">
         <ChatPane v-if="panel === 'chat'" />
         <RailMetrics v-else-if="panel === 'metrics'" />
@@ -61,9 +97,8 @@
       </div>
     </section>
 
-    <!-- Kept on the sheet too: on a phone it is the only way to move between the
-         three panels, and the only way to put it away. -->
     <nav
+      v-if="!sheet"
       class="border-base-content/10 bg-base-200/40 flex shrink-0 flex-col items-center gap-1 border-l py-3"
       :style="{ width: `${RAIL_WIDTH}px` }"
       :aria-label="$t('cloud-rail.title')"
@@ -97,14 +132,13 @@
       </button>
 
       <!-- Bottom of the strip, mirroring the nav's collapse on the other edge.
-           Hiding is remembered, and the tab on the edge brings it back. A sheet
-           has no collapsed resting state to hide to, so there it just closes. -->
+           Hiding is remembered, and the tab on the edge brings it back. -->
       <button
         type="button"
         class="icon-btn btn btn-ghost btn-square btn-sm text-base-content/40 mt-auto"
-        :title="sheet ? $t('cloud-rail.close') : $t('cloud-rail.hide')"
-        :aria-label="sheet ? $t('cloud-rail.close') : $t('cloud-rail.hide')"
-        @click="sheet ? closeRail() : hideRail()"
+        :title="$t('cloud-rail.hide')"
+        :aria-label="$t('cloud-rail.hide')"
+        @click="hideRail()"
       >
         <mdi:chevron-right class="size-5" />
       </button>

--- a/assets/components/ui/BarChart.spec.ts
+++ b/assets/components/ui/BarChart.spec.ts
@@ -73,3 +73,50 @@ describe("<BarChart />", () => {
     expect(heightOf(wrapper, 0)).toBeGreaterThan(50);
   });
 });
+
+describe("BarChart pointer readout", () => {
+  // jsdom lays nothing out, so every bar reports a zero rect. Stub each one to a
+  // real column so the hit test has something to walk.
+  function layOutBars(wrapper: ReturnType<typeof mount>, width = 10) {
+    wrapper.findAll(".bar").forEach((bar, i) => {
+      vi.spyOn(bar.element, "getBoundingClientRect").mockReturnValue({
+        left: i * width,
+        right: (i + 1) * width,
+        width,
+      } as DOMRect);
+    });
+  }
+
+  test("a mouse move reports the bar under the pointer", async () => {
+    const wrapper = await mountAndRender(ramp());
+    layOutBars(wrapper);
+    await wrapper.trigger("mousemove", { clientX: 25 });
+
+    const emitted = wrapper.emitted("hoverValue");
+    expect(emitted).toHaveLength(1);
+    expect(emitted![0][1]).toBe(2);
+  });
+
+  // A touch screen never fires mousemove, so the history panel's readout was
+  // stuck on the peak and no bar could be read on a phone.
+  test("a touch reports the bar under the finger", async () => {
+    const wrapper = await mountAndRender(ramp());
+    layOutBars(wrapper);
+    await wrapper.trigger("touchstart", { touches: [{ clientX: 25 }] });
+    await wrapper.trigger("touchmove", { touches: [{ clientX: 55 }] });
+
+    const emitted = wrapper.emitted("hoverValue");
+    expect(emitted).toHaveLength(2);
+    expect(emitted![0][1]).toBe(2);
+    expect(emitted![1][1]).toBe(5);
+  });
+
+  test("a touch with no contact point reports nothing", async () => {
+    const wrapper = await mountAndRender(ramp());
+    layOutBars(wrapper);
+    await wrapper.trigger("touchend", { touches: [] });
+    await wrapper.trigger("touchstart", { touches: [] });
+
+    expect(wrapper.emitted("hoverValue")).toBeUndefined();
+  });
+});

--- a/assets/components/ui/BarChart.vue
+++ b/assets/components/ui/BarChart.vue
@@ -1,5 +1,19 @@
 <template>
-  <div ref="chartContainer" class="flex items-end gap-[2px]" @mousemove="onContainerHover">
+  <div
+    ref="chartContainer"
+    class="flex touch-pan-y items-end gap-[2px]"
+    @mousemove="onContainerHover"
+    @touchstart="onContainerTouch"
+    @touchmove="onContainerTouch"
+  >
+    <!-- Inside the root element rather than above it: a comment above compiles to
+         a second root node in dev builds, and `wrapper.element` is then the
+         comment, so every `trigger()` in the spec fires at nothing. Vue itself
+         copes (attrs still fall through to the single element child).
+
+         `touch-pan-y` keeps a vertical swipe scrolling the panel while a
+         horizontal drag scrubs the bars, so the chart reads out on a phone
+         without trapping the scroll. -->
     <div
       v-for="(bar, i) in downsampledBars"
       :key="i"
@@ -117,18 +131,31 @@ function updateLastBar() {
 }
 
 function onContainerHover(event: MouseEvent) {
+  emitAt(event.clientX);
+}
+
+// A touch screen never fires mousemove, so without this the readout above a
+// history chart was stuck on the peak and every bar was a shape with no value.
+// The last touched bar stays reported after the finger lifts: there is no
+// `mouseleave` to fall back from, and a value that vanishes on lift is one
+// nobody can read.
+function onContainerTouch(event: TouchEvent) {
+  const touch = event.touches[0];
+  if (touch) emitAt(touch.clientX);
+}
+
+function emitAt(clientX: number) {
   if (!chartContainer.value) return;
 
   const bars = chartContainer.value.children;
   if (bars.length === 0) return;
 
-  const mouseX = event.clientX;
   let index = 0;
 
-  // Find the bar whose column contains the mouse x position
+  // Find the bar whose column contains the pointer's x position
   for (let i = 0; i < bars.length; i++) {
     const rect = bars[i].getBoundingClientRect();
-    if (mouseX >= rect.left) {
+    if (clientX >= rect.left) {
       index = i;
     } else {
       break;

--- a/assets/layouts/splash.vue
+++ b/assets/layouts/splash.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="hero max-h-500:pt-4 min-h-dvh content-start pt-[20dvh]">
-    <div class="hero-content">
+    <!-- Full width so the card inside can cap itself against the viewport. Left to
+         shrink-to-fit, a fixed-width card sets the hero's width and pushes the page
+         sideways on a phone instead of being narrowed by it. -->
+    <div class="hero-content w-full">
       <router-view></router-view>
     </div>
   </div>

--- a/assets/main.css
+++ b/assets/main.css
@@ -290,8 +290,12 @@ body {
 }
 
 /* CodeMirror autocomplete tooltip styles */
+/* `min-w-96` is 384px, which is wider than the phones the rule editor is opened
+ * on, so the floor gives way to the viewport before it pushes the page sideways. */
 .cm-tooltip {
-  @apply bg-base-200! border-base-content/40! min-w-96 rounded-sm border shadow-md;
+  @apply bg-base-200! border-base-content/40! rounded-sm border shadow-md;
+  min-width: min(24rem, calc(100vw - 2rem));
+  max-width: calc(100vw - 2rem);
 }
 
 .cm-tooltip-autocomplete ul {

--- a/assets/main.css
+++ b/assets/main.css
@@ -26,6 +26,10 @@
   padding-top: env(safe-area-inset-top);
 }
 
+@utility pb-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
 @custom-variant max-h-500 {
   @media (max-height: 500px) {
     @slot;

--- a/assets/pages/login.vue
+++ b/assets/pages/login.vue
@@ -1,5 +1,9 @@
 <template>
-  <div class="card bg-base-100 w-96 shrink-0 shadow-2xl">
+  <!-- Capped rather than fixed: `w-96` plus the hero's own padding is 416px, so a
+       384px card horizontally scrolled the login page on every phone. `max-w-full`
+       does not save it, because the hero shrinks to fit its content and resolves a
+       percentage max-width against a width it is still computing. -->
+  <div class="card bg-base-100 w-full max-w-96 shadow-2xl">
     <div class="card-body gap-6">
       <div class="flex flex-col items-center gap-3 text-center">
         <Logo class="h-12 w-12" />


### PR DESCRIPTION
On a phone the cloud rail kept its 48px vertical icon strip pinned to the
right edge of the sheet, which is a desktop affordance at a width that has
no room for it. The strip is gone on a sheet now and the three panels are
tabs across the top, where a thumb can reach them. The sheet also pads for
the home indicator, so the composer is no longer under it.

The evidence card above the composer always drew a hairline divider with
nothing under it: the composer always writes slot content, and it is a
`v-if` on the focused line, so `$slots.default` was truthy even when the
slot rendered a comment node. It now tests what the slot actually renders.

The two chat turns each get a colour, because in a wall of grey the one
thing a reader has to find again is where their own question ended: a
primary wash on the question, a cloud glyph on the answer.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WC7YimMstjkUhQvH6FUomR