### PR TITLE
fix(ui): redesign the log search surfaces

### DIFF
--- a/assets/components.d.ts
+++ b/assets/components.d.ts
@@ -180,6 +180,7 @@ declare module 'vue' {
     'Mdi:linkVariant': typeof import('~icons/mdi/link-variant')['default']
     'Mdi:linkVariantOff': typeof import('~icons/mdi/link-variant-off')['default']
     'Mdi:linkVariantPlus': typeof import('~icons/mdi/link-variant-plus')['default']
+    'Mdi:loading': typeof import('~icons/mdi/loading')['default']
     'Mdi:magnify': typeof import('~icons/mdi/magnify')['default']
     'Mdi:messageOutline': typeof import('~icons/mdi/message-outline')['default']
     'Mdi:messageQuestionOutline': typeof import('~icons/mdi/message-question-outline')['default']

--- a/assets/components/logs/EventSource.vue
+++ b/assets/components/logs/EventSource.vue
@@ -1,5 +1,5 @@
 <template>
-  <SearchStatus :status="searchStatus" />
+  <SearchStatus :status="searchStatus" :empty="noLogs" />
   <ul class="flex animate-pulse flex-col gap-4 p-4" v-if="loading || (noLogs && waitingForMoreLog && !inSearch)">
     <div class="flex flex-row gap-2" v-for="size in sizes">
       <div class="bg-base-content/50 h-3 w-40 shrink-0 rounded-full opacity-50"></div>
@@ -13,7 +13,7 @@
     :title="$t('label.no-logs')"
     :hint="$t('label.no-logs-hint')"
   >
-    <template #icon><mdi:text-box-outline class="size-5" /></template>
+    <template #icon><mdi:text-box-outline class="size-6" /></template>
   </EmptyState>
   <slot :messages="messages" v-else></slot>
   <IndeterminateBar :color :intensity="streaming ? 1 : 0" v-if="!historical" />

--- a/assets/components/logs/SearchStatus.spec.ts
+++ b/assets/components/logs/SearchStatus.spec.ts
@@ -4,6 +4,7 @@ import { nextTick } from "vue";
 import { createI18n } from "vue-i18n";
 import SearchStatus from "./SearchStatus.vue";
 import IndeterminateBar from "@/components/ui/IndeterminateBar.vue";
+import EmptyState from "@/components/ui/EmptyState.vue";
 
 /**
  * @vitest-environment jsdom
@@ -16,9 +17,9 @@ const i18n = createI18n({
       label: {
         "search-status": {
           searching: "Searching older logs…",
-          "searching-to": "Searching older logs… back to {time}",
-          capped: "{count} matches · searched back to {time}",
-          exhausted: "Searched all logs · {count} matches",
+          matches: "{count} matches",
+          "searched-all": "Searched all logs",
+          "scanned-to": "back to {time}",
           empty: "No matching logs",
           "empty-hint": "Searched all logs. Try a different term or clear the search.",
         },
@@ -27,11 +28,12 @@ const i18n = createI18n({
   },
 });
 
-function createStatus(overrides: Record<string, unknown> = {}) {
+function createStatus(overrides: Record<string, unknown> = {}, empty = false) {
   return mount(SearchStatus, {
     global: { plugins: [i18n] },
     props: {
       status: { active: false, done: false, matches: 0, scannedTo: undefined, reason: undefined, ...overrides },
+      empty,
     },
   });
 }
@@ -57,6 +59,16 @@ describe("<SearchStatus />", () => {
     await nextTick();
     expect(wrapper.find('[data-state="searching"]').exists()).toBe(true);
     expect(wrapper.findComponent(IndeterminateBar).exists()).toBe(true);
+  });
+
+  test("takes the whole page while a search runs with nothing on screen yet", async () => {
+    const wrapper = createStatus({ active: true, scannedTo: "2026-06-01T13:10:00Z" }, true);
+    vi.advanceTimersByTime(400);
+    await nextTick();
+    // The centred state, not the strip: EmptyState owns the layout.
+    expect(wrapper.findComponent(EmptyState).exists()).toBe(true);
+    expect(wrapper.find('[data-state="searching"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain("Searching older logs…");
   });
 
   test("reveals the searching bar even when progress events arrive faster than the delay", async () => {

--- a/assets/components/logs/SearchStatus.vue
+++ b/assets/components/logs/SearchStatus.vue
@@ -1,41 +1,77 @@
 <template>
-  <!-- Progress and completion are a thin sticky strip over the log stream; an empty
-       result is not a status line but the whole answer, so it takes the room the log
-       list would have filled. -->
+  <!-- An empty result is not a status line but the whole answer, so it takes the
+       room the log list would have filled. -->
   <EmptyState
     v-if="state === 'empty'"
     data-state="empty"
     :title="$t('label.search-status.empty')"
     :hint="$t('label.search-status.empty-hint')"
   >
-    <template #icon><mdi:text-search class="size-5" /></template>
+    <template #icon><mdi:text-search class="size-6" /></template>
   </EmptyState>
-  <div
-    v-else-if="state"
-    :data-state="state"
-    class="bg-base-200/80 text-base-content/70 sticky top-0 z-10 flex items-center gap-2 px-4 py-1.5 font-sans text-xs backdrop-blur"
+  <!-- Same, while the search is still running with nothing yet to show: the page
+       is otherwise blank, and a 12px line in the corner of an empty screen does
+       not say "this is working on it". Once matches are on screen the list is
+       the answer and progress goes back to being a thin strip over it. -->
+  <EmptyState
+    v-else-if="state === 'searching' && empty"
+    data-state="searching"
+    :title="$t('label.search-status.searching')"
+    :hint="matches"
   >
-    <template v-if="state === 'searching'">
-      <span>{{
-        status.scannedTo ? $t("label.search-status.searching-to", { time }) : $t("label.search-status.searching")
-      }}</span>
-      <div class="ml-auto w-1/2">
-        <IndeterminateBar color="primary" />
+    <template #icon><mdi:loading class="text-info size-6 motion-safe:animate-spin" /></template>
+    <template #actions>
+      <div class="flex flex-col items-center gap-2">
+        <IndeterminateBar color="primary" class="w-40 overflow-hidden rounded-full" />
+        <!-- The stamp walks backwards as the scan goes. It is the only readout
+             that proves the search is moving and not wedged, so it keeps its
+             seconds here even though the finished states drop them. -->
+        <span v-if="scanned" class="text-base-content/40 font-mono text-xs tabular-nums" :title="exactTime">
+          {{ scanned }}
+        </span>
       </div>
     </template>
-    <span v-else-if="state === 'capped'" class="tabular-nums">
-      {{ $t("label.search-status.capped", { count: status.matches, time }) }}
-    </span>
-    <span v-else-if="state === 'exhausted'" class="tabular-nums">
-      {{ $t("label.search-status.exhausted", { count: status.matches }) }}
-    </span>
+  </EmptyState>
+  <!-- With matches already on screen this is a boundary marker, not a banner: it
+       sits at the top of the list, which is the edge the search is working past
+       and the place you end up when you scroll looking for older matches. It was
+       sticky, which on the views where the document scrolls parked it under the
+       title bar where nobody ever saw it. -->
+  <div v-else-if="state" :data-state="state" class="border-base-content/10 bg-base-200/60 border-b font-sans">
+    <!-- Everything stays left: the find box floats over the right end of this
+         strip, and a detail parked under it is a detail nobody reads. -->
+    <div class="flex items-center gap-2 px-4 py-2">
+      <span class="flex size-5 shrink-0 items-center justify-center rounded-full" :class="tint">
+        <mdi:loading v-if="state === 'searching'" class="size-3.5 motion-safe:animate-spin" />
+        <mdi:check v-else-if="state === 'exhausted'" class="size-3.5" />
+        <mdi:information-outline v-else class="size-3.5" />
+      </span>
+      <span class="text-base-content/70 truncate text-sm">{{ label }}</span>
+      <span
+        v-for="(d, i) in details"
+        :key="d"
+        class="text-base-content/40 flex shrink-0 items-center gap-2 font-mono text-xs tabular-nums"
+        :title="exactTime"
+      >
+        <span v-if="i > 0" class="text-base-content/20" aria-hidden="true">·</span>
+        {{ d }}
+      </span>
+    </div>
+    <!-- The sweep is the strip's own bottom edge rather than a bar floating in
+         the row, so the whole header reads as the thing that is working. -->
+    <IndeterminateBar v-if="state === 'searching'" color="primary" class="-mb-px" />
   </div>
 </template>
 
 <script lang="ts" setup>
 import { type SearchStatus } from "@/composable/logs/eventStreams";
 
-const props = defineProps<{ status: SearchStatus }>();
+const props = defineProps<{
+  status: SearchStatus;
+  /** The stream has nothing on screen yet, so progress is the whole page. */
+  empty?: boolean;
+}>();
+const { t } = useI18n();
 
 // Reveal the in-progress bar only after a short delay so fast searches (the
 // common case, which return almost instantly) never flash it. Slow searches
