### PR TITLE
fix(events): stop a dead SSE client from wedging container events

### DIFF
--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -170,9 +170,11 @@ func (s *server) StreamRawBytes(in *pb.StreamRawBytesRequest, out pb.AgentServic
 }
 
 func (s *server) StreamEvents(in *pb.StreamEventsRequest, out pb.AgentService_StreamEventsServer) error {
-	events := make(chan container.ContainerEvent)
+	// buffered: Send blocks on gRPC flow control, and an unbuffered channel makes the
+	// store drop an event for any blip at all rather than only for a real stall
+	events := make(chan container.ContainerEvent, 64)
 
-	s.service.SubscribeEvents(out.Context(), events)
+	s.service.SubscribeEvents(container.WithSubscriberName(out.Context(), "agent-stream"), events)
 
 	for {
 		select {

--- a/internal/container/container_store.go
+++ b/internal/container/container_store.go
@@ -21,7 +21,7 @@ type StatsCollector interface {
 
 type ContainerStore struct {
 	containers              *xsync.Map[string, *Container]
-	subscribers             *xsync.Map[context.Context, chan<- ContainerEvent]
+	subscribers             *xsync.Map[context.Context, *eventSubscriber]
 	newContainerSubscribers *xsync.Map[context.Context, chan<- Container]
 	client                  Client
 	statsCollector          StatsCollector
@@ -41,7 +41,7 @@ func NewContainerStore(ctx context.Context, client Client, statsCollect StatsCol
 	s := &ContainerStore{
 		containers:              xsync.NewMap[string, *Container](),
 		client:                  client,
-		subscribers:             xsync.NewMap[context.Context, chan<- ContainerEvent](),
+		subscribers:             xsync.NewMap[context.Context, *eventSubscriber](),
 		newContainerSubscribers: xsync.NewMap[context.Context, chan<- Container](),
 		statsCollector:          statsCollect,
 		wg:                      sync.WaitGroup{},
@@ -87,6 +87,75 @@ var (
 	ErrContainerNotFound = errors.New("container not found")
 	maxFetchParallelism  = int64(30)
 )
+
+type subscriberNameKey struct{}
+
+// WithSubscriberName labels a subscription so a dropped-event warning can say which
+// consumer stalled. Subscribers are keyed by their context, so the name rides along on
+// that context instead of being threaded through every ClientService implementation.
+func WithSubscriberName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, subscriberNameKey{}, name)
+}
+
+func subscriberNameFrom(ctx context.Context) string {
+	if name, ok := ctx.Value(subscriberNameKey{}).(string); ok && name != "" {
+		return name
+	}
+	return "unnamed"
+}
+
+// dropLogInterval bounds how often one stalled subscriber may warn. A container with a
+// 5s healthcheck emits three exec events per cycle, so an unthrottled warning buries
+// every other line in the log while repeating the same fact.
+const dropLogInterval = 10 * time.Second
+
+// eventSubscriber is one registered consumer plus the bookkeeping needed to report a
+// stall as a single span rather than one line per lost event.
+type eventSubscriber struct {
+	ch   chan<- ContainerEvent
+	name string
+
+	mu      sync.Mutex
+	dropped int       // events lost since the last warning
+	total   int       // events lost since the stall began
+	since   time.Time // when the current stall began
+	lastLog time.Time
+}
+
+// recordDrop counts a lost event and reports whether this one should be logged.
+func (s *eventSubscriber) recordDrop(now time.Time) (dropped int, stalledFor time.Duration, shouldLog bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.since.IsZero() {
+		s.since = now
+	}
+	s.dropped++
+	s.total++
+
+	if !s.lastLog.IsZero() && now.Sub(s.lastLog) < dropLogInterval {
+		return 0, 0, false
+	}
+
+	s.lastLog = now
+	dropped, s.dropped = s.dropped, 0
+	return dropped, now.Sub(s.since), true
+}
+
+// recordDelivered closes out a stall. It reports the total lost only once, on the first
+// event that lands after the subscriber starts reading again.
+func (s *eventSubscriber) recordDelivered(now time.Time) (dropped int, stalledFor time.Duration, recovered bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.since.IsZero() {
+		return 0, 0, false
+	}
+
+	dropped, stalledFor = s.total, now.Sub(s.since)
+	s.dropped, s.total, s.since, s.lastLog = 0, 0, time.Time{}, time.Time{}
+	return dropped, stalledFor, true
+}
 
 // broadcastTimeout bounds how long a fan-out waits on a subscriber that is not
 // draining its channel.
@@ -163,16 +232,36 @@ func (s *ContainerStore) broadcast(event ContainerEvent) {
 	budget := &fanoutBudget{}
 	defer budget.stop()
 
-	s.subscribers.Range(func(ctx context.Context, events chan<- ContainerEvent) bool {
-		switch sendBounded(ctx, events, event, budget) {
+	s.subscribers.Range(func(ctx context.Context, sub *eventSubscriber) bool {
+		switch sendBounded(ctx, sub.ch, event, budget) {
 		case sendCancelled:
 			s.subscribers.Delete(ctx)
+		case sendOK:
+			if dropped, stalled, recovered := sub.recordDelivered(time.Now()); recovered {
+				// info, not warn: this is the line that closes out the warning above, and
+				// the default level shows it
+				log.Info().
+					Str("host", s.client.Host().Name).
+					Str("subscriber", sub.name).
+					Int("dropped", dropped).
+					Dur("stalledFor", stalled).
+					Msg("subscriber is reading container events again")
+			}
 		case sendDropped:
-			log.Warn().
+			log.Trace().
 				Str("host", s.client.Host().Name).
+				Str("subscriber", sub.name).
 				Str("event", event.Name).
 				Str("id", event.ActorID).
-				Msg("subscriber is not reading container events, dropping event")
+				Msg("dropped container event")
+			if dropped, stalled, shouldLog := sub.recordDrop(time.Now()); shouldLog {
+				log.Warn().
+					Str("host", s.client.Host().Name).
+					Str("subscriber", sub.name).
+					Int("dropped", dropped).
+					Dur("stalledFor", stalled).
+					Msg("subscriber is not reading container events, dropping events")
+			}
 		}
 		return true
 	})
@@ -341,7 +430,7 @@ func (s *ContainerStore) SubscribeEvents(ctx context.Context, events chan<- Cont
 		}
 	}()
 
-	s.subscribers.Store(ctx, events)
+	s.subscribers.Store(ctx, &eventSubscriber{ch: events, name: subscriberNameFrom(ctx)})
 	go func() {
 		<-ctx.Done()
 		s.subscribers.Delete(ctx)

--- a/internal/container/container_store_test.go
+++ b/internal/container/container_store_test.go
@@ -312,14 +312,14 @@ func TestContainerStore_broadcastBudgetIsShared(t *testing.T) {
 
 	store := &ContainerStore{
 		client:      client,
-		subscribers: xsync.NewMap[context.Context, chan<- ContainerEvent](),
+		subscribers: xsync.NewMap[context.Context, *eventSubscriber](),
 	}
 
 	const wedged = 5
 	for range wedged {
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
-		store.subscribers.Store(ctx, make(chan ContainerEvent))
+		store.subscribers.Store(ctx, &eventSubscriber{ch: make(chan ContainerEvent), name: "wedged"})
 	}
 
 	start := time.Now()
@@ -328,4 +328,60 @@ func TestContainerStore_broadcastBudgetIsShared(t *testing.T) {
 
 	assert.GreaterOrEqual(t, elapsed, broadcastTimeout, "should have waited on the wedged subscribers")
 	assert.Less(t, elapsed, 2*broadcastTimeout, "should have waited once, not once per subscriber")
+}
+
+// A stalled subscriber must report the stall as one throttled span. A container with a
+// 5s healthcheck emits three exec events per cycle, and a line per lost event buries
+// every other thing in the log.
+func TestEventSubscriber_dropLoggingIsThrottled(t *testing.T) {
+	sub := &eventSubscriber{ch: make(chan ContainerEvent), name: "sse-events"}
+	start := time.Now()
+
+	dropped, stalled, shouldLog := sub.recordDrop(start)
+	assert.True(t, shouldLog, "the first drop should be logged")
+	assert.Equal(t, 1, dropped)
+	assert.Equal(t, time.Duration(0), stalled)
+
+	for i := range 20 {
+		_, _, shouldLog := sub.recordDrop(start.Add(time.Duration(i) * time.Second / 2))
+		assert.False(t, shouldLog, "drops inside the interval should be silent")
+	}
+
+	dropped, stalled, shouldLog = sub.recordDrop(start.Add(dropLogInterval))
+	assert.True(t, shouldLog, "a drop past the interval should be logged")
+	assert.Equal(t, 21, dropped, "should report every drop since the last line, not just this one")
+	assert.Equal(t, dropLogInterval, stalled, "should report how long the stall has run")
+}
+
+func TestEventSubscriber_reportsRecoveryOnce(t *testing.T) {
+	sub := &eventSubscriber{ch: make(chan ContainerEvent), name: "sse-events"}
+	start := time.Now()
+
+	sub.recordDrop(start)
+	sub.recordDrop(start.Add(time.Second))
+
+	dropped, stalled, recovered := sub.recordDelivered(start.Add(2 * time.Second))
+	assert.True(t, recovered)
+	assert.Equal(t, 2, dropped, "recovery reports the whole stall, not just the unlogged tail")
+	assert.Equal(t, 2*time.Second, stalled)
+
+	_, _, recovered = sub.recordDelivered(start.Add(3 * time.Second))
+	assert.False(t, recovered, "a subscriber that never stalled should stay quiet")
+}
+
+// The warning has to name the consumer that stalled. Without it there is no way to tell
+// an SSE client that wedged from the notification listener or an agent stream.
+func TestContainerStore_subscriberIsNamed(t *testing.T) {
+	ctx := WithSubscriberName(t.Context(), "sse-events")
+	assert.Equal(t, "sse-events", subscriberNameFrom(ctx))
+	assert.Equal(t, "unnamed", subscriberNameFrom(t.Context()), "an unlabelled subscription should still be loggable")
+
+	store := &ContainerStore{
+		subscribers: xsync.NewMap[context.Context, *eventSubscriber](),
+	}
+	store.subscribers.Store(ctx, &eventSubscriber{ch: make(chan ContainerEvent, 1), name: subscriberNameFrom(ctx)})
+
+	sub, ok := store.subscribers.Load(ctx)
+	assert.True(t, ok, "subscriber should be registered under the context it was passed")
+	assert.Equal(t, "sse-events", sub.name)
 }

--- a/internal/notification/event_listener.go
+++ b/internal/notification/event_listener.go
@@ -56,8 +56,9 @@ func (l *ContainerEventListener) Start() {
 	l.cancelFunc = cancel
 
 	rawEvents := make(chan container.ContainerEvent, 1000)
+	named := container.WithSubscriberName(ctx, "notifications")
 	for _, client := range l.clients {
-		client.SubscribeEvents(ctx, rawEvents)
+		client.SubscribeEvents(named, rawEvents)
 	}
 
 	go l.enrich(ctx, rawEvents)

--- a/internal/support/web/sse.go
+++ b/internal/support/web/sse.go
@@ -11,11 +11,23 @@ import (
 	"time"
 
 	"net/http"
+
+	"github.com/rs/zerolog/log"
 )
+
+// writeTimeout bounds a single write to an SSE client. A client that goes away without
+// closing the socket (a sleeping laptop, a NAT that forgot the flow) stays writable until
+// its send buffer fills, and the write then blocks until the kernel gives up retransmitting,
+// which takes minutes. For that whole window the handler stops reading its event channel
+// and the container store drops every event aimed at it. A deadline turns the wedge into an
+// error the handler returns on, which cancels the request context and unsubscribes it.
+const writeTimeout = 10 * time.Second
 
 type SSEWriter struct {
 	w io.Writer
 	f http.Flusher
+	// nil when the ResponseWriter cannot set deadlines, in which case writes block as before
+	rc *http.ResponseController
 }
 
 type HasId interface {
@@ -44,10 +56,24 @@ func NewSSEWriter(ctx context.Context, w http.ResponseWriter, r *http.Request) (
 		f: w.(http.Flusher),
 	}
 
+	// probe once rather than per write: a wrapped ResponseWriter that does not implement
+	// SetWriteDeadline reports it the same way every time
+	rc := http.NewResponseController(w)
+	if err := rc.SetWriteDeadline(time.Time{}); err == nil {
+		sse.rc = rc
+	} else {
+		log.Debug().Err(err).Msg("sse stream cannot set write deadlines, a dead client will block writes")
+	}
+
 	return sse, nil
 }
 
 func (s *SSEWriter) Write(data []byte) (int, error) {
+	if s.rc != nil {
+		// covers the payload, the gzip flush and the http flush below
+		s.rc.SetWriteDeadline(time.Now().Add(writeTimeout))
+	}
+
 	written, err := s.w.Write(data)
 	if err != nil {
 		return written, err

--- a/internal/support/web/sse_test.go
+++ b/internal/support/web/sse_test.go
@@ -1,0 +1,68 @@
+package support_web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadlineRecorder is an httptest.ResponseRecorder that can set write deadlines, the way
+// a real *http.response over a net.Conn can.
+type deadlineRecorder struct {
+	*httptest.ResponseRecorder
+	deadlines []time.Time
+	err       error
+}
+
+func (d *deadlineRecorder) SetWriteDeadline(t time.Time) error {
+	if d.err != nil {
+		return d.err
+	}
+	d.deadlines = append(d.deadlines, t)
+	return nil
+}
+
+func newSSE(t *testing.T, w http.ResponseWriter) *SSEWriter {
+	t.Helper()
+	r := httptest.NewRequest("GET", "/api/events/stream", nil)
+	sse, err := NewSSEWriter(t.Context(), w, r)
+	require.NoError(t, err)
+	return sse
+}
+
+// A client that goes away without closing its socket leaves the write blocking until the
+// kernel gives up retransmitting, which is minutes. For that whole window the handler
+// stops reading its event channel and the container store drops every event aimed at it.
+func TestSSEWriter_setsWriteDeadlinePerWrite(t *testing.T) {
+	w := &deadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+	sse := newSSE(t, w)
+
+	// one cleared deadline from the probe in NewSSEWriter
+	require.Len(t, w.deadlines, 1)
+	assert.True(t, w.deadlines[0].IsZero(), "the probe should not leave a deadline armed")
+
+	before := time.Now()
+	require.NoError(t, sse.Event("container-event", map[string]string{"id": "1234"}))
+	require.NoError(t, sse.Ping())
+
+	require.Len(t, w.deadlines, 3, "every write should arm its own deadline")
+	for _, d := range w.deadlines[1:] {
+		assert.WithinRange(t, d, before.Add(writeTimeout), time.Now().Add(writeTimeout))
+	}
+	assert.Contains(t, w.Body.String(), "container-event")
+}
+
+// A ResponseWriter wrapped by middleware may not support deadlines. That is worth a debug
+// line, not a broken stream.
+func TestSSEWriter_writesWithoutDeadlineSupport(t *testing.T) {
+	w := &deadlineRecorder{ResponseRecorder: httptest.NewRecorder(), err: http.ErrNotSupported}
+	sse := newSSE(t, w)
+
+	assert.Nil(t, sse.rc, "deadline support should be probed once, not attempted per write")
+	require.NoError(t, sse.Event("container-event", map[string]string{"id": "1234"}))
+	assert.Contains(t, w.Body.String(), "container-event")
+}

--- a/internal/web/events.go
+++ b/internal/web/events.go
@@ -44,7 +44,7 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 	stats := make(chan container.ContainerStat, statBufferSize)
 	availableHosts := make(chan container.Host)
 
-	h.hostService.SubscribeEventsAndStats(r.Context(), events, stats)
+	h.hostService.SubscribeEventsAndStats(container.WithSubscriberName(r.Context(), "sse-events"), events, stats)
 	h.hostService.SubscribeAvailableHosts(r.Context(), availableHosts)
 
 	userLabels := h.config.Labels
@@ -84,21 +84,33 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 		setVisible(host, containers)
 		return containers, true
 	}
-	// retries a stale host and pushes the recovered list; false means the client is gone
-	repairHost := func(host string) bool {
-		if last, stale := staleHosts[host]; !stale || time.Since(last) < staleHostRetryInterval {
-			return true
+
+	// A repair lists containers on a host that just failed, so it can take the whole
+	// --timeout (10s by default) to come back. Run off the loop below: inline, one stale
+	// host plus a container with a 5s healthcheck kept this handler inside a Docker call
+	// more often than not, and every event it did not read in the meantime was dropped by
+	// the store for good.
+	type hostRefresh struct {
+		host       string
+		containers []container.Container
+		err        error
+	}
+	refreshes := make(chan hostRefresh, 8)
+	repairing := make(map[string]bool)
+	// requestRepair starts a throttled background retry of a host whose list failed
+	requestRepair := func(host string) {
+		last, stale := staleHosts[host]
+		if !stale || repairing[host] || time.Since(last) < staleHostRetryInterval {
+			return
 		}
-		containers, ok := refreshHost(host)
-		if !ok {
-			return true
-		}
-		log.Debug().Str("host", host).Int("count", len(containers)).Msg("recovered stale host")
-		if err := sseWriter.Event("containers-changed", containers); err != nil {
-			log.Error().Err(err).Msg("error writing containers to event stream")
-			return false
-		}
-		return true
+		repairing[host] = true
+		go func() {
+			containers, err := h.hostService.ListContainersForHost(host, userLabels)
+			select {
+			case refreshes <- hostRefresh{host: host, containers: containers, err: err}:
+			case <-r.Context().Done():
+			}
+		}()
 	}
 	isVisible := func(host, id string) bool {
 		if host != "" {
@@ -163,6 +175,24 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 				log.Debug().Err(err).Msg("error writing keep-alive to event stream")
 				return
 			}
+		case refresh := <-refreshes:
+			delete(repairing, refresh.host)
+			if refresh.err != nil {
+				// a start/rename may have repaired this host while the retry was in flight
+				if _, stale := staleHosts[refresh.host]; !stale {
+					continue
+				}
+				log.Warn().Err(refresh.err).Str("host", refresh.host).Msg("failed to refresh containers, will retry")
+				staleHosts[refresh.host] = time.Now()
+				continue
+			}
+			delete(staleHosts, refresh.host)
+			setVisible(refresh.host, refresh.containers)
+			log.Debug().Str("host", refresh.host).Int("count", len(refresh.containers)).Msg("recovered stale host")
+			if err := sseWriter.Event("containers-changed", refresh.containers); err != nil {
+				log.Error().Err(err).Msg("error writing containers to event stream")
+				return
+			}
 		case host := <-availableHosts:
 			// an agent that reconnected has no visible set yet; its first traffic fills it
 			if _, ok := visibleByHost[host.ID]; host.Available && !ok {
@@ -176,15 +206,12 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 			if !isVisible("", stat.ID) {
 				// an unknown ID may belong to a container a stale host never got to report.
 				// a just-started container produces a stat every second, so this also covers
-				// a host that is otherwise quiet
+				// a host that is otherwise quiet. The repair lands on the refreshes channel,
+				// so this stat is skipped and the next one a second later gets through.
 				for host := range staleHosts {
-					if !repairHost(host) {
-						return
-					}
+					requestRepair(host)
 				}
-				if !isVisible("", stat.ID) {
-					continue
-				}
+				continue
 			}
 			if err := sseWriter.Event("container-stat", stat); err != nil {
 				log.Error().Err(err).Msg("error writing event to event stream")
@@ -198,8 +225,8 @@ func (h *handler) streamEvents(w http.ResponseWriter, r *http.Request) {
 
 			// start/rename refresh on their own below; anything else from a stale host is a
 			// chance to repair it
-			if event.Name != "start" && event.Name != "rename" && !repairHost(event.Host) {
-				return
+			if event.Name != "start" && event.Name != "rename" {
+				requestRepair(event.Host)
 			}
 
 			switch event.Name {


### PR DESCRIPTION
Chasing the `subscriber is not reading container events, dropping event` spam. The store dropping events is correct (it used to deadlock instead, #5039), but nothing bounded how long a reader could stall, and the warning did not say which reader it was.

Two ways a subscriber could stall for minutes:

- **No write deadline on the SSE stream.** A client that goes away without closing its socket stays writable until the send buffer fills, and the write then blocks until the kernel gives up retransmitting. For that whole window the handler reads nothing and every event aimed at it is lost. Harmless for the `exec_*` chatter a healthcheck produces, but a `start` or `die` in that window is gone for good and the container sits stale in the UI until reload. `SSEWriter` now arms a 10s deadline per write, probed once so a ResponseWriter that cannot do deadlines falls back to today's behavior.
- **Stale-host repair ran inline in the event loop.** `ListContainersForHost` can take the whole `--timeout` against an unreachable agent. One stale host plus a container with a 5s healthcheck kept the handler inside a Docker call more often than not. Repairs now run in a goroutine and land on a `refreshes` channel.

Logging: subscribers carry a name through their context (`sse-events`, `notifications`, `agent-stream`), so the warning says who stalled. Drops are collapsed into one throttled line per 10s with a count and how long the stall has run, instead of three lines every 5s, and an info line marks the stall ending.

Also buffers the agent's event channel, which was unbuffered, so any blip in the blocking gRPC `Send` dropped an event rather than only a real stall.

Tests cover the throttle, the recovery line, subscriber naming, and the deadline wiring (including the unsupported fallback). Existing suite passes with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015t8b2BRYUo1KrbBPzrj94J
