### PR TITLE
fix(cloud): scope the rail's alert dot, and forget alerts when unlinked

### DIFF
--- a/assets/auto-imports.d.ts
+++ b/assets/auto-imports.d.ts
@@ -440,6 +440,7 @@ declare global {
   const useVModel: typeof import('@vueuse/core').useVModel
   const useVModels: typeof import('@vueuse/core').useVModels
   const useVibrate: typeof import('@vueuse/core').useVibrate
+  const useViewAlerts: typeof import('./composable/cloud/cloudRail').useViewAlerts
   const useViewContext: typeof import('./composable/logs/viewContext').useViewContext
   const useVirtualList: typeof import('@vueuse/core').useVirtualList
   const useVisibleFilter: typeof import('./composable/logs/visible').useVisibleFilter
@@ -970,6 +971,7 @@ declare module 'vue' {
     readonly useVModel: UnwrapRef<typeof import('@vueuse/core')['useVModel']>
     readonly useVModels: UnwrapRef<typeof import('@vueuse/core')['useVModels']>
     readonly useVibrate: UnwrapRef<typeof import('@vueuse/core')['useVibrate']>
+    readonly useViewAlerts: UnwrapRef<typeof import('./composable/cloud/cloudRail')['useViewAlerts']>
     readonly useViewContext: UnwrapRef<typeof import('./composable/logs/viewContext')['useViewContext']>
     readonly useVirtualList: UnwrapRef<typeof import('@vueuse/core')['useVirtualList']>
     readonly useVisibleFilter: UnwrapRef<typeof import('./composable/logs/visible')['useVisibleFilter']>

--- a/assets/components/cloud/history/AlertHistory.vue
+++ b/assets/components/cloud/history/AlertHistory.vue
@@ -25,7 +25,13 @@
         {{ $t("notifications.history.empty") }}
       </p>
 
-      <AlertRow v-for="alert in alerts" :key="alert.alertId" :alert="alert" />
+      <!-- Part of the chain above, not a sibling of it. As a sibling the rows
+           rendered underneath whichever line was showing, so unlinking in the
+           settings card printed "linking would remember these" over a list of
+           remembered alerts. -->
+      <template v-else>
+        <AlertRow v-for="alert in alerts" :key="alert.alertId" :alert="alert" />
+      </template>
     </div>
   </div>
 </template>

--- a/assets/components/cloud/rail/CloudRail.vue
+++ b/assets/components/cloud/rail/CloudRail.vue
@@ -157,7 +157,9 @@ const ChatPane = defineAsyncComponent(() => import("@/components/cloud/chat/Chat
 
 const { panel, panelWidth, sheet, closeRail, toggleRail, hideRail } = useCloudRail();
 const { messages, reset: resetChat } = useCloudChat();
-const { unseen: unseenAlerts } = useRecentAlerts();
+// Scoped to the view, because the panel this bell opens is. The nav's bell keeps
+// the instance-wide one: it opens the notifications page, which shows everything.
+const { unseen: unseenAlerts } = useViewAlerts();
 const { t } = useI18n();
 
 const items = computed(() => [

--- a/assets/components/cloud/rail/RailAlerts.vue
+++ b/assets/components/cloud/rail/RailAlerts.vue
@@ -33,22 +33,19 @@
 </template>
 
 <script lang="ts" setup>
-const { alerts, fetchRecentAlerts, markAlertsSeen, loading, loaded, failed } = useRecentAlerts();
-const view = useViewContext();
+const { fetchRecentAlerts, markAlertsSeen, loading, loaded, failed } = useRecentAlerts();
+const { visible, scoped, single } = useViewAlerts();
 
-onMounted(async () => {
-  await fetchRecentAlerts();
-  // Open the panel and the bell's dot goes out: someone looked.
-  markAlertsSeen();
+onMounted(() => fetchRecentAlerts());
+
+// The panel is open, so whatever it is showing has been looked at — and only
+// that. Marking the instance's newest seen from a panel scoped to one container
+// put out the nav's bell for alerts that were never on this screen, which is
+// also why a panel showing nothing marks nothing.
+//
+// An effect rather than a one-shot in onMounted: the rows usually land after the
+// panel opens, and more can arrive while it stays open.
+watchEffect(() => {
+  if (visible.value.length) markAlertsSeen(visible.value[0]);
 });
-
-const ids = computed(() => new Set(view.value.containers.map((c) => c.id)));
-const scoped = computed(() => ids.value.size > 0);
-const single = computed(() => ids.value.size === 1);
-
-// On a view with no containers of its own (the home page, settings) there is
-// nothing to scope to, so the panel shows the instance the way the page does.
-const visible = computed(() =>
-  scoped.value ? alerts.value.filter((a) => ids.value.has(a.containerId)) : alerts.value,
-);
 </script>

--- a/assets/composable/cloud/cloudRail.ts
+++ b/assets/composable/cloud/cloudRail.ts
@@ -19,6 +19,35 @@ const panel = ref<RailPanel>();
  *  the rail never sits over the logs. */
 export const RAIL_WIDTH = 48;
 
+/**
+ * The recent alerts, scoped to whatever log view is on screen.
+ *
+ * The rail's panel answers "what fired on what you're looking at" — the only
+ * reason it earns a place beside the stream rather than a link to the
+ * notifications page — so its bell has to ask the same question. An
+ * instance-wide dot there promised rows the panel then filtered away.
+ *
+ * Lives beside the rail rather than with the alerts because the bell needs the
+ * scope while the panel is closed and unmounted, and one definition keeps the
+ * dot and the rows it promises from drifting apart again.
+ */
+export function useViewAlerts() {
+  const { alerts, unseenIn } = useRecentAlerts();
+  const view = useViewContext();
+
+  const ids = computed(() => new Set(view.value.containers.map((c) => c.id)));
+  const scoped = computed(() => ids.value.size > 0);
+  const single = computed(() => ids.value.size === 1);
+
+  // On a view with no containers of its own (the home page, settings) there is
+  // nothing to scope to, so the panel shows the instance the way the page does.
+  const visible = computed(() =>
+    scoped.value ? alerts.value.filter((a) => ids.value.has(a.containerId)) : alerts.value,
+  );
+
+  return { visible, scoped, single, unseen: unseenIn(ids) };
+}
+
 export function useCloudRail() {
   const { width: windowWidth } = useWindowSize();
   const { linked } = useCloudSurface();

--- a/assets/composable/cloud/recentAlerts.spec.ts
+++ b/assets/composable/cloud/recentAlerts.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import { ref, computed } from "vue";
+import type { CloudAlert } from "./cloudAlerts";
+
+// Reactive so a test can link and unlink the instance the way the settings card
+// does: in place, without a reload.
+type CloudLink = { linked: boolean };
+const holder = vi.hoisted(() => ({ cloudConfig: null as ReturnType<typeof import("vue").ref<CloudLink>> | null }));
+vi.mock("./cloudConfig", async () => {
+  const { ref: vueRef } = await import("vue");
+  holder.cloudConfig = vueRef<CloudLink>({ linked: false });
+  return { useCloudConfig: () => ({ cloudConfig: holder.cloudConfig }) };
+});
+
+// The watermark is per-reader, not per-instance, so it lives in profile storage.
+// A plain ref keeps the test off localStorage and lets it be reset per case.
+const watermark = vi.hoisted(() => ({ ref: null as ReturnType<typeof import("vue").ref<number>> | null }));
+vi.mock("@/composable/app/profileStorage", async () => {
+  const { ref: vueRef } = await import("vue");
+  return {
+    useProfileStorage: () => (watermark.ref ??= vueRef(0)),
+  };
+});
+
+const ns = (n: number) => n * 1_000_000;
+
+function alert(overrides: Partial<CloudAlert> = {}): CloudAlert {
+  return {
+    alertId: "a1",
+    containerId: "abc",
+    hostId: "h",
+    ts: ns(100),
+    headline: "Pool exhausted",
+    level: "error",
+    eventCount: 3,
+    createdAt: ns(100),
+    isOrigin: true,
+    ...overrides,
+  };
+}
+
+const setLinked = (linked: boolean) => (holder.cloudConfig!.value = { linked });
+
+function respondWith(hits: CloudAlert[]) {
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ hits }) });
+}
+
+/** Fresh module state per test: everything here is shared across the page. */
+async function freshModule() {
+  vi.resetModules();
+  watermark.ref = null;
+  const mod = await import("./recentAlerts");
+  setLinked(false);
+  return mod;
+}
+
+describe("useRecentAlerts", () => {
+  beforeEach(() => {
+    respondWith([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("asks cloud for nothing while the instance is unlinked", async () => {
+    const { useRecentAlerts } = await freshModule();
+    const { fetchRecentAlerts, alerts } = useRecentAlerts();
+
+    await fetchRecentAlerts();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(alerts.value).toEqual([]);
+  });
+
+  test("loads the history once the instance links, without waiting for a poll", async () => {
+    // The boot race: cloudConfig is fetched asynchronously, so the history's own
+    // fetch usually runs while the instance still looks unlinked.
+    const { useRecentAlerts } = await freshModule();
+    const { fetchRecentAlerts, alerts } = useRecentAlerts();
+
+    await fetchRecentAlerts();
+    expect(alerts.value).toEqual([]);
+
+    respondWith([alert()]);
+    setLinked(true);
+    await vi.waitFor(() => expect(alerts.value).toHaveLength(1));
+  });
+
+  test("drops the history when the instance is unlinked in place", async () => {
+    // Unlinking does not reload the page, so without this the notifications
+    // history went on listing alerts under a line saying nothing is remembered.
+    const { useRecentAlerts } = await freshModule();
+    setLinked(true);
+    respondWith([alert()]);
+
+    const { fetchRecentAlerts, alerts, byContainer, unseen } = useRecentAlerts();
+    await fetchRecentAlerts();
+    expect(alerts.value).toHaveLength(1);
+
+    setLinked(false);
+    expect(alerts.value).toEqual([]);
+    expect(byContainer.value.size).toBe(0);
+    expect(unseen.value).toBe(false);
+  });
+});
+
+describe("unseenIn", () => {
+  beforeEach(() => respondWith([]));
+  afterEach(() => vi.restoreAllMocks());
+
+  /** Links, loads the given alerts, and hands back the composable. */
+  async function loaded(hits: CloudAlert[]) {
+    const { useRecentAlerts } = await freshModule();
+    setLinked(true);
+    respondWith(hits);
+    const api = useRecentAlerts();
+    await api.fetchRecentAlerts();
+    return api;
+  }
+
+  test("is quiet when nothing fired on the containers in view", async () => {
+    // The reported bug: the rail's bell lit for an alert on another container,
+    // and the panel it opened is scoped to the view, so it showed nothing.
+    const { unseenIn, unseen } = await loaded([alert({ containerId: "other" })]);
+    const dot = unseenIn(computed(() => new Set(["abc"])));
+
+    expect(dot.value).toBe(false);
+    expect(unseen.value).toBe(true);
+  });
+
+  test("lights for an alert on a container in view", async () => {
+    const { unseenIn } = await loaded([alert({ containerId: "abc" })]);
+    expect(unseenIn(computed(() => new Set(["abc"]))).value).toBe(true);
+  });
+
+  test("falls back to the instance on a view with no containers of its own", async () => {
+    // The home page and settings have nothing to scope to, so the panel shows
+    // the instance and the dot has to agree with it.
+    const { unseenIn } = await loaded([alert({ containerId: "other" })]);
+    expect(unseenIn(computed(() => new Set<string>())).value).toBe(true);
+  });
+
+  test("tracks the scope as the reader moves between containers", async () => {
+    const { unseenIn } = await loaded([alert({ containerId: "other" })]);
+    const ids = ref(new Set(["abc"]));
+    const dot = unseenIn(ids);
+
+    expect(dot.value).toBe(false);
+    ids.value = new Set(["other"]);
+    expect(dot.value).toBe(true);
+  });
+});
+
+describe("markAlertsSeen", () => {
+  beforeEach(() => respondWith([]));
+  afterEach(() => vi.restoreAllMocks());
+
+  async function loaded(hits: CloudAlert[]) {
+    const { useRecentAlerts } = await freshModule();
+    setLinked(true);
+    respondWith(hits);
+    const api = useRecentAlerts();
+    await api.fetchRecentAlerts();
+    return api;
+  }
+
+  test("reading a scoped panel leaves the instance-wide dot alone", async () => {
+    // The rail's panel shows one container. Marking the instance's newest seen
+    // from there put out the nav's bell for an alert never on this screen.
+    const mine = alert({ alertId: "mine", containerId: "abc", ts: ns(100) });
+    const theirs = alert({ alertId: "theirs", containerId: "other", ts: ns(300) });
+    const { markAlertsSeen, unseen, unseenIn } = await loaded([mine, theirs]);
+
+    const scope = computed(() => new Set(["abc"]));
+    markAlertsSeen(mine);
+
+    expect(unseenIn(scope).value).toBe(false);
+    expect(unseen.value).toBe(true);
+  });
+
+  test("reading the whole history puts every dot out", async () => {
+    const newest = alert({ alertId: "newest", containerId: "other", ts: ns(300) });
+    const { markAlertsSeen, unseen } = await loaded([alert({ ts: ns(100) }), newest]);
+
+    markAlertsSeen();
+    expect(unseen.value).toBe(false);
+  });
+
+  test("never moves the watermark backwards", async () => {
+    const older = alert({ alertId: "older", ts: ns(100) });
+    const { markAlertsSeen, unseen } = await loaded([older, alert({ alertId: "newer", ts: ns(300) })]);
+
+    markAlertsSeen();
+    markAlertsSeen(older);
+    expect(unseen.value).toBe(false);
+  });
+});

--- a/assets/composable/cloud/recentAlerts.ts
+++ b/assets/composable/cloud/recentAlerts.ts
@@ -1,3 +1,4 @@
+import type { MaybeRefOrGetter } from "vue";
 import type { CloudAlert } from "./cloudAlerts";
 
 /**
@@ -23,6 +24,28 @@ const loaded = ref(false);
 const failed = ref(false);
 
 let pending: Promise<void> | null = null;
+
+// Module scope rather than per-consumer: every surface below derives from
+// whether the instance is linked *right now*, not from what the last fetch
+// happened to return.
+const { linked } = useCloudSurface();
+
+// Linking and unlinking both happen without a reload — the settings card clears
+// the cloud config in place — and the moment either does, the rows this module
+// is holding stop describing the instance in front of the reader. So they are
+// dropped, and refetched when there is somewhere to ask again.
+//
+// The refetch also covers boot. `cloudConfig` is fetched asynchronously, so the
+// first `fetchRecentAlerts()` of a page load usually runs while the instance
+// still looks unlinked and early-returns; without this the history sat empty
+// until the bell's poll came round a minute later.
+watch(linked, (isLinked) => {
+  alerts.value = [];
+  loaded.value = false;
+  failed.value = false;
+  pending = null;
+  if (isLinked) pending = load();
+});
 
 /**
  * The newest alert this browser has been shown, as nanoseconds.
@@ -57,8 +80,6 @@ async function load(limit = 200): Promise<void> {
 }
 
 export function useRecentAlerts() {
-  const { linked } = useCloudSurface();
-
   function fetchRecentAlerts(limit?: number) {
     if (!linked.value) {
       alerts.value = [];
@@ -75,8 +96,13 @@ export function useRecentAlerts() {
     return load(limit);
   }
 
-  /** Newest first, which is the only order any of these surfaces wants. */
-  const newestFirst = computed(() => [...alerts.value].sort((a, b) => b.ts - a.ts));
+  /** Newest first, which is the only order any of these surfaces wants.
+   *
+   *  Empty while unlinked: an unlinked instance has no memory, so it has no
+   *  history — including the rows an earlier link left behind in this tab.
+   *  Gating it here rather than in each surface is what keeps a stale row out of
+   *  the history, both bells and the dot on a container row in one move. */
+  const newestFirst = computed(() => (linked.value ? [...alerts.value].sort((a, b) => b.ts - a.ts) : []));
 
   /**
    * The most recent alert per container, for the severity dot. A container with
@@ -102,10 +128,35 @@ export function useRecentAlerts() {
     return !!newest && newest.ts > lastSeenTs.value;
   });
 
+  /**
+   * The same question asked of one set of containers.
+   *
+   * A dot has to ask whatever its destination answers. The nav's bell opens the
+   * notifications page, which shows the instance, so it keeps `unseen`. The
+   * rail's bell opens a panel scoped to the view, so an instance-wide dot there
+   * promised rows the panel then filtered away, and the reader who followed it
+   * landed on "nothing has fired on what you're looking at".
+   *
+   * An empty scope is a view with no containers of its own (home, settings),
+   * where the panel shows the instance and so does the dot.
+   */
+  function unseenIn(ids: MaybeRefOrGetter<Set<string>>) {
+    return computed(() => {
+      const scope = toValue(ids);
+      if (scope.size === 0) return unseen.value;
+      return newestFirst.value.some((a) => scope.has(a.containerId) && a.ts > lastSeenTs.value);
+    });
+  }
+
   /** Called when the history is actually on screen, not when it is fetched: the
-   *  dot goes out because someone looked, not because a request landed. */
-  function markAlertsSeen() {
-    const newest = newestFirst.value[0];
+   *  dot goes out because someone looked, not because a request landed.
+   *
+   *  `upTo` is the newest alert the surface actually rendered. A scoped panel
+   *  that marked the instance's newest seen put out the nav's bell for alerts
+   *  the reader never saw, so the watermark moves only as far as the rows that
+   *  were on screen. Monotonic either way. */
+  function markAlertsSeen(upTo?: CloudAlert) {
+    const newest = upTo ?? newestFirst.value[0];
     if (newest && newest.ts > lastSeenTs.value) lastSeenTs.value = newest.ts;
   }
 
@@ -116,6 +167,7 @@ export function useRecentAlerts() {
     fetchRecentAlerts,
     refreshRecentAlerts,
     unseen,
+    unseenIn,
     markAlertsSeen,
     loading,
     loaded,


### PR DESCRIPTION
Two bugs behind the same shared list of recent alerts.

### The dot promised rows the panel filtered away

The bell on the cloud rail lit for any alert on the instance (`unseen`), but the panel it opens is scoped to the containers in view. An alert on another container put a dot on the bell, and the reader who followed it landed on "nothing has fired on what you're looking at".

A dot now asks whatever its destination answers. The nav's bell opens the notifications page, which shows the instance, so it keeps the unscoped question. The rail's asks it of the view, via `unseenIn(ids)`.

Reading a scoped panel also stopped marking the instance's newest alert seen. `markAlertsSeen(upTo?)` advances the watermark only as far as the rows actually rendered, so a panel scoped to one container no longer puts out the nav's bell for alerts that were never on screen, and a panel showing nothing marks nothing.

### The history listed alerts on an unlinked instance

`AlertRow` sat outside `AlertHistory`'s `v-if`/`v-else-if` chain, as a sibling of it. `clearCloudState()` clears the cloud config in place on unlink but never touched the alerts this module holds. So unlinking from settings, without a reload, rendered the muted "alerts show up here once this instance is linked" line with the remembered alerts listed underneath it. The same stale array kept feeding both bells and every container row dot.

Gating the list on `linked` fixes all four surfaces in one place, and a `watch` drops and refetches around a link change. That also covers a boot race found on the way: `cloudConfig` is fetched asynchronously, so the first `fetchRecentAlerts()` of a page load usually ran while the instance still looked unlinked and early-returned, leaving a linked instance's history blank until the nav's 60s poll.

### Notes

- `useViewAlerts()` lives in `cloudRail.ts`, not `recentAlerts.ts`: the bell needs the scope while the panel is unmounted, and importing `viewContext` into `recentAlerts.ts` pulls the container store and i18n in with it.
- Not addressed here: `byContainer` has no age cutoff, so a container row keeps its dot for an alert that fired days ago. Wants a product answer on the window.

New `recentAlerts.spec.ts` covers the scoping, the watermark and the unlink path. Full suite 369 passing, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z6kRveDpkmExSz8XZG73f