@@ -68,7 +104,14 @@ watch(
 );
 onScopeDispose(() => clearTimeout(timer));
 
-const time = computed(() => (props.status.scannedTo ? new Date(props.status.scannedTo).toLocaleString() : ""));
+// An unparseable stamp drops the detail rather than formatting to junk: the
+// headline is the part that matters and it stands on its own.
+const scannedTo = computed(() => {
+  if (!props.status.scannedTo) return undefined;
+  const date = new Date(props.status.scannedTo);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+});
+const exactTime = computed(() => scannedTo.value?.toLocaleString());
 
 const state = computed<"searching" | "empty" | "capped" | "exhausted" | null>(() => {
   if (showSearching.value) return "searching";
@@ -77,5 +120,58 @@ const state = computed<"searching" | "empty" | "capped" | "exhausted" | null>(()
     if (wasSlow.value) return props.status.reason === "capped" ? "capped" : "exhausted";
   }
   return null;
+});
+
+// State rides on the glyph so the strip itself stays neutral against the log
+// text it sits on.
+const tint = computed(() => (state.value === "exhausted" ? "bg-success/10 text-success" : "bg-info/10 text-info"));
+
+// The headline says what happened; the count or the scan boundary trails it as
+// a quiet mono detail rather than being welded into the same sentence.
+const label = computed(() => {
+  switch (state.value) {
+    case "exhausted":
+      return t("label.search-status.searched-all");
+    case "capped":
+      return t("label.search-status.matches", { count: props.status.matches });
+    default:
+      return t("label.search-status.searching");
+  }
+});
+
+// How far back the scan reached is a boundary, not staleness, so it is an
+// absolute stamp trimmed to what tells the two ends of a log apart. The full one
+// is a hover away. Seconds survive the trim only while the search is running,
+// where this stamp walking backwards is the proof that it is still moving.
+const scanned = computed(() => {
+  if (!scannedTo.value) return "";
+  const time = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    ...(state.value === "searching" ? { second: "2-digit" } : {}),
+  }).format(scannedTo.value);
+  return t("label.search-status.scanned-to", { time });
+});
+
+// The running total, which climbs while the search walks backwards. Nothing
+// showed it before the search finished, which left the in-progress state saying
+// only that something was happening and not how well it was going.
+const matches = computed(() =>
+  props.status.matches > 0 ? t("label.search-status.matches", { count: props.status.matches }) : "",
+);
+
+// The headline says what happened; the count and the scan boundary trail it as
+// quiet mono details rather than being welded into the same sentence.
+const details = computed(() => {
+  switch (state.value) {
+    case "exhausted":
+      return [t("label.search-status.matches", { count: props.status.matches })];
+    case "capped":
+      return [scanned.value].filter(Boolean);
+    default:
+      return [matches.value, scanned.value].filter(Boolean);
+  }
 });
 </script>

