### PR TITLE
fix(web): remove data race on the releases cache

### DIFF
--- a/internal/web/notifications.go
+++ b/internal/web/notifications.go
@@ -908,16 +908,18 @@ func (h *handler) testWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 // Releases handler
-var releasesCache *cache.Cache[[]releases.Release]
-
-func (h *handler) getReleases(w http.ResponseWriter, r *http.Request) {
-	if releasesCache == nil {
-		releasesCache = cache.New(func() ([]releases.Release, error) {
+func (h *handler) releases() *cache.Cache[[]releases.Release] {
+	h.releasesOnce.Do(func() {
+		h.releasesCache = cache.New(func() ([]releases.Release, error) {
 			return releases.Fetch(h.config.Version)
 		}, time.Hour)
-	}
+	})
 
-	result, err := releasesCache.Get()
+	return h.releasesCache
+}
+
+func (h *handler) getReleases(w http.ResponseWriter, r *http.Request) {
+	result, err := h.releases().Get()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -3,18 +3,21 @@ package web
 import (
 	"context"
 	"io/fs"
+	"sync"
 	"time"
 
 	"net/http"
 	"strings"
 
 	"github.com/amir20/dozzle/internal/auth"
+	"github.com/amir20/dozzle/internal/cache"
 	"github.com/amir20/dozzle/internal/cloud"
 	"github.com/amir20/dozzle/internal/container"
 	"github.com/amir20/dozzle/internal/imagecheck"
 	dozzle_mcp "github.com/amir20/dozzle/internal/mcp"
 	"github.com/amir20/dozzle/internal/notification"
 	"github.com/amir20/dozzle/internal/notification/dispatcher"
+	"github.com/amir20/dozzle/internal/releases"
 	container_support "github.com/amir20/dozzle/internal/support/container"
 	"github.com/amir20/dozzle/types"
 
@@ -154,6 +157,9 @@ type handler struct {
 	content     fs.FS
 	config      *Config
 	hostService HostService
+
+	releasesOnce  sync.Once
+	releasesCache *cache.Cache[[]releases.Release]
 }
 
 func CreateServer(hostService HostService, content fs.FS, config Config) *http.Server {


### PR DESCRIPTION
The race detector flagged `/api/releases` under concurrent requests. The cache was a package-level `var releasesCache *cache.Cache[...]` initialized lazily inside the handler, so two goroutines could both see it as nil and both run `cache.New`. One goroutine's write to the var raced the other's `Get`.

Moved the cache onto the handler struct behind a `sync.Once`. Zero value works, so the `&handler{}` literals in tests are unaffected.

`go test -race ./internal/web/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9vgTsPBHZEgb6R8snYiiz