### PR TITLE
fix(auth): reject sha256 hashes at startup

### DIFF
--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -16,6 +16,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// sha256AdvisoryURL explains why sha256 hashes stopped being accepted, and is
+// the one thing an operator with a pre-bcrypt users.yml needs to read.
+const sha256AdvisoryURL = "https://github.com/amir20/dozzle/security/advisories/GHSA-w7qr-q9fh-fj35"
+
 type User struct {
 	Username        string                    `json:"username" yaml:"-"`
 	Email           string                    `json:"email" yaml:"email"`
@@ -118,8 +122,17 @@ func decodeUsersFromFile(path string) (UserDatabase, error) {
 			return users, fmt.Errorf("user %s has no password, github, or email, so it can never sign in", username)
 		}
 
-		if user.Password != "" && !(len(user.Password) == 64 || len(user.Password) == 60) {
-			return users, fmt.Errorf("user %s has an invalid password hash: expected 60 or 64 characters, got %d", username, len(user.Password))
+		// A sha256 hash is 64 characters. It used to be a supported format, so this
+		// check used to accept one, but CompareHashAndPassword has refused to compare
+		// one since v10.0.1. Accepting it here means the file loads clean, the login
+		// page renders a password form, and the refusal lands on the first login
+		// attempt instead of at startup. Reject it where main.go can name the file.
+		if len(user.Password) == 64 {
+			return users, fmt.Errorf("user %s has a sha256 password hash, which is no longer supported: regenerate it with `dozzle generate` to get a bcrypt hash, see %s", username, sha256AdvisoryURL)
+		}
+
+		if user.Password != "" && len(user.Password) != 60 {
+			return users, fmt.Errorf("user %s has an invalid password hash: expected 60 characters, got %d", username, len(user.Password))
 		}
 
 		if user.Name == "" {
@@ -260,8 +273,14 @@ func (u *UserDatabase) findIndexed(key string, index func() map[string]*User) *U
 }
 
 func CompareHashAndPassword(hash, password string) bool {
+	// decodeUsersFromFile rejects a sha256 hash, so this is unreachable from a
+	// file that loaded. It stays as a guard because this runs on an
+	// unauthenticated request: exiting here turns "someone guessed a username"
+	// into a process kill, and the users.yml reload can put a hash in front of
+	// this long after startup.
 	if len(hash) == 64 {
-		log.Fatal().Msg("sha256 passwords are no longer supported. Please use bcrypt. See https://github.com/amir20/dozzle/security/advisories/GHSA-w7qr-q9fh-fj35 for more details.")
+		log.Error().Msgf("sha256 passwords are no longer supported. Please use bcrypt. See %s for more details.", sha256AdvisoryURL)
+		return false
 	}
 
 	if len(hash) == 60 {
@@ -269,7 +288,7 @@ func CompareHashAndPassword(hash, password string) bool {
 		return err == nil
 	}
 
-	log.Error().Str("hash", hash).Msg("Invalid hash length. Expecting 64 or 60 characters.")
+	log.Error().Int("length", len(hash)).Msg("Invalid hash length. Expecting 60 characters.")
 
 	return false
 }

--- a/internal/auth/users_test.go
+++ b/internal/auth/users_test.go
@@ -182,3 +182,29 @@ func TestSigningKeyCoversLinkedAccounts(t *testing.T) {
 	require.NotEqual(t, base, tokenFor("someone-else", "amir@example.com"), "changing github must rotate sessions")
 	require.NotEqual(t, base, tokenFor("amir20", "other@example.com"), "changing email must rotate sessions")
 }
+
+// A sha256 hash used to be a supported format, and the length check used to
+// accept one long after CompareHashAndPassword stopped comparing it. That
+// combination loads clean and then refuses at the first login attempt, which is
+// an unauthenticated request. Reject it at load instead.
+func TestSha256PasswordHashIsRejected(t *testing.T) {
+	_, err := ReadUsersFromFile(writeUsers(t, `
+users:
+  amir:
+    email: amir@example.com
+    password: 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+`))
+	require.ErrorContains(t, err, "amir")
+	require.ErrorContains(t, err, "sha256")
+	require.ErrorContains(t, err, "dozzle generate", "the error has to say how to fix the file")
+	require.ErrorContains(t, err, "GHSA-w7qr-q9fh-fj35")
+}
+
+// The comparison runs on an unauthenticated request, so a hash it cannot handle
+// has to fail the login rather than take the process down. A users.yml reload
+// can also put one in front of this long after startup.
+func TestCompareHashAndPasswordRefusesSha256WithoutExiting(t *testing.T) {
+	require.False(t, CompareHashAndPassword("5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8", "password"))
+	require.False(t, CompareHashAndPassword("too-short", "password"))
+	require.True(t, CompareHashAndPassword("$2y$11$pTGu6dnTT7Uh3ob7uC6X7OkAamlhHpJ0/mEbsmiPyO85pumillZme", "password"))
+}


### PR DESCRIPTION
## Problem

`CompareHashAndPassword` has called `log.Fatal()` on a 64-character hash since #4429, but `decodeUsersFromFile` still accepts 64 characters as a valid password hash length.

As a result, a `users.yml` created before the bcrypt switch loads successfully, and the failure only happens on the first login attempt instead of at startup.

The login request is `POST /api/token`, which is registered outside `RequireAuthentication`. The check is based on the hash length rather than the supplied password, so the process exits before any password comparison takes place.

This means:

* A wrong password still crashes the process.
* An empty password still crashes the process.
* Knowing a username is enough to trigger the crash.
* `admin` is a likely username to guess.

The more likely scenario is an operator upgrading from v9. Dozzle starts without errors, the login page renders a password form because `AnyPassword` only checks whether the hash is non-empty, and the container dies as soon as the user submits the form.

With `restart: unless-stopped`, this results in a crash loop, with nothing in the logs pointing to `users.yml`.

## Reproduction

Use a `users.yml` containing a pre-bcrypt SHA-256 hash:

```yaml
users:
  admin:
    name: Admin
    password: 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
```

Dozzle starts normally.

Then, without a session:

```bash
curl -X POST localhost:8080/api/token -d 'username=admin&password=anything'
```

The process exits with:

```json
{"level":"fatal","message":"sha256 passwords are no longer supported. Please use bcrypt. ..."}
```

Exit code: `1`

## Fix

Reject the SHA-256 hash in `decodeUsersFromFile`, where `main.go` already converts loader errors into a startup failure that identifies the users file.

The error should clearly explain how to regenerate the password hash:

```text
Could not read users file: ./data/users.yml
  user admin has a sha256 password hash, which is no longer supported:
  regenerate it with `dozzle generate` to get a bcrypt hash, see
  https://github.com/amir20/dozzle/security/advisories/GHSA-w7qr-q9fh-fj35
```

`CompareHashAndPassword` should also return `false` instead of exiting the process.

The loader makes that branch unreachable for a valid users file loaded at startup. However, `CompareHashAndPassword` can still receive a new hash through an unauthenticated request, and `readFileIfChanged` can introduce a new hash long after startup.

In those cases, an invalid hash should cause the login to fail rather than terminate the process. This is consistent with the reasoning already captured in `TestReloadFailureFailsClosed`.

The invalid-length log should record the hash length rather than the hash itself, so password hashes are never written to the logs.

## Tests

Two tests were added. Both currently fail on master:

* `TestSha256PasswordHashIsRejected`

  * Covers the users file loader.
  * Verifies that the error identifies the affected user.
  * Verifies that the message mentions `dozzle generate`.
  * Verifies that the security advisory is included.

* `TestCompareHashAndPasswordRefusesSha256WithoutExiting`

  * Covers SHA-256 hashes.
  * Covers short/invalid hashes.
  * Covers a valid bcrypt hash.
  * Verifies that invalid hashes do not terminate the process.

`go test -race ./...` passes with the fix.

## Not Included

No documentation changes are included.

There is currently nothing under `docs/` that mentions the SHA-256 password removal. A migration note would be useful, but it would require the four translations and a `sourceHash` restamp, so that felt better suited for a separate PR.

For now, the error message provides the required migration instructions.