--- a/assets/components/search/Search.spec.ts
+++ b/assets/components/search/Search.spec.ts
@@ -21,15 +21,15 @@ describe("<Search />", () => {
     search.resetSearch();
   });
 
-  test("flags an invalid regex with a warning style", async () => {
+  test("flags an invalid regex on the box without recoloring it", async () => {
     const wrapper = mountSearch();
     search.searchQueryFilter.value = "valid";
     await nextTick();
-    expect(wrapper.find(".input").classes()).not.toContain("input-warning");
+    expect(wrapper.find('[data-testid="search-box"]').attributes("data-invalid")).toBeUndefined();
 
     search.searchQueryFilter.value = "[";
     await nextTick();
-    expect(wrapper.find(".input").classes()).toContain("input-warning");
+    expect(wrapper.find('[data-testid="search-box"]').attributes("data-invalid")).toBe("true");
   });
 
   test("binds the input to the shared search filter", async () => {

--- a/assets/components/search/Search.vue
+++ b/assets/components/search/Search.vue
@@ -1,33 +1,79 @@
 <template>
   <transition name="slide">
     <!-- Padded past the cloud rail so the box does not open on top of it. A
-         drag sets left/top, which this does not touch. -->
+         drag sets left/top, which this does not touch. The strip itself is
+         inert: it spans the window, so whatever sits under it (the topbar) has
+         to stay clickable. Only the card takes the pointer. -->
     <div
-      class="fixed z-50 flex w-full justify-end p-2"
+      class="pointer-events-none fixed z-50 flex w-full justify-end p-2"
       v-show="showSearch"
       ref="container"
       :style="[style, { paddingRight: railOffset ? `${railOffset + 8}px` : undefined }]"
     >
-      <div class="input input-primary flex items-center shadow-lg" :class="!isValidQuery ? 'input-warning' : ''">
-        <mdi:magnify />
+      <!-- Primary on the border, not on a filled control: this is the one thing
+           on screen the user is driving while it is open, and a neutral card
+           floating over the stream did not say so. -->
+      <div
+        class="rounded-box border-primary/40 bg-base-200 focus-within:border-primary/80 pointer-events-auto flex items-center gap-1.5 border py-1.5 pr-1.5 pl-1 shadow-lg transition-colors"
+        :class="{ '!border-warning/60': !isValidQuery }"
+        :data-invalid="!isValidQuery || undefined"
+        data-testid="search-box"
+      >
+        <!-- The box is draggable, but only by the grip: dragging from the input
+             fights text selection. -->
+        <div
+          ref="handle"
+          class="text-base-content/25 hover:text-base-content/50 cursor-move transition-colors"
+          :title="$t('toolbar.move-search')"
+        >
+          <mdi:drag-vertical class="size-4" />
+        </div>
+
+        <mdi:magnify class="text-primary size-4 shrink-0" />
+
         <input
-          class="input input-ghost w-72 flex-1"
+          class="text-base-content placeholder:text-base-content/40 w-64 min-w-0 flex-1 bg-transparent font-mono text-sm outline-none"
           type="text"
-          placeholder="Find / RegEx"
+          :placeholder="$t('placeholder.find-logs')"
           ref="input"
           v-model="searchQueryFilter"
           @keyup.esc="resetSearch()"
         />
+
+        <!-- An unparseable regex is a note on the query, not an alarm on the
+             surface: the glyph carries it and the box keeps its contrast. -->
+        <mdi:alert-circle-outline
+          v-if="!isValidQuery"
+          class="text-warning size-4 shrink-0"
+          :title="$t('toolbar.invalid-regex')"
+        />
+
+        <div class="bg-base-content/10 mx-0.5 h-5 w-px shrink-0"></div>
+
         <button
-          class="btn btn-circle btn-xs"
-          :class="inverseFilter ? 'btn-error' : 'btn-ghost'"
+          type="button"
+          class="icon-btn inline-flex size-6 shrink-0 items-center justify-center rounded-md transition-colors"
+          :class="
+            inverseFilter
+              ? 'bg-secondary/15 text-secondary hover:bg-secondary/25'
+              : 'text-base-content/50 hover:bg-base-content/10 hover:text-base-content'
+          "
+          :aria-pressed="inverseFilter"
           @click="toggleInverse()"
           :title="inverseFilter ? $t('toolbar.inverse-on') : $t('toolbar.inverse-off')"
         >
-          <mdi:filter-off-outline v-if="inverseFilter" />
-          <mdi:filter-outline v-else />
+          <mdi:filter-off-outline v-if="inverseFilter" class="size-4" />
+          <mdi:filter-outline v-else class="size-4" />
         </button>
-        <a class="btn btn-circle btn-xs" @click="resetSearch()"> <mdi:close /></a>
+
+        <button
+          type="button"
+          class="icon-btn text-base-content/50 hover:bg-base-content/10 hover:text-base-content inline-flex size-6 shrink-0 items-center justify-center rounded-md transition-colors"
+          @click="resetSearch()"
+          :title="$t('toolbar.close-search')"
+        >
+          <mdi:close class="size-4" />
+        </button>
       </div>
     </div>
   </transition>
@@ -36,10 +82,34 @@
 <script lang="ts" setup>
 const input = ref<HTMLInputElement>();
 const container = ref<HTMLDivElement>();
+const handle = ref<HTMLDivElement>();
 const { searchQueryFilter, showSearch, resetSearch, isValidQuery, inverseFilter, toggleInverse } = useSearchFilter();
 const { railOffset } = useCloudRail();
 
-const { style } = useDraggable(container);
+// Opening on top of the container title bar covers the stats and the toolbar
+// the box is not about. It opens just under the header instead, measured rather
+// than hardcoded because the header is a different height on mobile and on the
+// views that carry no stats. Once the box has been dragged it stays where it
+// was put.
+const FALLBACK_TOP = 56;
+const moved = ref(false);
+const { style, position } = useDraggable(container, {
+  handle,
+  initialValue: { x: 0, y: FALLBACK_TOP },
+  onEnd: () => (moved.value = true),
+});
+
+watch(
+  showSearch,
+  (open) => {
+    if (!open || moved.value) return;
+    nextTick(() => {
+      const header = document.querySelector('[data-testid="scrollable-header"]');
+      position.value = { x: 0, y: header ? Math.round(header.getBoundingClientRect().bottom) : FALLBACK_TOP };
+    });
+  },
+  { immediate: true },
+);
 
 onKeyStroke("f", (e) => {
   if (!search.value) return;
@@ -76,5 +146,17 @@ onUnmounted(() => resetSearch());
 .slide-leave-to {
   transform: translateY(-150px);
   opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .slide-enter-active,
+  .slide-leave-active {
+    transition: opacity 100ms linear;
+  }
+
+  .slide-enter-from,
+  .slide-leave-to {
+    transform: none;
+  }
 }
 </style>

--- a/assets/components/ui/EmptyState.vue
+++ b/assets/components/ui/EmptyState.vue
@@ -5,13 +5,13 @@
     content would have filled rather than reading as a stray status line, and stays
     neutral so nothing about an empty result looks like a failure.
   -->
-  <div class="flex flex-col items-center gap-3 px-4 py-12 text-center font-sans">
-    <div class="bg-base-content/5 text-base-content/40 flex size-10 items-center justify-center rounded-full">
+  <div class="flex flex-col items-center gap-4 px-4 py-16 text-center font-sans">
+    <div class="bg-base-content/5 text-base-content/40 flex size-12 items-center justify-center rounded-full">
       <slot name="icon" />
     </div>
-    <div class="flex flex-col gap-1">
-      <p class="text-sm font-semibold">{{ title }}</p>
-      <p v-if="hint" class="text-base-content/50 text-xs">{{ hint }}</p>
+    <div class="flex flex-col gap-1.5">
+      <p class="text-base font-semibold">{{ title }}</p>
+      <p v-if="hint" class="text-base-content/50 text-sm">{{ hint }}</p>
     </div>
     <div v-if="$slots.actions" class="mt-1 flex flex-wrap items-center justify-center gap-2">
       <slot name="actions" />

--- a/locales/da.yml
+++ b/locales/da.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Søg
   inverse-on: Ekskluder matchende (inverteret)
   inverse-off: Inkluder matchende (normal)
+  invalid-regex: Ugyldigt regulært udtryk
+  close-search: Luk søgning
+  move-search: Træk for at flytte
   show: Vis kun {std}
   show-all: Vis alle streams
   stop: Stop
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Alt hvad containeren skriver, vises her med det samme."
   search-status:
     searching: Søger i ældre logs…
-    searching-to: Søger i ældre logs… tilbage til {time}
-    capped: "{count} match · søgt tilbage til {time}"
-    exhausted: Søgt i alle logs · {count} match
+    matches: "{count} match"
+    searched-all: "Søgt i alle logs"
+    scanned-to: "tilbage til {time}"
     empty: "Ingen matchende logs"
     empty-hint: "Søgte i alle logs. Prøv et andet søgeord, eller ryd søgningen."
   show-all-containers: Vis alle containere
@@ -209,6 +212,7 @@ button:
   refresh: Opdater
 placeholder:
   search-containers: Søg containere (⌘ + k, ⌃k)
+  find-logs: Find i logs eller regex
   search: Søg
 settings:
   show-image-update-alert: 'Vis en notifikation når en container har en opdatering'

--- a/locales/de.yml
+++ b/locales/de.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Suchen
   inverse-on: Übereinstimmungen ausschließen (invertiert)
   inverse-off: Übereinstimmungen einschließen (normal)
+  invalid-regex: Ungültiger regulärer Ausdruck
+  close-search: Suche schließen
+  move-search: Zum Verschieben ziehen
   show: Zeige nur {std}
   show-all: Zeige alle Streams
   stop: Stop
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Alles, was der Container schreibt, erscheint hier sofort."
   search-status:
     searching: Durchsuche ältere Logs…
-    searching-to: Durchsuche ältere Logs… zurück bis {time}
-    capped: "{count} Treffer · durchsucht bis {time}"
-    exhausted: Alle Logs durchsucht · {count} Treffer
+    matches: "{count} Treffer"
+    searched-all: "Alle Logs durchsucht"
+    scanned-to: "zurück bis {time}"
     empty: "Keine passenden Logs"
     empty-hint: "Alle Logs durchsucht. Probiere einen anderen Suchbegriff oder setze die Suche zurück."
   show-all-containers: Zeige alle Container
@@ -209,6 +212,7 @@ button:
   refresh: Aktualisieren
 placeholder:
   search-containers: Suche Container (⌘ + k, ⌃k)
+  find-logs: In Logs suchen oder Regex
   search: Suche
 settings:
   show-image-update-alert: 'Benachrichtigung anzeigen, wenn ein Container ein Update hat'

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Search
   inverse-on: Exclude matching (inverse)
   inverse-off: Include matching (normal)
+  invalid-regex: Invalid regular expression
+  close-search: Close search
+  move-search: Drag to move
   show: Show {std}
   show-all: Show all
   stop: Stop
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Anything the container writes shows up here right away."
   search-status:
     searching: Searching older logs…
-    searching-to: Searching older logs… back to {time}
-    capped: "{count} matches · searched back to {time}"
-    exhausted: Searched all logs · {count} matches
+    matches: "{count} matches"
+    searched-all: "Searched all logs"
+    scanned-to: "back to {time}"
     empty: "No matching logs"
     empty-hint: "Searched all logs. Try a different term or clear the search."
   show-all-containers: Show all containers
@@ -217,6 +220,7 @@ button:
   refresh: Refresh
 placeholder:
   search-containers: Search containers (⌘ + k, ⌃k)
+  find-logs: Find in logs or regex
   search: Search
 cloud-rail:
   title: Dozzle Cloud

--- a/locales/es.yml
+++ b/locales/es.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Buscar
   inverse-on: Excluir coincidencias (inverso)
   inverse-off: Incluir coincidencias (normal)
+  invalid-regex: Expresión regular no válida
+  close-search: Cerrar búsqueda
+  move-search: Arrastra para mover
   show: Mostrar {std}
   show-all: Mostrar todo
   stop: Detener
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Todo lo que el contenedor escriba aparecerá aquí de inmediato."
   search-status:
     searching: Buscando registros anteriores…
-    searching-to: Buscando registros anteriores… hasta {time}
-    capped: "{count} coincidencias · buscado hasta {time}"
-    exhausted: Todos los registros buscados · {count} coincidencias
+    matches: "{count} coincidencias"
+    searched-all: "Todos los registros buscados"
+    scanned-to: "hasta {time}"
     empty: "Ningún registro coincide"
     empty-hint: "Se buscó en todos los registros. Prueba otro término o borra la búsqueda."
   show-all-containers: Mostrar todos los contenedores
@@ -209,6 +212,7 @@ button:
   refresh: Actualizar
 placeholder:
   search-containers: Buscar contenedores (⌘ + K, CTRL + K)
+  find-logs: Buscar en los registros o regex
   search: Buscar
 cloud-rail:
   title: Dozzle Cloud

--- a/locales/fr.yml
+++ b/locales/fr.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Chercher
   inverse-on: Exclure les correspondances (inverse)
   inverse-off: Inclure les correspondances (normal)
+  invalid-regex: Expression régulière invalide
+  close-search: Fermer la recherche
+  move-search: Glisser pour déplacer
   show: Montrer seulement {std}
   show-all: Afficher tous les flux
   stop: Stop
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Tout ce que le conteneur écrit apparaîtra ici immédiatement."
   search-status:
     searching: Recherche dans les logs plus anciens…
-    searching-to: Recherche dans les logs plus anciens… jusqu'à {time}
-    capped: "{count} résultats · recherché jusqu'à {time}"
-    exhausted: Tous les logs recherchés · {count} résultats
+    matches: "{count} résultats"
+    searched-all: "Tous les logs recherchés"
+    scanned-to: "jusqu'à {time}"
     empty: "Aucun log correspondant"
     empty-hint: "Tous les logs ont été recherchés. Essayez un autre terme ou effacez la recherche."
   show-all-containers: Afficher tous les conteneurs
@@ -209,6 +212,7 @@ button:
   refresh: Actualiser
 placeholder:
   search-containers: Recherche de conteneurs (⌘ + k, ⌃k)
+  find-logs: Rechercher dans les logs ou regex
   search: Recherche
 settings:
   show-image-update-alert: 'Afficher une notification lorsqu''un conteneur a une mise à jour'

--- a/locales/id.yml
+++ b/locales/id.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Cari
   inverse-on: Kecualikan yang cocok (inversi)
   inverse-off: Sertakan yang cocok (normal)
+  invalid-regex: Ekspresi reguler tidak valid
+  close-search: Tutup pencarian
+  move-search: Seret untuk memindahkan
   show: Tampilkan {std}
   show-all: Tampilkan semua
   stop: Hentikan
@@ -111,9 +114,9 @@ label:
   no-logs-hint: "Apa pun yang ditulis kontainer akan langsung muncul di sini."
   search-status:
     searching: Mencari log lama…
-    searching-to: Mencari log lama… kembali ke {time}
-    capped: "{count} hasil · dicari kembali ke {time}"
-    exhausted: Semua log dicari · {count} hasil
+    matches: "{count} hasil"
+    searched-all: "Semua log dicari"
+    scanned-to: "kembali ke {time}"
     empty: "Tidak ada log yang cocok"
     empty-hint: "Semua log sudah dicari. Coba kata lain atau hapus pencarian."
   show-all-containers: Tampilkan semua kontainer
@@ -216,6 +219,7 @@ button:
 
 placeholder:
   search-containers: Cari kontainer (⌘ + k, ⌃k)
+  find-logs: Cari di log atau regex
   search: Cari
 
 settings:

--- a/locales/it.yml
+++ b/locales/it.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Cerca
   inverse-on: Escludi corrispondenze (inverso)
   inverse-off: Includi corrispondenze (normale)
+  invalid-regex: Espressione regolare non valida
+  close-search: Chiudi ricerca
+  move-search: Trascina per spostare
   show: Mostra solo {std}
   show-all: Mostra tutto
   stop: Stop
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Tutto ciò che il container scrive apparirà subito qui."
   search-status:
     searching: Ricerca nei log meno recenti…
-    searching-to: Ricerca nei log meno recenti… fino a {time}
-    capped: "{count} risultati · cercato fino a {time}"
-    exhausted: Cercato in tutti i log · {count} risultati
+    matches: "{count} risultati"
+    searched-all: "Cercato in tutti i log"
+    scanned-to: "fino a {time}"
     empty: "Nessun log corrispondente"
     empty-hint: "Cercato in tutti i log. Prova un altro termine o cancella la ricerca."
   show-all-containers: Mostra tutti i container
@@ -209,6 +212,7 @@ button:
   refresh: Aggiorna
 placeholder:
   search-containers: Ricerca container (⌘ + k, ⌃k)
+  find-logs: Cerca nei log o regex
   search: Cerca
 settings:
   show-image-update-alert: 'Mostra una notifica quando un container ha un aggiornamento'

--- a/locales/ko.yml
+++ b/locales/ko.yml
@@ -5,6 +5,9 @@ toolbar:
   search: 검색
   inverse-on: 일치 항목 제외 (반전)
   inverse-off: 일치 항목 포함 (일반)
+  invalid-regex: 잘못된 정규식
+  close-search: 검색 닫기
+  move-search: 드래그하여 이동
   show: "{std} 보기"
   show-all: 전체 보기
   stop: 중지
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "컨테이너가 출력하는 내용이 바로 여기에 표시됩니다."
   search-status:
     searching: 이전 로그 검색 중…
-    searching-to: 이전 로그 검색 중… {time}까지
-    capped: "{count}개 일치 · {time}까지 검색함"
-    exhausted: 모든 로그 검색 완료 · {count}개 일치
+    matches: "{count}개 일치"
+    searched-all: "모든 로그 검색 완료"
+    scanned-to: "{time}까지"
     empty: "일치하는 로그가 없습니다"
     empty-hint: "모든 로그를 검색했습니다. 다른 검색어를 시도하거나 검색을 지우세요."
   show-all-containers: 전체 컨테이너 보기
@@ -211,6 +214,7 @@ button:
   refresh: 새로고침
 placeholder:
   search-containers: 컨테이너 검색 (⌘ + k, ⌃k)
+  find-logs: 로그에서 찾기 또는 정규식
   search: 검색
 settings:
   show-image-update-alert: '컨테이너에 업데이트가 있을 때 알림 표시'

--- a/locales/nl.yml
+++ b/locales/nl.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Zoeken
   inverse-on: Overeenkomsten uitsluiten (omgekeerd)
   inverse-off: Overeenkomsten opnemen (normaal)
+  invalid-regex: Ongeldige reguliere expressie
+  close-search: Zoeken sluiten
+  move-search: Sleep om te verplaatsen
   show: Toon {std}
   show-all: Toon alles
   stop: Stoppen
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Alles wat de container schrijft, verschijnt hier direct."
   search-status:
     searching: Oudere logs doorzoeken…
-    searching-to: Oudere logs doorzoeken… terug tot {time}
-    capped: "{count} overeenkomsten · doorzocht tot {time}"
-    exhausted: Alle logs doorzocht · {count} overeenkomsten
+    matches: "{count} overeenkomsten"
+    searched-all: "Alle logs doorzocht"
+    scanned-to: "terug tot {time}"
     empty: "Geen overeenkomende logs"
     empty-hint: "Alle logs doorzocht. Probeer een andere zoekterm of wis de zoekopdracht."
   show-all-containers: Toon alle containers
@@ -210,6 +213,7 @@ button:
   refresh: Vernieuwen
 placeholder:
   search-containers: Zoek containers (⌘ + k, ⌃k)
+  find-logs: Zoek in logs of regex
   search: Zoeken
 settings:
   show-image-update-alert: 'Toon een melding wanneer een container een update heeft'

--- a/locales/pl.yml
+++ b/locales/pl.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Szukaj
   inverse-on: Wyklucz pasujące (odwrotnie)
   inverse-off: Uwzględnij pasujące (normalnie)
+  invalid-regex: Nieprawidłowe wyrażenie regularne
+  close-search: Zamknij wyszukiwanie
+  move-search: Przeciągnij, aby przenieść
   show: Pokaż tylko {std}
   show-all: Pokaż wszystko
   stop: Stop
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Wszystko, co zapisze kontener, pojawi się tutaj od razu."
   search-status:
     searching: Przeszukiwanie starszych logów…
-    searching-to: Przeszukiwanie starszych logów… wstecz do {time}
-    capped: "{count} dopasowań · przeszukano do {time}"
-    exhausted: Przeszukano wszystkie logi · {count} dopasowań
+    matches: "{count} dopasowań"
+    searched-all: "Przeszukano wszystkie logi"
+    scanned-to: "wstecz do {time}"
     empty: "Brak pasujących logów"
     empty-hint: "Przeszukano wszystkie logi. Spróbuj innej frazy lub wyczyść wyszukiwanie."
   show-all-containers: Pokaż wszystkie kontenery
@@ -211,6 +214,7 @@ button:
   refresh: Odśwież
 placeholder:
   search-containers: Przeszukaj kontery (⌘ + k, ⌃k)
+  find-logs: Szukaj w logach lub regex
   search: Szukaj
 settings:
   show-image-update-alert: 'Pokaż powiadomienie, gdy kontener ma aktualizację'

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Pesquisar
   inverse-on: Excluir correspondências (inverso)
   inverse-off: Incluir correspondências (normal)
+  invalid-regex: Expressão regular inválida
+  close-search: Fechar pesquisa
+  move-search: Arraste para mover
   show: Mostrar {std}
   show-all: Mostrar tudo
   stop: Parar
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Tudo o que o contêiner escrever aparecerá aqui imediatamente."
   search-status:
     searching: Pesquisando logs mais antigos…
-    searching-to: Pesquisando logs mais antigos… até {time}
-    capped: "{count} correspondências · pesquisado até {time}"
-    exhausted: Todos os logs pesquisados · {count} correspondências
+    matches: "{count} correspondências"
+    searched-all: "Todos os logs pesquisados"
+    scanned-to: "até {time}"
     empty: "Nenhum log correspondente"
     empty-hint: "Todos os logs foram pesquisados. Tente outro termo ou limpe a pesquisa."
   show-all-containers: Mostrar todos os containers
@@ -209,6 +212,7 @@ button:
   refresh: Atualizar
 placeholder:
   search-containers: Pesquisar containers (⌘ + k, ⌃k)
+  find-logs: Pesquisar nos logs ou regex
   search: Pesquisar
 settings:
   show-image-update-alert: 'Mostrar uma notificação quando um contêiner tiver uma atualização'

--- a/locales/ru.yml
+++ b/locales/ru.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Поиск
   inverse-on: Исключить совпадения (инверсия)
   inverse-off: Включить совпадения (обычно)
+  invalid-regex: Некорректное регулярное выражение
+  close-search: Закрыть поиск
+  move-search: Перетащите, чтобы переместить
   show: Показать только {std}
   show-all: Показать все потоки
   stop: Остановить
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Всё, что запишет контейнер, сразу появится здесь."
   search-status:
     searching: Поиск в старых логах…
-    searching-to: Поиск в старых логах… до {time}
-    capped: "{count} совпадений · поиск до {time}"
-    exhausted: Все логи просмотрены · {count} совпадений
+    matches: "{count} совпадений"
+    searched-all: "Все логи просмотрены"
+    scanned-to: "до {time}"
     empty: "Нет подходящих логов"
     empty-hint: "Просмотрены все логи. Попробуйте другой запрос или очистите поиск."
   show-all-containers: Показать все контейнеры
@@ -209,6 +212,7 @@ button:
   refresh: Обновить
 placeholder:
   search-containers: Поиск контейнеров (⌘ + k, ⌃k)
+  find-logs: Поиск в логах или regex
   search: Поиск
 settings:
   show-image-update-alert: 'Показывать уведомление, когда у контейнера есть обновление'

--- a/locales/sl.yml
+++ b/locales/sl.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Iskanje
   inverse-on: Izključi ujemanja (obratno)
   inverse-off: Vključi ujemanja (običajno)
+  invalid-regex: Neveljaven regularni izraz
+  close-search: Zapri iskanje
+  move-search: Povlecite za premik
   show: Prikaži {std}
   show-all: Prikaži vse
   stop: Ustavi
@@ -116,9 +119,9 @@ label:
   no-logs-hint: "Vse, kar vsebnik zapiše, se takoj pojavi tukaj."
   search-status:
     searching: Iskanje po starejših dnevnikih…
-    searching-to: Iskanje po starejših dnevnikih… nazaj do {time}
-    capped: "{count} zadetkov · iskano nazaj do {time}"
-    exhausted: Preiskani vsi dnevniki · {count} zadetkov
+    matches: "{count} zadetkov"
+    searched-all: "Preiskani vsi dnevniki"
+    scanned-to: "nazaj do {time}"
     empty: "Ni ujemajočih se dnevnikov"
     empty-hint: "Preiskani vsi dnevniki. Poskusite z drugim izrazom ali počistite iskanje."
 tooltip:
@@ -211,6 +214,7 @@ button:
   refresh: Osveži
 placeholder:
   search-containers: Iskanje zabojnikov (⌘ + k, ⌃k)
+  find-logs: Iskanje po dnevnikih ali regex
   search: Iskanje
 settings:
   show-image-update-alert: 'Pokaži obvestilo, ko je za vsebnik na voljo posodobitev'

--- a/locales/tr.yml
+++ b/locales/tr.yml
@@ -5,6 +5,9 @@ toolbar:
   search: Ara
   inverse-on: Eşleşenleri hariç tut (ters)
   inverse-off: Eşleşenleri dahil et (normal)
+  invalid-regex: Geçersiz düzenli ifade
+  close-search: Aramayı kapat
+  move-search: Taşımak için sürükleyin
   show: Sadece {std} göster
   show-all: Tüm akışları göster
   stop: Durdur
@@ -110,9 +113,9 @@ label:
   no-logs-hint: "Konteynerin yazdığı her şey anında burada görünür."
   search-status:
     searching: Eski loglar aranıyor…
-    searching-to: Eski loglar aranıyor… {time} tarihine kadar
-    capped: "{count} eşleşme · {time} tarihine kadar arandı"
-    exhausted: Tüm loglar arandı · {count} eşleşme
+    matches: "{count} eşleşme"
+    searched-all: "Tüm loglar arandı"
+    scanned-to: "{time} tarihine kadar"
     empty: "Eşleşen log yok"
     empty-hint: "Tüm loglar arandı. Farklı bir terim deneyin veya aramayı temizleyin."
   show-all-containers: Tüm konteynerleri göster
@@ -212,6 +215,7 @@ button:
   refresh: Yenile
 placeholder:
   search-containers: Konteynerlerde ara (⌘ + k, ⌃k)
+  find-logs: Günlüklerde ara veya regex
   search: Ara
 settings:
   show-image-update-alert: 'Bir kapsayıcının güncellemesi olduğunda bildirim göster'

--- a/locales/zh-tw.yml
+++ b/locales/zh-tw.yml
@@ -5,6 +5,9 @@ toolbar:
   search: 搜尋
   inverse-on: 排除符合項目（反向）
   inverse-off: 包含符合項目（一般）
+  invalid-regex: 無效的正規表示式
+  close-search: 關閉搜尋
+  move-search: 拖曳以移動
   show: 僅顯示 {std}
   show-all: 顯示全部
   stop: 停止
@@ -88,9 +91,9 @@ label:
   no-logs-hint: "容器輸出的內容會立即顯示在這裡。"
   search-status:
     searching: 正在搜尋較舊的日誌…
-    searching-to: 正在搜尋較舊的日誌…回溯至 {time}
-    capped: "{count} 筆符合 · 已搜尋至 {time}"
-    exhausted: 已搜尋所有日誌 · {count} 筆符合
+    matches: "{count} 筆符合"
+    searched-all: "已搜尋所有日誌"
+    scanned-to: "回溯至 {time}"
     empty: "沒有符合的日誌"
     empty-hint: "已搜尋所有日誌。請試試其他關鍵字或清除搜尋。"
   show-all-containers: 顯示所有容器
@@ -211,6 +214,7 @@ button:
   refresh: 重新整理
 placeholder:
   search-containers: 搜尋容器 (⌘ + k, ⌃k)
+  find-logs: 在日誌中尋找或正規表示式
   search: 搜尋
 settings:
   show-image-update-alert: '當容器有更新時顯示通知'

--- a/locales/zh.yml
+++ b/locales/zh.yml
@@ -5,6 +5,9 @@ toolbar:
   search: 搜索
   inverse-on: 排除匹配项（反向）
   inverse-off: 包含匹配项（正常）
+  invalid-regex: 无效的正则表达式
+  close-search: 关闭搜索
+  move-search: 拖动以移动
   show: 显示 {std}
   show-all: 显示全部
   stop: 停止
@@ -88,9 +91,9 @@ label:
   no-logs-hint: "容器输出的内容会立即显示在这里。"
   search-status:
     searching: 正在搜索较旧的日志…
-    searching-to: 正在搜索较旧的日志…回溯至 {time}
-    capped: "{count} 条匹配 · 已搜索至 {time}"
-    exhausted: 已搜索所有日志 · {count} 条匹配
+    matches: "{count} 条匹配"
+    searched-all: "已搜索所有日志"
+    scanned-to: "回溯至 {time}"
     empty: "没有匹配的日志"
     empty-hint: "已搜索所有日志。请尝试其他关键词或清除搜索。"
   show-all-containers: 显示所有容器
@@ -209,6 +212,7 @@ button:
   refresh: 刷新
 placeholder:
   search-containers: 搜索容器 (⌘ + k, ⌃k)
+  find-logs: 在日志中查找或正则
   search: 搜索
 settings:
   show-image-update-alert: '当容器有更新时显示通知'


### PR DESCRIPTION
Two search surfaces in the log view were still off-system: the ⌘F find box, and the progress status that shows while a search walks back through older logs.

## Find box

Was `input input-primary` wrapping an `input-ghost`, with `btn-error` on the inverse toggle.

- One bordered card matching `FuzzySearchModal`. Primary rides the border and the magnify glyph, not a filled control.
- A bad regex is a warning glyph plus a border tint instead of recoloring the whole box, so the query keeps full contrast.
- Inverse toggle reads as a mode (`secondary`, like the pin) rather than a destructive action.
- Opens below the container title bar instead of on top of its stats and toolbar. The offset is measured off the header, since mobile and the stats-less views are different heights. Dragging it still sticks.
- Drag moved onto a grip. It used to start anywhere, including on top of the input text.
- The full-width drag strip is now `pointer-events-none`, so it stops swallowing clicks across the whole topbar while search is open.
- Placeholder was a hardcoded English `"Find / RegEx"`.

## Search status

- While nothing is on screen yet, progress takes the page rather than being a 12px line in the corner of a blank screen: spinner, headline, running match count, scan boundary, sweep. Same shape as "No matching logs", which is what it turns into.
- With matches on screen it stays a thin row, but at the top of the list. It was `sticky top-0 z-10`, and on every view where the document scrolls (not the pinned-column case) that parked it under the `z-20` title bar, where it was never visible.
- The running count now shows **during** the search, not only after it finishes.
- The boundary stamp keeps its seconds while scanning — it walking backwards is the proof the search is moving — and drops them once done. Full value on hover.
- The run-on sentence splits into a headline plus quiet mono details.
- `EmptyState` got a size bump (title `text-sm`→`text-base`, circle `size-10`→`size-12`). It is only used by these log states, so they all grew together.

## Locales

`searching-to` / `capped` / `exhausted` replaced by `matches` / `searched-all` / `scanned-to` across all 16 files, recomposed from the fragments each locale already carried. Four new keys for the find box.

351 frontend tests and typecheck pass. Verified in the running app in light and dark across all four states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U1sqwrpdSmSXX3cpDvVCFb