### PR TITLE
fix(cloud): stop long alert headlines spilling out of the popover

### DIFF
--- a/assets/components/cloud/history/AlertDot.vue
+++ b/assets/components/cloud/history/AlertDot.vue
@@ -29,21 +29,31 @@
 
     <template #default="{ close }">
       <!-- The same parts as an AlertRow, at popover width: tinted glyph, a
-           headline that carries its own severity chip, then the meta line. -->
+           headline that carries its own severity chip, then the meta line.
+
+           The headline is whatever Cloud wrote, and for a log-anchored alert
+           that is often the raw line: a stack-trace class name is one 50-char
+           word with nowhere to break. `break-words` is not enough, because a
+           flex item is still sized to its min-content and min-content is that
+           word — the text spilled out past the rounded corner. `wrap-anywhere`
+           folds the break opportunity into min-content, so the item shrinks to
+           the panel and the word breaks. -->
       <div class="flex items-start gap-3 p-3">
         <div class="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full" :class="tint">
           <mdi:alert-circle-outline class="size-4" />
         </div>
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-            <span class="text-sm font-semibold">{{ alert.headline }}</span>
+            <span class="text-sm font-semibold wrap-anywhere">{{ alert.headline }}</span>
             <span class="status-pill" :class="pill">{{ alert.level || "info" }}</span>
           </div>
           <div class="text-base-content/60 mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
             <RelativeTime :date="firedAt" />
             <span class="font-mono">{{ $t("notifications.history.events", { n: alert.eventCount }) }}</span>
           </div>
-          <p v-if="alert.summary" class="text-base-content/60 mt-1.5 line-clamp-4 text-sm">{{ alert.summary }}</p>
+          <p v-if="alert.summary" class="text-base-content/60 mt-1.5 line-clamp-4 text-sm wrap-anywhere">
+            {{ alert.summary }}
+          </p>
         </div>
       </div>
 

--- a/assets/components/cloud/history/AlertRow.vue
+++ b/assets/components/cloud/history/AlertRow.vue
@@ -8,7 +8,7 @@
 
     <div class="min-w-0 flex-1">
       <div class="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-        <span class="text-sm font-semibold">{{ alert.headline }}</span>
+        <span class="text-sm font-semibold wrap-anywhere">{{ alert.headline }}</span>
         <span class="status-pill" :class="pill">{{ alert.level || "info" }}</span>
         <span v-if="alert.isOrigin === false" class="text-base-content/40 text-xs">
           {{ $t("notifications.history.still-happening") }}
@@ -28,7 +28,7 @@
         </span>
       </div>
 
-      <p v-if="alert.summary" class="text-base-content/60 mt-1.5 text-sm">{{ alert.summary }}</p>
+      <p v-if="alert.summary" class="text-base-content/60 mt-1.5 text-sm wrap-anywhere">{{ alert.summary }}</p>
 
       <!-- Narrow enough that the actions cannot sit beside the text, so they sit
            under it rather than squeezing the summary into a column. -->

--- a/assets/components/logs/entries/AlertLogItem.vue
+++ b/assets/components/logs/entries/AlertLogItem.vue
@@ -7,7 +7,7 @@
             <mdi:bell-alert class="size-3" />
             {{ $t("label.alert") }}
           </span>
-          <span class="font-semibold">{{ alert.headline }}</span>
+          <span class="font-semibold wrap-anywhere">{{ alert.headline }}</span>
           <!-- Only the count rides the summary line. Everything else —
                  containers, what triage held back, the investigation — sits
                  behind Details. -->


### PR DESCRIPTION
The alert dot popover renders the headline verbatim from Cloud, and for a log-anchored alert that is often the raw line. A stack-trace class name like `Microsoft.EntityFrameworkCore.DatabaseConnection:` is one 50-char word with no break opportunity in it, and it rendered straight through the right edge of the panel.

The headline span is a flex item, so it gets `min-width: auto` and is sized to its min-content. min-content is that word, wider than the 256px of content a `w-80` panel has, so the parent `min-w-0 flex-1` never gets a chance to help.

`break-words` would not have fixed this either. `overflow-wrap: break-word` does not feed into min-content sizing, so the item still refuses to shrink. `wrap-anywhere` does.

`AlertRow` and `AlertLogItem` render the same string through the same flex-wrap row, so they had the same latent bug at wider widths. Fixed there too.

Not fixed here: the headline in the screenshot is two concatenated log lines cut mid-word. That string arrives verbatim in `AlertHit.Headline` and Dozzle never trims it, so that one is Cloud side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5TWyFt13EH6PSsWzKNCeq