### PR TITLE
feat: add oidc auth provider that reads users and roles from the token

### DIFF
--- a/assets/components/shell/Links.vue
+++ b/assets/components/shell/Links.vue
@@ -61,7 +61,7 @@
             </div>
           </div>
 
-          <template v-if="config.authProvider === 'simple' || config.logoutUrl">
+          <template v-if="hasSession || config.logoutUrl">
             <div class="bg-base-content/10 my-1.5 h-px"></div>
             <button
               @click.prevent="logout()"
@@ -79,6 +79,10 @@
 <script lang="ts" setup>
 const { mounted: cloudSurfaceMounted } = useCloudSurface();
 const { logoutUrl } = config;
+
+// simple and oidc hold a session cookie Dozzle issued, so logging out means
+// clearing it. Forward proxy has none: the logout URL is the whole logout there.
+const hasSession = config.authProvider === "simple" || config.authProvider === "oidc";
 
 // The bell is the only place that watches for a fire the reader has not seen, so
 // it owns the polling. Without a cloud link there is nothing to remember and
@@ -101,13 +105,17 @@ watch(visibility, (state) => {
 });
 
 async function logout() {
-  if (logoutUrl) {
-    location.href = logoutUrl;
-  } else {
+  if (hasSession) {
     await fetch(withBase("/api/token"), {
       method: "DELETE",
     });
+  }
 
+  // Under oidc the URL is where to go once the session is gone, usually the
+  // issuer's own logout, so it runs after the DELETE rather than instead of it.
+  if (logoutUrl) {
+    location.href = logoutUrl;
+  } else {
     location.reload();
   }
 }

--- a/assets/stores/config.ts
+++ b/assets/stores/config.ts
@@ -10,7 +10,7 @@ export interface Config {
   hostname: string;
   mode: "server" | "swarm" | "k8s";
   hosts: Host[];
-  authProvider: "simple" | "none" | "forward-proxy";
+  authProvider: "simple" | "none" | "forward-proxy" | "oidc";
   oauthProviders?: { name: string; loginUrl: string; icon: string }[];
   passwordLogin?: boolean;
   logoutUrl?: string;

--- a/docs/.vitepress/locales/de.ts
+++ b/docs/.vitepress/locales/de.ts
@@ -38,6 +38,7 @@ export const de: Labels = {
     authentication: "Authentifizierung",
     "authentication/simple": "Einfach (users.yml)",
     "authentication/oauth": "GitHub & OIDC",
+    "authentication/oidc": "OpenID Connect",
     "authentication/forward-proxy": "Forward Proxy",
     actions: "Aktionen",
     "app-icons": "Symbole",

--- a/docs/.vitepress/locales/en.ts
+++ b/docs/.vitepress/locales/en.ts
@@ -38,6 +38,7 @@ export const en: Labels = {
     authentication: "Authentication",
     "authentication/simple": "Simple (users.yml)",
     "authentication/oauth": "GitHub & OIDC",
+    "authentication/oidc": "OpenID Connect",
     "authentication/forward-proxy": "Forward Proxy",
     actions: "Actions",
     "app-icons": "Icons",

--- a/docs/.vitepress/locales/es.ts
+++ b/docs/.vitepress/locales/es.ts
@@ -38,6 +38,7 @@ export const es: Labels = {
     authentication: "Autenticación",
     "authentication/simple": "Simple (users.yml)",
     "authentication/oauth": "GitHub y OIDC",
+    "authentication/oidc": "OpenID Connect",
     "authentication/forward-proxy": "Proxy inverso",
     actions: "Acciones",
     "app-icons": "Iconos",

--- a/docs/.vitepress/locales/fr.ts
+++ b/docs/.vitepress/locales/fr.ts
@@ -38,6 +38,7 @@ export const fr: Labels = {
     authentication: "Authentification",
     "authentication/simple": "Simple (users.yml)",
     "authentication/oauth": "GitHub et OIDC",
+    "authentication/oidc": "OpenID Connect",
     "authentication/forward-proxy": "Proxy d'authentification",
     actions: "Actions",
     "app-icons": "Icônes",

--- a/docs/.vitepress/locales/structure.ts
+++ b/docs/.vitepress/locales/structure.ts
@@ -29,7 +29,7 @@ export const SECTIONS: Section[] = [
     items: [
       {
         slug: "authentication",
-        items: ["authentication/simple", "authentication/oauth", "authentication/forward-proxy"],
+        items: ["authentication/simple", "authentication/oauth", "authentication/oidc", "authentication/forward-proxy"],
       },
       { group: "containers", items: ["container-names", "container-groups", "container-links", "app-icons"] },
       { group: "hosts", items: ["agent", "remote-hosts", "hostname"] },

--- a/docs/.vitepress/locales/zh.ts
+++ b/docs/.vitepress/locales/zh.ts
@@ -38,6 +38,7 @@ export const zh: Labels = {
     authentication: "身份验证",
     "authentication/simple": "简单模式 (users.yml)",
     "authentication/oauth": "GitHub 与 OIDC",
+    "authentication/oidc": "OpenID Connect",
     "authentication/forward-proxy": "前置代理",
     actions: "操作",
     "app-icons": "图标",

--- a/docs/de/guide/authentication.md
+++ b/docs/de/guide/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Authentifizierung
-sourceHash: c0e3f963afbe
+sourceHash: 111fbadf1b7a
 ---
 
 # Authentifizierung
@@ -26,9 +26,10 @@ Dozzle hat Zugriff auf `docker.sock`, was — sofern nicht eingeschränkt — **
 | ------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [Simple](/de/guide/authentication/simple)               | Dozzle, in `users.yml`   | Du hast keine Authentifizierungslösung und möchtest, dass Dozzle die Anmeldungen übernimmt.                                                                  |
 | [GitHub & OIDC](/de/guide/authentication/oauth)         | Dozzle, in `users.yml`   | Du möchtest, dass sich dieselben Benutzer aus `users.yml` mit GitHub, Google, Keycloak, Pocket ID, Zitadel oder Authentik anmelden statt mit einem Passwort. |
+| [OpenID Connect](/de/guide/authentication/oidc)         | Dein Identity Provider   | Du möchtest, dass Keycloak, Authentik, Zitadel oder Pocket ID die Benutzerliste besitzt, mit Rollen und Filtern aus dem Token und ohne `users.yml`.          |
 | [Forward Proxy](/de/guide/authentication/forward-proxy) | Dein Proxy               | Du betreibst bereits Authelia, Authentik, Cloudflare Access oder Ähnliches und möchtest, dass es die Authentifizierung vollständig übernimmt.                |
 
-Simple und OAuth sind derselbe Anbieter: `users.yml` ist in beiden Fällen die Benutzerliste, und OAuth ergänzt nur einen zweiten Weg, um nachzuweisen, dass du einer der Benutzer darin bist. Der Forward Proxy ist der eigenständige Weg, und er ist die richtige Wahl, wenn du organisations- oder domainweite Zugriffsregeln brauchst, was `users.yml` bewusst nicht kann.
+Simple und OAuth sind derselbe Anbieter: `users.yml` ist in beiden Fällen die Benutzerliste, und OAuth ergänzt nur einen zweiten Weg, um nachzuweisen, dass du einer der Benutzer darin bist. OpenID Connect und Forward Proxy sind die eigenständigen Wege, bei denen etwas außerhalb von Dozzle die Benutzer besitzt. Nimm `oidc`, wenn dein Identity Provider Rollen in das Token schreiben kann, und den Forward Proxy, wenn du organisations- oder domainweite Zugriffsregeln brauchst, die vor Dozzle durchgesetzt werden, was `users.yml` bewusst nicht kann.
 
 ## <Icon icon="mdi:file-document-edit-outline" inline /> users.yml erzeugen
 

--- a/docs/de/guide/authentication/oauth.md
+++ b/docs/de/guide/authentication/oauth.md
@@ -1,6 +1,6 @@
 ---
 title: Mit GitHub & OIDC anmelden
-sourceHash: 7e8f4dfb70fa
+sourceHash: cfb7126acb65
 ---
 
 # <Icon icon="mdi:shield-account" inline /> Mit GitHub & OIDC anmelden
@@ -10,6 +10,9 @@ Dozzle kann Benutzer sich mit einem externen Konto anmelden lassen, statt ein Pa
 Das hat eine Konsequenz, die gleich vorweg gesagt sein will: **`users.yml` ist die Zugriffsliste.** Ein externes Konto, mit dem kein Eintrag verknüpft ist, kann sich nicht anmelden, und es wird nie automatisch ein Konto angelegt.
 
 Die Anmeldung mit Passwort funktioniert weiterhin daneben, was wichtig ist, wenn eine OAuth-App kaputtgeht und du hereinkommen musst, um sie zu reparieren.
+
+> [!TIP]
+> Wenn du lieber den Identity Provider die Benutzerliste besitzen lässt, mit Rollen und Filtern aus dem Token und ganz ohne `users.yml`, ist das ein eigener Anbieter: siehe [OpenID Connect](/de/guide/authentication/oidc).
 
 ## Mit GitHub anmelden
 
@@ -141,6 +144,8 @@ Die E-Mail-Adresse muss von deinem Anbieter als verifiziert markiert sein. Dozzl
 
 > [!NOTE]
 > GitHub gleicht über den Login ab und OIDC über die E-Mail-Adresse, und dieser Unterschied ist Absicht. Ein GitHub-Login ist stabil und immer vorhanden, während eine GitHub-E-Mail-Adresse privat sein oder geändert werden kann. Bei OIDC gibt es kein stabiles, menschenlesbares Gegenstück, also ist die verifizierte E-Mail-Adresse das Merkmal, das Betreiber tatsächlich kennen.
+
+In diesem Modus weist der Anbieter nur nach, wer du bist. Rollen und Filter kommen weiterhin aus `users.yml`, und ein Benutzer, den die Datei nicht auflistet, kann sich nicht anmelden, egal wie viele Rollen das Token trägt. Damit der Anbieter beides entscheidet, nimm stattdessen [`--auth-provider oidc`](/de/guide/authentication/oidc).
 
 ### Google
 

--- a/docs/de/guide/authentication/oidc.md
+++ b/docs/de/guide/authentication/oidc.md
@@ -1,0 +1,160 @@
+---
+title: OpenID Connect
+sourceHash: 9dcc3df4a715
+---
+
+# <Icon icon="mdi:shield-account" inline /> OpenID Connect
+
+Mit `--auth-provider oidc` ist dein Identity Provider die Benutzerdatenbank. Dozzle liest `users.yml` in diesem Modus nie: Wer ein Benutzer ist, welche Rollen er hat und welche Container er sehen darf, kommt alles aus dem OpenID-Connect-Token. Lege in Keycloak, Authentik, Zitadel oder Pocket ID einen Benutzer an und er kann sich anmelden; entferne seine Rolle und er kann es nicht mehr.
+
+Das ist etwas anderes als die [Anmeldung von `users.yml`-Benutzern über OIDC](/de/guide/authentication/oauth#mit-oidc-anmelden) beim Anbieter `simple`. Dort weist der Anbieter nur nach, wer du bist, und `users.yml` entscheidet weiterhin, was du bekommst. Nimm `simple`, wenn du jeden Benutzer von Hand auflisten willst, und `oidc`, wenn der Anbieter die Liste besitzen soll.
+
+## Minimale Konfiguration
+
+Registriere Dozzle bei deinem Anbieter als vertraulichen Client und setze die Redirect-URI auf:
+
+```
+https://your-dozzle-host/api/auth/callback
+```
+
+Nimm den Basispfad mit auf, falls Dozzle unter einem läuft, zum Beispiel `https://example.com/dozzle/api/auth/callback`. Zeig Dozzle dann den Issuer:
+
+::: code-group
+
+```sh [cli]
+$ docker run -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/dozzle/data:/data -p 8080:8080 amir20/dozzle --auth-provider oidc --auth-oidc-issuer https://keycloak.example.com/realms/main --auth-oidc-client-id dozzle --auth-oidc-client-secret secret
+```
+
+```yaml [docker-compose.yml]
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /path/to/dozzle/data:/data
+    ports:
+      - 8080:8080
+    environment:
+      DOZZLE_AUTH_PROVIDER: oidc
+      DOZZLE_AUTH_OIDC_ISSUER: https://keycloak.example.com/realms/main
+      DOZZLE_AUTH_OIDC_CLIENT_ID: dozzle
+      DOZZLE_AUTH_OIDC_CLIENT_SECRET: secret
+```
+
+:::
+
+Das ist schon alles. Für die gängigen Layouts müssen keine Claim-Pfade gesetzt werden, und `DOZZLE_AUTH_OIDC_NAME` ändert nur die Beschriftung des Anmeldebuttons. Das Client Secret akzeptiert ebenfalls ein Gegenstück mit `_FILE`, siehe [Docker Secrets verwenden](/de/guide/authentication/oauth#docker-secrets-fur-das-client-secret-verwenden).
+
+Die Issuer-URL ist die, unter der `/.well-known/openid-configuration` ausgeliefert wird. Dozzle holt sich dieses Dokument, um die Endpunkte für Authorization, Token und Userinfo zu finden, und startet den Ablauf gar nicht erst, wenn das Dokument einen anderen Issuer nennt als den, den du konfiguriert hast.
+
+## Rollen
+
+Die Rollen eines Benutzers werden aus dem Token gelesen. Dozzle probiert diese Claims der Reihe nach und nimmt den ersten, der vorhanden ist:
+
+1. `dozzle_roles`
+2. `resource_access.<client-id>.roles`
+3. `roles`
+
+Die Client-ID ist bereits konfiguriert, mit `DOZZLE_AUTH_OIDC_CLIENT_ID=dozzle` lautet der zweite Pfad also `resource_access.dozzle.roles`, und genau dort legt Keycloak Client-Rollen ab. Für dieses Layout muss nichts weiter gesetzt werden.
+
+Liegen deine Rollen woanders, ersetzt `DOZZLE_AUTH_OIDC_ROLES_CLAIM` die Suche durch den einen punktgetrennten Pfad, den du angibst:
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: realm_access.roles
+```
+
+Jeder Claim wird zuerst im ID-Token und dann in der Userinfo-Antwort gesucht, es spielt also keine Rolle, in welchem von beiden dein Anbieter ihn unterbringt. Drei Formen werden akzeptiert: ein Array aus Strings, ein einzelner durch Kommas oder Leerzeichen getrennter String und ein Objekt, dessen Schlüssel die Rollen sind, denn so kodiert Zitadel Projektrollen.
+
+Die Rollennamen sind dieselben wie in `users.yml`: `shell`, `actions`, `download`, `notifications`, `cloud` und `all`, mit `^` zum Ausschließen, `all,^shell` gewährt also alles außer Shell-Zugriff. Namen mit dem Präfix `dozzle_` werden ebenfalls akzeptiert, was hilft, wenn der Anbieter einen Rollen-Claim für mehrere Anwendungen gemeinsam nutzt. Unter [Rollen](/de/guide/authentication/simple#bestimmte-rollen-fur-benutzer-setzen) steht, was jede einzelne freischaltet.
+
+> [!WARNING]
+> `groups` steht bewusst nicht auf der Liste. Bei Authentik oder Google gehört jeder Benutzer zu mindestens einer Gruppe, eine Suche dort würde also aus „abgelehnt“ ein „angemeldet und darf jeden Container lesen“ machen. Wenn Gruppen das sind, was du hast, bilde sie beim Anbieter auf einen Claim `dozzle_roles` ab, siehe die Beispiele unten.
+
+### Wenn eine Anmeldung abgelehnt wird
+
+Die Anmeldung wird abgelehnt, wenn keiner der Claims vorhanden ist oder wenn der erste vorhandene leer ist. Das Log nennt die Pfade, die probiert wurden:
+
+```
+WRN OIDC login rejected: no roles claim found in the ID token or userinfo, or it was empty sub=... tried="dozzle_roles, resource_access.dozzle.roles, roles"
+```
+
+Ein Claim, der vorhanden ist, aber nichts enthält, was Dozzle als Rolle erkennt, ist etwas anderes. Dieser Benutzer meldet sich ohne Rechte an, genau wie mit `roles: none` in `users.yml`: Er kann die Logs der Container lesen, die sein Filter erlaubt, und sonst nichts. Keycloak-Realm-Rollen verhalten sich so, weil dort jeder Benutzer `offline_access` und `uma_authorization` trägt, weshalb die Beispiele unten stattdessen Client-Rollen verwenden.
+
+## Filter
+
+Container-Filter funktionieren genauso, gelesen aus dem ersten von `dozzle_filters`, `resource_access.<client-id>.filters` und `filters`, der vorhanden ist, oder aus dem einen Pfad in `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`. Jeder Wert ist ein Filter in [derselben Syntax wie in `users.yml`](/de/guide/authentication/simple#bestimmte-filter-fur-benutzer-setzen), zum Beispiel `label=com.example.app` oder `name=web`:
+
+```json
+"resource_access": {
+  "dozzle": {
+    "roles": ["shell", "actions"],
+    "filters": ["label=com.example.app"]
+  }
+}
+```
+
+Ein Benutzer ohne Filter-Claim sieht jeden Container, den die Dozzle-Instanz sieht. Ein Filter, der sich nicht parsen lässt, lässt die Anmeldung fehlschlagen, statt verworfen zu werden, ein Tippfehler beim Anbieter kann also nicht stillschweigend erweitern, was jemand sieht.
+
+## Identität
+
+Der Claim `sub` ist die stabile ID des Benutzers. Er ist der Schlüssel für das Profilverzeichnis unter `/data`, Einstellungen folgen der Person also auch dann, wenn sich ihr Benutzername oder ihre E-Mail-Adresse beim Anbieter ändert. Der im Menü angezeigte Name ist `name`, mit Rückfall auf `preferred_username`, dann `email`, dann `sub`. `email` und `picture` speisen den Avatar, und eine `picture`-URL wird direkt verwendet, wenn der Anbieter eine schickt.
+
+Anders als beim Anbieter `simple` muss die E-Mail-Adresse hier nicht verifiziert sein. Sie wird nur angezeigt und nie mit etwas abgeglichen, ein Issuer, der keinen E-Mail-Scope gewährt, funktioniert also problemlos.
+
+## Sitzungen
+
+Nach der Anmeldung stellt Dozzle sein eigenes Sitzungs-Cookie aus, das die Rollen und Filter trägt, die es aus dem Token gelesen hat. Sie werden bei jeder Anfrage angewendet, aber nicht erneut abgerufen: Eine Rollenänderung beim Anbieter wirkt erst bei der nächsten Anmeldung des Benutzers. Wenn diese Lücke stört, setze [`--auth-ttl`](/de/guide/supported-env-vars) auf etwas wie `8h`, damit Sitzungen ablaufen und mit einem frischen Token neu aufgebaut werden.
+
+## Abmelden
+
+Beim Abmelden wird Dozzles Sitzung gelöscht. Ist `--auth-logout-url` gesetzt, wird der Browser anschließend dorthin geschickt. Zeig damit auf die End-Session-URL deines Anbieters, um den Benutzer auch beim Anbieter abzumelden:
+
+```yaml
+DOZZLE_AUTH_LOGOUT_URL: https://keycloak.example.com/realms/main/protocol/openid-connect/logout
+```
+
+## Was sich von `simple` unterscheidet
+
+Beide Anbieter teilen sich die Flags `--auth-oidc-*`, der Unterschied zeigt sich also im Verhalten:
+
+- `users.yml` wird nie gelesen. Liegt eine unter `/data`, protokolliert Dozzle, dass es sie ignoriert.
+- Es gibt kein Passwortformular und keinen Endpunkt `/api/token`. Der Identity Provider ist der einzige Weg hinein, eine falsche Callback-URL oder ein abgelaufenes Client Secret sperrt also alle aus, bis es behoben ist.
+- `--auth-github-*` ist ein Fehler beim Start. GitHub ist kein OpenID-Connect-Issuer und veröffentlicht keine Claims, aus denen sich Rollen lesen ließen.
+- Beim Start werden der Issuer und die Claim-Pfade protokolliert, aus denen die Rollen gelesen werden.
+
+## Beispiele für Anbieter
+
+### Keycloak
+
+Lege in deinem Realm einen Client `dozzle` mit eingeschalteter Client-Authentifizierung an und trage die Redirect-URI von oben ein. Erstelle dann im Tab **Roles** des Clients die Client-Rollen, die du vergeben willst: `shell`, `actions`, `download`, `notifications`, `cloud` oder `all`. Weise sie unter **Role mapping** Benutzern oder Gruppen zu.
+
+Keycloak gibt Client-Rollen als `resource_access.<client-id>.roles` aus, wo Dozzle ohnehin sucht. Öffne unter den **Client scopes** des Clients den dedizierten Scope und prüfe, dass der Mapper **client roles** den Claim dem ID-Token oder der Userinfo hinzufügt; Dozzle liest beide, aber nicht das Access-Token.
+
+Für Filter legst du ein Benutzerattribut `dozzle_filters` an sowie im dedizierten Scope einen Mapper **User Attribute** mit demselben Token-Claim-Namen und eingeschaltetem **Multivalued**. Jeder Wert ist ein Filter, etwa `label=com.example.app`.
+
+### Authentik
+
+Füge unter **Customization** → **Property Mappings** ein Scope Mapping hinzu, das die Rollen aus den Gruppen des Benutzers zurückgibt, und hänge es an den Dozzle-Provider:
+
+```python
+roles = []
+if request.user.ak_groups.filter(name="dozzle-admins").exists():
+    roles.append("all")
+elif request.user.ak_groups.filter(name="dozzle-users").exists():
+    roles.append("download")
+return {"dozzle_roles": roles}
+```
+
+Ein Benutzer, der in keiner der beiden Gruppen ist, bekommt eine leere Liste und wird abgelehnt.
+
+### Zitadel
+
+Gib Benutzern Projektrollen, die nach den Dozzle-Rollen benannt sind, und aktiviere **Assert Roles on Authentication** an der Anwendung. Zitadels Rollen-Claim ist ein Objekt mit den Rollennamen als Schlüssel, was Dozzle akzeptiert, setze also:
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: urn:zitadel:iam:org:project:roles
+```
+
+### Google
+
+Googles Tokens enthalten keinen Rollen-Claim, `oidc` lässt sich also nicht damit verwenden. Nimm stattdessen den [Anbieter `simple` mit Google-Anmeldung](/de/guide/authentication/oauth#google), bei dem `users.yml` entscheidet, wer hereinkommt.

--- a/docs/de/guide/supported-env-vars.md
+++ b/docs/de/guide/supported-env-vars.md
@@ -1,6 +1,6 @@
 ---
 title: Umgebungsvariablen und Unterbefehle
-sourceHash: 3b46b35a4f0e
+sourceHash: a9818d761eb6
 ---
 
 # Globale Umgebungsvariablen
@@ -28,6 +28,8 @@ Die Konfiguration erfolgt über Optionen oder Umgebungsvariablen. Die Tabelle un
 | `--auth-oidc-client-id`       | `DOZZLE_AUTH_OIDC_CLIENT_ID`       | `""`              |
 | `--auth-oidc-client-secret`   | `DOZZLE_AUTH_OIDC_CLIENT_SECRET`   | `""`              |
 | `--auth-oidc-name`            | `DOZZLE_AUTH_OIDC_NAME`            | `SSO`             |
+| `--auth-oidc-roles-claim`     | `DOZZLE_AUTH_OIDC_ROLES_CLAIM`     | `""`              |
+| `--auth-oidc-filters-claim`   | `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`   | `""`              |
 | `--enable-actions`            | `DOZZLE_ENABLE_ACTIONS`            | `false`           |
 | `--enable-shell`              | `DOZZLE_ENABLE_SHELL`              | `false`           |
 | `--enable-mcp`                | `DOZZLE_ENABLE_MCP`                | `false`           |
@@ -46,6 +48,9 @@ Die Konfiguration erfolgt über Optionen oder Umgebungsvariablen. Die Tabelle un
 
 > [!TIP]
 > `DOZZLE_AUTH_GITHUB_CLIENT_SECRET` und `DOZZLE_AUTH_OIDC_CLIENT_SECRET` akzeptieren auch ein Gegenstück mit `_FILE`, das eine Datei benennt, aus der der Wert gelesen wird, zur Nutzung mit [Docker Secrets](/de/guide/authentication/oauth#docker-secrets-fur-das-client-secret-verwenden).
+
+> [!TIP]
+> `DOZZLE_AUTH_OIDC_ROLES_CLAIM` und `DOZZLE_AUTH_OIDC_FILTERS_CLAIM` gelten nur für [`--auth-provider oidc`](/de/guide/authentication/oidc) und werden nur gebraucht, wenn die Claims an einer Stelle liegen, an der die Standardsuche nicht nachsieht.
 
 > [!TIP]
 > Manche Optionen wie `--remote-host` oder `--remote-agent` lassen sich mehrfach angeben. Zum Beispiel `--remote-agent 167.99.1.1:7007 --remote-agent 167.99.1.2:7007` oder kommagetrennt `DOZZLE_REMOTE_AGENT=167.99.1.1:7007,167.99.1.2:7007`.

--- a/docs/es/guide/authentication.md
+++ b/docs/es/guide/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Autenticación
-sourceHash: c0e3f963afbe
+sourceHash: 111fbadf1b7a
 ---
 
 # Autenticación
@@ -26,9 +26,10 @@ Dozzle tiene acceso a `docker.sock`, lo que, salvo que lo restrinjas, equivale a
 | ------------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Simple](/es/guide/authentication/simple)               | Dozzle, en `users.yml`      | No tienes ninguna solución de autenticación y quieres que Dozzle se encargue de los inicios de sesión.                                                     |
 | [GitHub y OIDC](/es/guide/authentication/oauth)         | Dozzle, en `users.yml`      | Quieres que los mismos usuarios de `users.yml` inicien sesión con GitHub, Google, Keycloak, Pocket ID, Zitadel o Authentik en lugar de con una contraseña. |
+| [OpenID Connect](/es/guide/authentication/oidc)         | Tu proveedor de identidad   | Quieres que Keycloak, Authentik, Zitadel o Pocket ID sean los dueños de la lista de usuarios, con roles y filtros leídos del token y sin `users.yml`.      |
 | [Forward proxy](/es/guide/authentication/forward-proxy) | Tu proxy                    | Ya usas Authelia, Authentik, Cloudflare Access o algo similar, y quieres que se encargue por completo de la autenticación.                                 |
 
-Simple y OAuth son el mismo proveedor: `users.yml` es la lista de usuarios en los dos casos, y OAuth solo añade una segunda forma de demostrar que eres uno de los usuarios que hay en ella. El forward proxy es el que va aparte, y es la opción correcta cuando necesitas reglas de acceso por organización o por dominio, algo que `users.yml` deliberadamente no hace.
+Simple y OAuth son el mismo proveedor: `users.yml` es la lista de usuarios en los dos casos, y OAuth solo añade una segunda forma de demostrar que eres uno de los usuarios que hay en ella. OpenID Connect y el forward proxy son los que van aparte: en ellos algo externo a Dozzle es el dueño de los usuarios. Elige `oidc` cuando tu proveedor de identidad pueda poner los roles en el token, y el forward proxy cuando necesites reglas de acceso por organización o por dominio aplicadas delante de Dozzle, algo que `users.yml` deliberadamente no hace.
 
 ## <Icon icon="mdi:file-document-edit-outline" inline /> Generar users.yml
 

--- a/docs/es/guide/authentication/oauth.md
+++ b/docs/es/guide/authentication/oauth.md
@@ -1,6 +1,6 @@
 ---
 title: Iniciar sesión con GitHub y OIDC
-sourceHash: 7e8f4dfb70fa
+sourceHash: cfb7126acb65
 ---
 
 # <Icon icon="mdi:shield-account" inline /> Iniciar sesión con GitHub y OIDC
@@ -10,6 +10,9 @@ Dozzle puede permitir que los usuarios inicien sesión con una cuenta externa en
 Eso tiene una consecuencia que conviene dejar clara desde el principio: **`users.yml` es la lista de permitidos.** Una cuenta externa que no esté vinculada a ninguna entrada no puede iniciar sesión, y nunca se crea ninguna cuenta de forma automática.
 
 El inicio de sesión con contraseña sigue funcionando en paralelo, algo que importa cuando una OAuth App se rompe y necesitas entrar para arreglarla.
+
+> [!TIP]
+> Si prefieres que el proveedor de identidad sea el dueño de la lista de usuarios, con roles y filtros leídos del token y sin ningún `users.yml`, eso es un proveedor aparte: consulta [OpenID Connect](/es/guide/authentication/oidc).
 
 ## Iniciar sesión con GitHub
 
@@ -141,6 +144,8 @@ Tu proveedor tiene que marcar ese correo como verificado. Dozzle rechaza el inic
 
 > [!NOTE]
 > GitHub identifica por el login y OIDC por el correo, y esa diferencia es intencionada. Un login de GitHub es estable y siempre está presente, mientras que el correo de GitHub puede ser privado o cambiar. OIDC no tiene un equivalente estable y legible por personas, así que el correo verificado es el dato que los administradores conocen de verdad.
+
+En este modo el proveedor solo demuestra quién eres. Los roles y los filtros siguen saliendo de `users.yml`, y un usuario que no esté en el archivo no puede iniciar sesión por muchos roles que lleve el token. Para que el proveedor decida las dos cosas, usa [`--auth-provider oidc`](/es/guide/authentication/oidc) en su lugar.
 
 ### Google
 

--- a/docs/es/guide/authentication/oidc.md
+++ b/docs/es/guide/authentication/oidc.md
@@ -1,0 +1,160 @@
+---
+title: OpenID Connect
+sourceHash: 9dcc3df4a715
+---
+
+# <Icon icon="mdi:shield-account" inline /> OpenID Connect
+
+Con `--auth-provider oidc`, tu proveedor de identidad es la base de datos de usuarios. En este modo Dozzle nunca lee `users.yml`: quién es un usuario, qué roles tiene y qué contenedores puede ver salen todos del token de OpenID Connect. Añade un usuario en Keycloak, Authentik, Zitadel o Pocket ID y podrá iniciar sesión; quítale el rol y ya no podrá.
+
+Esto es distinto de [iniciar sesión con OIDC con los usuarios de `users.yml`](/es/guide/authentication/oauth#iniciar-sesion-con-oidc) bajo el proveedor `simple`. Ahí el proveedor solo demuestra quién eres y `users.yml` sigue decidiendo qué obtienes. Elige `simple` cuando quieras listar cada usuario a mano, y `oidc` cuando el proveedor deba ser el dueño de la lista.
+
+## Configuración mínima
+
+Registra Dozzle como cliente confidencial en tu proveedor y pon la redirect URI en:
+
+```
+https://your-dozzle-host/api/auth/callback
+```
+
+Incluye la ruta base si Dozzle se ejecuta bajo una, por ejemplo `https://example.com/dozzle/api/auth/callback`. Después apunta Dozzle al issuer:
+
+::: code-group
+
+```sh [cli]
+$ docker run -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/dozzle/data:/data -p 8080:8080 amir20/dozzle --auth-provider oidc --auth-oidc-issuer https://keycloak.example.com/realms/main --auth-oidc-client-id dozzle --auth-oidc-client-secret secret
+```
+
+```yaml [docker-compose.yml]
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /path/to/dozzle/data:/data
+    ports:
+      - 8080:8080
+    environment:
+      DOZZLE_AUTH_PROVIDER: oidc
+      DOZZLE_AUTH_OIDC_ISSUER: https://keycloak.example.com/realms/main
+      DOZZLE_AUTH_OIDC_CLIENT_ID: dozzle
+      DOZZLE_AUTH_OIDC_CLIENT_SECRET: secret
+```
+
+:::
+
+Eso es todo. Para las disposiciones más habituales no hace falta configurar ninguna ruta de claim, y `DOZZLE_AUTH_OIDC_NAME` solo cambia la etiqueta del botón de inicio de sesión. El client secret también acepta una variante `_FILE`, consulta [Usar secretos de Docker](/es/guide/authentication/oauth#usar-secretos-de-docker-para-el-client-secret).
+
+La URL del issuer es la que sirve `/.well-known/openid-configuration`. Dozzle descarga ese documento para localizar los endpoints de autorización, token y userinfo, y se niega a iniciar el flujo si el documento indica un issuer distinto del que has configurado.
+
+## Roles
+
+Los roles de un usuario se leen del token. Dozzle prueba estos claims en orden y se queda con el primero que exista:
+
+1. `dozzle_roles`
+2. `resource_access.<client-id>.roles`
+3. `roles`
+
+El client id ya está configurado, así que con `DOZZLE_AUTH_OIDC_CLIENT_ID=dozzle` la segunda ruta es `resource_access.dozzle.roles`, que es donde Keycloak coloca los roles de cliente. Para esa disposición no hace falta configurar nada más.
+
+Si tus roles viven en otro sitio, `DOZZLE_AUTH_OIDC_ROLES_CLAIM` sustituye la búsqueda por la única ruta separada por puntos que le indiques:
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: realm_access.roles
+```
+
+Cada claim se busca primero en el ID token y después en la respuesta de userinfo, así que da igual en cuál de los dos lo ponga tu proveedor. Se aceptan tres formas: un array de cadenas, una única cadena separada por comas o espacios, y un objeto cuyas claves son los roles, que es como Zitadel codifica los roles de proyecto.
+
+Los nombres de rol son los mismos que en `users.yml`: `shell`, `actions`, `download`, `notifications`, `cloud` y `all`, con `^` para excluir, así que `all,^shell` concede todo excepto el acceso por shell. También se aceptan los nombres con prefijo `dozzle_`, lo que ayuda cuando el proveedor comparte un mismo claim de roles entre varias aplicaciones. Consulta [roles](/es/guide/authentication/simple#asignar-roles-especificos-a-los-usuarios) para ver qué desbloquea cada uno.
+
+> [!WARNING]
+> `groups` queda fuera de la lista a propósito. En Authentik o Google todos los usuarios pertenecen al menos a un grupo, así que buscar ahí convertiría "denegado" en "con sesión iniciada y puede leer todos los contenedores". Si lo que tienes son grupos, mapéalos a un claim `dozzle_roles` en el proveedor, consulta los ejemplos más abajo.
+
+### Cuando se rechaza un inicio de sesión
+
+El inicio de sesión se rechaza cuando no existe ninguno de los claims, o cuando el primero que existe está vacío. El log nombra las rutas que se han probado:
+
+```
+WRN OIDC login rejected: no roles claim found in the ID token or userinfo, or it was empty sub=... tried="dozzle_roles, resource_access.dozzle.roles, roles"
+```
+
+Un claim que está presente pero no contiene nada que Dozzle reconozca como rol es otra cosa. Ese usuario inicia sesión sin privilegios, igual que con `roles: none` en `users.yml`: puede leer los logs de los contenedores que permita su filtro, y nada más. Los roles de realm de Keycloak se comportan así, porque ahí todos los usuarios llevan `offline_access` y `uma_authorization`, y por eso los ejemplos de más abajo usan roles de cliente en su lugar.
+
+## Filtros
+
+Los filtros de contenedores funcionan de la misma manera: se leen del primero de `dozzle_filters`, `resource_access.<client-id>.filters` y `filters` que exista, o de la única ruta indicada en `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`. Cada valor es un filtro con la [misma sintaxis que `users.yml`](/es/guide/authentication/simple#asignar-filtros-especificos-a-los-usuarios), por ejemplo `label=com.example.app` o `name=web`:
+
+```json
+"resource_access": {
+  "dozzle": {
+    "roles": ["shell", "actions"],
+    "filters": ["label=com.example.app"]
+  }
+}
+```
+
+Un usuario sin claim de filtros ve todos los contenedores que ve la instancia de Dozzle. Un filtro que no se puede interpretar hace fallar el inicio de sesión en lugar de descartarse, así que una errata en el proveedor no puede ampliar en silencio lo que alguien ve.
+
+## Identidad
+
+El claim `sub` es el identificador estable del usuario. Es la clave del directorio de perfil bajo `/data`, así que los ajustes siguen a la persona aunque su nombre de usuario o su correo cambien en el proveedor. El nombre que se muestra en el menú es `name`, con `preferred_username` como alternativa, después `email` y por último `sub`. `email` y `picture` alimentan el avatar, y cuando el proveedor envía una URL en `picture` se usa directamente.
+
+A diferencia del proveedor `simple`, aquí el correo no tiene que estar verificado. Solo se muestra, nunca se compara con nada, así que un issuer que no conceda el scope de correo funciona sin problema.
+
+## Sesiones
+
+Tras iniciar sesión, Dozzle emite su propia cookie de sesión con los roles y los filtros que leyó del token. Se aplican en cada petición, pero no se vuelven a consultar: un cambio de rol en el proveedor tiene efecto en el siguiente inicio de sesión del usuario. Si ese margen importa, pon [`--auth-ttl`](/es/guide/supported-env-vars) en algo como `8h` para que las sesiones caduquen y se vuelvan a establecer a partir de un token nuevo.
+
+## Cerrar sesión
+
+Cerrar sesión borra la sesión de Dozzle. Si `--auth-logout-url` está definido, el navegador se envía después a esa URL, así que apúntala a la URL de fin de sesión de tu proveedor para cerrar también la sesión en el proveedor:
+
+```yaml
+DOZZLE_AUTH_LOGOUT_URL: https://keycloak.example.com/realms/main/protocol/openid-connect/logout
+```
+
+## Qué cambia respecto a `simple`
+
+Los dos proveedores comparten los flags `--auth-oidc-*`, así que la diferencia se nota en el comportamiento:
+
+- `users.yml` nunca se lee. Si existe uno bajo `/data`, Dozzle registra en el log que lo está ignorando.
+- No hay formulario de contraseña ni endpoint `/api/token`. El proveedor de identidad es la única forma de entrar, así que una URL de callback equivocada o un client secret caducado dejan a todo el mundo fuera hasta que se arregle.
+- `--auth-github-*` es un error de arranque. GitHub no es un issuer de OpenID Connect y no publica ningún claim del que leer roles.
+- Al arrancar se registran en el log el issuer y las rutas de claim de las que se leerán los roles.
+
+## Ejemplos por proveedor
+
+### Keycloak
+
+Crea un cliente `dozzle` en tu realm con la autenticación de cliente activada y añade la redirect URI de arriba. Después, en la pestaña **Roles** del cliente, crea los roles de cliente que quieras repartir: `shell`, `actions`, `download`, `notifications`, `cloud` o `all`. Asígnalos a usuarios o grupos en **Role mapping**.
+
+Keycloak emite los roles de cliente como `resource_access.<client-id>.roles`, que Dozzle ya busca. Revisa los **Client scopes** del cliente, abre el scope dedicado y confirma que el mapper **client roles** añade el claim al ID token o a userinfo; Dozzle lee los dos pero no el access token.
+
+Para los filtros, añade un atributo de usuario `dozzle_filters` y un mapper **User Attribute** en el scope dedicado con el mismo nombre de claim en el token y **Multivalued** activado. Cada valor es un filtro, como `label=com.example.app`.
+
+### Authentik
+
+Añade un scope mapping en **Customization** → **Property Mappings** que devuelva los roles a partir de los grupos del usuario, y asócialo al proveedor de Dozzle:
+
+```python
+roles = []
+if request.user.ak_groups.filter(name="dozzle-admins").exists():
+    roles.append("all")
+elif request.user.ak_groups.filter(name="dozzle-users").exists():
+    roles.append("download")
+return {"dozzle_roles": roles}
+```
+
+Un usuario que no esté en ninguno de los dos grupos recibe una lista vacía y se le rechaza.
+
+### Zitadel
+
+Concede a los usuarios roles de proyecto con los nombres de los roles de Dozzle y activa **Assert Roles on Authentication** en la aplicación. El claim de roles de Zitadel es un objeto cuyas claves son los nombres de rol, algo que Dozzle acepta, así que configura:
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: urn:zitadel:iam:org:project:roles
+```
+
+### Google
+
+Los tokens de Google no llevan ningún claim de roles, así que `oidc` no se puede usar con él. Usa en su lugar el [proveedor `simple` con inicio de sesión de Google](/es/guide/authentication/oauth#google), donde `users.yml` decide quién entra.

--- a/docs/es/guide/supported-env-vars.md
+++ b/docs/es/guide/supported-env-vars.md
@@ -1,6 +1,6 @@
 ---
 title: Variables de entorno y subcomandos
-sourceHash: 3b46b35a4f0e
+sourceHash: a9818d761eb6
 ---
 
 # Variables de entorno globales
@@ -28,6 +28,8 @@ La configuración se puede hacer con flags o con variables de entorno. La tabla 
 | `--auth-oidc-client-id`       | `DOZZLE_AUTH_OIDC_CLIENT_ID`       | `""`              |
 | `--auth-oidc-client-secret`   | `DOZZLE_AUTH_OIDC_CLIENT_SECRET`   | `""`              |
 | `--auth-oidc-name`            | `DOZZLE_AUTH_OIDC_NAME`            | `SSO`             |
+| `--auth-oidc-roles-claim`     | `DOZZLE_AUTH_OIDC_ROLES_CLAIM`     | `""`              |
+| `--auth-oidc-filters-claim`   | `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`   | `""`              |
 | `--enable-actions`            | `DOZZLE_ENABLE_ACTIONS`            | `false`           |
 | `--enable-shell`              | `DOZZLE_ENABLE_SHELL`              | `false`           |
 | `--enable-mcp`                | `DOZZLE_ENABLE_MCP`                | `false`           |
@@ -46,6 +48,9 @@ La configuración se puede hacer con flags o con variables de entorno. La tabla 
 
 > [!TIP]
 > `DOZZLE_AUTH_GITHUB_CLIENT_SECRET` y `DOZZLE_AUTH_OIDC_CLIENT_SECRET` también aceptan una variante `_FILE` que indica el archivo del que leer el valor, pensada para usarse con [secretos de Docker](/es/guide/authentication/oauth#usar-secretos-de-docker-para-el-client-secret).
+
+> [!TIP]
+> `DOZZLE_AUTH_OIDC_ROLES_CLAIM` y `DOZZLE_AUTH_OIDC_FILTERS_CLAIM` solo se aplican a [`--auth-provider oidc`](/es/guide/authentication/oidc), y solo hacen falta cuando los claims viven en un sitio donde la búsqueda por defecto no mira.
 
 > [!TIP]
 > Algunos flags como `--remote-host` o `--remote-agent` se pueden repetir. Por ejemplo, `--remote-agent 167.99.1.1:7007 --remote-agent 167.99.1.2:7007` o separados por comas con `DOZZLE_REMOTE_AGENT=167.99.1.1:7007,167.99.1.2:7007`.

--- a/docs/fr/guide/authentication.md
+++ b/docs/fr/guide/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: Authentification
-sourceHash: c0e3f963afbe
+sourceHash: 111fbadf1b7a
 ---
 
 # Authentification
@@ -22,13 +22,14 @@ Dozzle a accès à `docker.sock`, ce qui équivaut, sauf restriction, à un acc�
 
 ## <Icon icon="mdi:key-outline" inline /> Choisir une méthode
 
-| Méthode                                                 | Qui gère les utilisateurs | À utiliser quand                                                                                                                                                   |
-| ------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| [Simple](/fr/guide/authentication/simple)               | Dozzle, dans `users.yml`  | Vous n'avez pas de solution d'authentification et vous voulez que Dozzle gère les connexions.                                                                      |
-| [GitHub et OIDC](/fr/guide/authentication/oauth)        | Dozzle, dans `users.yml`  | Vous voulez que les mêmes utilisateurs de `users.yml` se connectent avec GitHub, Google, Keycloak, Pocket ID, Zitadel ou Authentik plutôt qu'avec un mot de passe. |
-| [Forward proxy](/fr/guide/authentication/forward-proxy) | Votre proxy               | Vous utilisez déjà Authelia, Authentik, Cloudflare Access ou équivalent, et vous voulez qu'il gère entièrement l'authentification.                                 |
+| Méthode                                                 | Qui gère les utilisateurs    | À utiliser quand                                                                                                                                                    |
+| ------------------------------------------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Simple](/fr/guide/authentication/simple)               | Dozzle, dans `users.yml`     | Vous n'avez pas de solution d'authentification et vous voulez que Dozzle gère les connexions.                                                                       |
+| [GitHub et OIDC](/fr/guide/authentication/oauth)        | Dozzle, dans `users.yml`     | Vous voulez que les mêmes utilisateurs de `users.yml` se connectent avec GitHub, Google, Keycloak, Pocket ID, Zitadel ou Authentik plutôt qu'avec un mot de passe.  |
+| [OpenID Connect](/fr/guide/authentication/oidc)         | Votre fournisseur d'identité | Vous voulez que Keycloak, Authentik, Zitadel ou Pocket ID possède la liste des utilisateurs, avec les rôles et les filtres lus depuis le token et sans `users.yml`. |
+| [Forward proxy](/fr/guide/authentication/forward-proxy) | Votre proxy                  | Vous utilisez déjà Authelia, Authentik, Cloudflare Access ou équivalent, et vous voulez qu'il gère entièrement l'authentification.                                  |
 
-Simple et OAuth sont le même fournisseur : `users.yml` est la liste des utilisateurs dans les deux cas, et OAuth ajoute seulement une deuxième façon de prouver que vous êtes l'un de ces utilisateurs. Le forward proxy est celui qui se distingue, et c'est le bon choix quand vous avez besoin de règles d'accès à l'échelle d'une organisation ou d'un domaine, ce que `users.yml` ne fait volontairement pas.
+Simple et OAuth sont le même fournisseur : `users.yml` est la liste des utilisateurs dans les deux cas, et OAuth ajoute seulement une deuxième façon de prouver que vous êtes l'un de ces utilisateurs. OpenID Connect et le forward proxy sont ceux qui se distinguent, avec quelque chose d'extérieur à Dozzle qui possède les utilisateurs. Choisissez `oidc` quand votre fournisseur d'identité peut mettre des rôles dans le token, et le forward proxy quand vous avez besoin de règles d'accès à l'échelle d'une organisation ou d'un domaine appliquées devant Dozzle, ce que `users.yml` ne fait volontairement pas.
 
 ## <Icon icon="mdi:file-document-edit-outline" inline /> Générer users.yml
 

--- a/docs/fr/guide/authentication/oauth.md
+++ b/docs/fr/guide/authentication/oauth.md
@@ -1,6 +1,6 @@
 ---
 title: Se connecter avec GitHub et OIDC
-sourceHash: 7e8f4dfb70fa
+sourceHash: cfb7126acb65
 ---
 
 # <Icon icon="mdi:shield-account" inline /> Se connecter avec GitHub et OIDC
@@ -10,6 +10,9 @@ Dozzle peut laisser les utilisateurs se connecter avec un compte externe au lieu
 Cela a une conséquence qui mérite d'être dite d'emblée : **`users.yml` est la liste d'autorisation.** Un compte externe auquel aucune entrée n'est liée ne peut pas se connecter, et aucun compte n'est jamais créé automatiquement.
 
 La connexion par mot de passe continue de fonctionner à côté, ce qui compte quand une OAuth App casse et qu'il faut pouvoir entrer pour la réparer.
+
+> [!TIP]
+> Si vous préférez que le fournisseur d'identité possède la liste des utilisateurs, avec les rôles et les filtres lus depuis le token et sans `users.yml` du tout, c'est un fournisseur à part entière : voir [OpenID Connect](/fr/guide/authentication/oidc).
 
 ## Se connecter avec GitHub
 
@@ -141,6 +144,8 @@ L'email doit être marqué comme vérifié par votre fournisseur. Dozzle refuse 
 
 > [!NOTE]
 > GitHub fait la correspondance sur le login et OIDC sur l'email, et cette différence est voulue. Un login GitHub est stable et toujours présent, alors qu'un email GitHub peut être privé ou changer. OIDC n'a pas d'équivalent stable et lisible par un humain, l'email vérifié est donc l'attribut que les administrateurs connaissent réellement.
+
+Dans ce mode, le fournisseur prouve seulement qui vous êtes. Les rôles et les filtres viennent toujours de `users.yml`, et un utilisateur que le fichier ne liste pas ne peut pas se connecter, quel que soit le nombre de rôles que porte le token. Pour que le fournisseur décide des deux, utilisez plutôt [`--auth-provider oidc`](/fr/guide/authentication/oidc).
 
 ### Google
 

--- a/docs/fr/guide/authentication/oidc.md
+++ b/docs/fr/guide/authentication/oidc.md
@@ -1,0 +1,160 @@
+---
+title: OpenID Connect
+sourceHash: 9dcc3df4a715
+---
+
+# <Icon icon="mdi:shield-account" inline /> OpenID Connect
+
+Avec `--auth-provider oidc`, votre fournisseur d'identité est la base des utilisateurs. Dozzle ne lit jamais `users.yml` dans ce mode : qui est un utilisateur, quels rôles il possède et quels conteneurs il peut voir viennent tous du token OpenID Connect. Ajoutez un utilisateur dans Keycloak, Authentik, Zitadel ou Pocket ID et il peut se connecter ; retirez-lui son rôle et il ne le peut plus.
+
+C'est différent de [connecter les utilisateurs de `users.yml` avec OIDC](/fr/guide/authentication/oauth#se-connecter-avec-oidc) sous le fournisseur `simple`. Là, le fournisseur prouve seulement qui vous êtes et c'est toujours `users.yml` qui décide de ce que vous obtenez. Choisissez `simple` quand vous voulez lister chaque utilisateur à la main, et `oidc` quand c'est le fournisseur qui doit posséder la liste.
+
+## Configuration minimale
+
+Enregistrez Dozzle comme client confidentiel auprès de votre fournisseur et réglez l'URI de redirection sur :
+
+```
+https://your-dozzle-host/api/auth/callback
+```
+
+Incluez le chemin de base si Dozzle tourne sous un chemin de base, par exemple `https://example.com/dozzle/api/auth/callback`. Pointez ensuite Dozzle sur l'émetteur :
+
+::: code-group
+
+```sh [cli]
+$ docker run -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/dozzle/data:/data -p 8080:8080 amir20/dozzle --auth-provider oidc --auth-oidc-issuer https://keycloak.example.com/realms/main --auth-oidc-client-id dozzle --auth-oidc-client-secret secret
+```
+
+```yaml [docker-compose.yml]
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /path/to/dozzle/data:/data
+    ports:
+      - 8080:8080
+    environment:
+      DOZZLE_AUTH_PROVIDER: oidc
+      DOZZLE_AUTH_OIDC_ISSUER: https://keycloak.example.com/realms/main
+      DOZZLE_AUTH_OIDC_CLIENT_ID: dozzle
+      DOZZLE_AUTH_OIDC_CLIENT_SECRET: secret
+```
+
+:::
+
+C'est tout. Aucun chemin de claim n'a besoin d'être défini pour les dispositions courantes, et `DOZZLE_AUTH_OIDC_NAME` ne change que le libellé du bouton de connexion. Le client secret accepte aussi un équivalent `_FILE`, voir [Utiliser les secrets Docker](/fr/guide/authentication/oauth#utiliser-les-secrets-docker-pour-le-client-secret).
+
+L'URL de l'émetteur est celle qui sert `/.well-known/openid-configuration`. Dozzle récupère ce document pour trouver les endpoints d'autorisation, de token et de userinfo, et refuse de démarrer le flux si le document déclare un émetteur différent de celui que vous avez configuré.
+
+## Rôles
+
+Les rôles d'un utilisateur sont lus depuis le token. Dozzle essaie ces claims dans l'ordre et prend le premier qui existe :
+
+1. `dozzle_roles`
+2. `resource_access.<client-id>.roles`
+3. `roles`
+
+Le client id est déjà configuré, donc avec `DOZZLE_AUTH_OIDC_CLIENT_ID=dozzle` le deuxième chemin est `resource_access.dozzle.roles`, qui est l'endroit où Keycloak place les rôles de client. Rien d'autre n'a besoin d'être défini pour cette disposition.
+
+Si vos rôles se trouvent ailleurs, `DOZZLE_AUTH_OIDC_ROLES_CLAIM` remplace la recherche par le seul chemin, séparé par des points, que vous lui donnez :
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: realm_access.roles
+```
+
+Chaque claim est cherché d'abord dans l'ID token puis dans la réponse userinfo, peu importe donc dans lequel des deux votre fournisseur le place. Trois formes sont acceptées : un tableau de chaînes, une seule chaîne séparée par des virgules ou des espaces, et un objet dont les clés sont les rôles, ce qui est la façon dont Zitadel encode les rôles de projet.
+
+Les noms de rôles sont les mêmes que dans `users.yml` : `shell`, `actions`, `download`, `notifications`, `cloud` et `all`, avec `^` pour soustraire, donc `all,^shell` accorde tout sauf l'accès au shell. Les noms préfixés par `dozzle_` sont acceptés aussi, ce qui aide quand le fournisseur partage un même claim de rôles entre plusieurs applications. Voir [rôles](/fr/guide/authentication/simple#definir-des-roles-specifiques-pour-les-utilisateurs) pour ce que chacun débloque.
+
+> [!WARNING]
+> `groups` est volontairement absent de la liste. Chez Authentik ou Google, chaque utilisateur appartient à au moins un groupe, donc le chercher transformerait « refusé » en « connecté et peut lire tous les conteneurs ». Si ce sont des groupes que vous avez, transposez-les en un claim `dozzle_roles` côté fournisseur, voir les exemples ci-dessous.
+
+### Quand une connexion est refusée
+
+La connexion est rejetée quand aucun des claims n'existe, ou quand le premier qui existe est vide. Le log nomme les chemins qui ont été essayés :
+
+```
+WRN OIDC login rejected: no roles claim found in the ID token or userinfo, or it was empty sub=... tried="dozzle_roles, resource_access.dozzle.roles, roles"
+```
+
+Un claim présent mais qui ne contient rien que Dozzle reconnaisse comme un rôle est un cas différent. Cet utilisateur se connecte sans aucun privilège, comme avec `roles: none` dans `users.yml` : il peut lire les logs des conteneurs que son filtre autorise, et rien de plus. Les rôles de realm de Keycloak se comportent ainsi, parce que chaque utilisateur y porte `offline_access` et `uma_authorization`, c'est pourquoi les exemples ci-dessous utilisent des rôles de client à la place.
+
+## Filtres
+
+Les filtres de conteneurs fonctionnent de la même façon, lus depuis le premier de `dozzle_filters`, `resource_access.<client-id>.filters` et `filters` qui existe, ou depuis le seul chemin donné dans `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`. Chaque valeur est un filtre dans la [même syntaxe que `users.yml`](/fr/guide/authentication/simple#definir-des-filtres-specifiques-pour-les-utilisateurs), par exemple `label=com.example.app` ou `name=web` :
+
+```json
+"resource_access": {
+  "dozzle": {
+    "roles": ["shell", "actions"],
+    "filters": ["label=com.example.app"]
+  }
+}
+```
+
+Un utilisateur sans claim de filtres voit tous les conteneurs que l'instance Dozzle peut voir. Un filtre qui ne se parse pas fait échouer la connexion au lieu d'être ignoré, une faute de frappe côté fournisseur ne peut donc pas élargir discrètement ce que quelqu'un voit.
+
+## Identité
+
+Le claim `sub` est l'identifiant stable de l'utilisateur. Il sert de clé au répertoire de profil sous `/data`, les réglages suivent donc la personne même si son nom d'utilisateur ou son email change chez le fournisseur. Le nom affiché dans le menu est `name`, avec repli sur `preferred_username`, puis `email`, puis `sub`. `email` et `picture` alimentent l'avatar, et une URL `picture` est utilisée directement quand le fournisseur en envoie une.
+
+Contrairement au fournisseur `simple`, l'email n'a pas besoin d'être vérifié ici. Il est seulement affiché, jamais comparé à quoi que ce soit, un émetteur qui n'accorde aucun scope email fonctionne donc très bien.
+
+## Sessions
+
+Après la connexion, Dozzle émet son propre cookie de session portant les rôles et les filtres qu'il a lus dans le token. Ils sont appliqués à chaque requête, mais ne sont pas récupérés à nouveau : un changement de rôle chez le fournisseur prend effet à la prochaine connexion de l'utilisateur. Si cet écart compte, réglez [`--auth-ttl`](/fr/guide/supported-env-vars) sur quelque chose comme `8h` pour que les sessions expirent et soient rétablies à partir d'un token frais.
+
+## Déconnexion
+
+Se déconnecter efface la session de Dozzle. Si `--auth-logout-url` est défini, le navigateur y est ensuite envoyé, pointez-le donc sur l'URL de fin de session de votre fournisseur pour déconnecter aussi l'utilisateur du fournisseur :
+
+```yaml
+DOZZLE_AUTH_LOGOUT_URL: https://keycloak.example.com/realms/main/protocol/openid-connect/logout
+```
+
+## Ce qui diffère de `simple`
+
+Les deux fournisseurs partagent les flags `--auth-oidc-*`, la différence se voit donc dans le comportement :
+
+- `users.yml` n'est jamais lu. S'il en existe un sous `/data`, Dozzle journalise qu'il l'ignore.
+- Il n'y a ni formulaire de mot de passe ni endpoint `/api/token`. Le fournisseur d'identité est le seul moyen d'entrer, donc une URL de callback erronée ou un client secret expiré verrouille tout le monde jusqu'à ce que ce soit réparé.
+- `--auth-github-*` est une erreur au démarrage. GitHub n'est pas un émetteur OpenID Connect et ne publie aucun claim d'où lire des rôles.
+- Le démarrage journalise l'émetteur et les chemins de claims depuis lesquels les rôles seront lus.
+
+## Exemples de fournisseurs
+
+### Keycloak
+
+Créez un client `dozzle` dans votre realm avec l'authentification du client activée, et ajoutez l'URI de redirection ci-dessus. Puis, sous l'onglet **Roles** du client, créez les rôles de client que vous voulez distribuer : `shell`, `actions`, `download`, `notifications`, `cloud` ou `all`. Attribuez-les aux utilisateurs ou aux groupes sous **Role mapping**.
+
+Keycloak émet les rôles de client sous `resource_access.<client-id>.roles`, que Dozzle cherche déjà. Vérifiez les **Client scopes** du client, ouvrez le scope dédié et confirmez que le mapper **client roles** ajoute le claim à l'ID token ou au userinfo ; Dozzle lit les deux mais pas l'access token.
+
+Pour les filtres, ajoutez un attribut utilisateur `dozzle_filters` et un mapper **User Attribute** sur le scope dédié avec le même nom de claim dans le token et **Multivalued** activé. Chaque valeur est un filtre, par exemple `label=com.example.app`.
+
+### Authentik
+
+Ajoutez un scope mapping sous **Customization** → **Property Mappings** qui renvoie les rôles à partir des groupes de l'utilisateur, et attachez-le au fournisseur Dozzle :
+
+```python
+roles = []
+if request.user.ak_groups.filter(name="dozzle-admins").exists():
+    roles.append("all")
+elif request.user.ak_groups.filter(name="dozzle-users").exists():
+    roles.append("download")
+return {"dozzle_roles": roles}
+```
+
+Un utilisateur qui n'est dans aucun des deux groupes obtient une liste vide et est refusé.
+
+### Zitadel
+
+Accordez aux utilisateurs des rôles de projet nommés d'après les rôles Dozzle et activez **Assert Roles on Authentication** sur l'application. Le claim de rôles de Zitadel est un objet dont les clés sont les noms de rôles, ce que Dozzle accepte, réglez donc :
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: urn:zitadel:iam:org:project:roles
+```
+
+### Google
+
+Les tokens de Google ne portent aucun claim de rôles, `oidc` ne peut donc pas être utilisé avec lui. Utilisez plutôt le [fournisseur `simple` avec la connexion Google](/fr/guide/authentication/oauth#google), où c'est `users.yml` qui décide qui entre.

--- a/docs/fr/guide/supported-env-vars.md
+++ b/docs/fr/guide/supported-env-vars.md
@@ -1,6 +1,6 @@
 ---
 title: Variables d'environnement et sous-commandes
-sourceHash: 3b46b35a4f0e
+sourceHash: a9818d761eb6
 ---
 
 # Variables d'environnement globales
@@ -28,6 +28,8 @@ La configuration se fait avec des options en ligne de commande ou des variables 
 | `--auth-oidc-client-id`       | `DOZZLE_AUTH_OIDC_CLIENT_ID`       | `""`              |
 | `--auth-oidc-client-secret`   | `DOZZLE_AUTH_OIDC_CLIENT_SECRET`   | `""`              |
 | `--auth-oidc-name`            | `DOZZLE_AUTH_OIDC_NAME`            | `SSO`             |
+| `--auth-oidc-roles-claim`     | `DOZZLE_AUTH_OIDC_ROLES_CLAIM`     | `""`              |
+| `--auth-oidc-filters-claim`   | `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`   | `""`              |
 | `--enable-actions`            | `DOZZLE_ENABLE_ACTIONS`            | `false`           |
 | `--enable-shell`              | `DOZZLE_ENABLE_SHELL`              | `false`           |
 | `--enable-mcp`                | `DOZZLE_ENABLE_MCP`                | `false`           |
@@ -46,6 +48,9 @@ La configuration se fait avec des options en ligne de commande ou des variables 
 
 > [!TIP]
 > `DOZZLE_AUTH_GITHUB_CLIENT_SECRET` et `DOZZLE_AUTH_OIDC_CLIENT_SECRET` acceptent aussi un équivalent `_FILE` qui nomme un fichier depuis lequel lire la valeur, à utiliser avec les [secrets Docker](/fr/guide/authentication/oauth#utiliser-les-secrets-docker-pour-le-client-secret).
+
+> [!TIP]
+> `DOZZLE_AUTH_OIDC_ROLES_CLAIM` et `DOZZLE_AUTH_OIDC_FILTERS_CLAIM` ne s'appliquent qu'à [`--auth-provider oidc`](/fr/guide/authentication/oidc), et ne sont nécessaires que lorsque les claims se trouvent à un endroit où la recherche par défaut ne regarde pas.
 
 > [!TIP]
 > Certaines options comme `--remote-host` ou `--remote-agent` peuvent être répétées. Par exemple, `--remote-agent 167.99.1.1:7007 --remote-agent 167.99.1.2:7007`, ou séparées par des virgules avec `DOZZLE_REMOTE_AGENT=167.99.1.1:7007,167.99.1.2:7007`.

--- a/docs/guide/authentication.md
+++ b/docs/guide/authentication.md
@@ -21,13 +21,14 @@ Dozzle has access to `docker.sock`, which — unless restricted — is equivalen
 
 ## <Icon icon="mdi:key-outline" inline /> Choosing a method
 
-| Method                                               | Who owns the users     | Use it when                                                                                                                          |
-| ---------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [Simple](/guide/authentication/simple)               | Dozzle, in `users.yml` | You have no authentication solution and want Dozzle to handle logins.                                                                |
-| [GitHub & OIDC](/guide/authentication/oauth)         | Dozzle, in `users.yml` | You want the same `users.yml` users to sign in with GitHub, Google, Keycloak, Pocket ID, Zitadel or Authentik instead of a password. |
-| [Forward Proxy](/guide/authentication/forward-proxy) | Your proxy             | You already run Authelia, Authentik, Cloudflare Access or similar, and want it to own authentication entirely.                       |
+| Method                                               | Who owns the users     | Use it when                                                                                                                             |
+| ---------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| [Simple](/guide/authentication/simple)               | Dozzle, in `users.yml` | You have no authentication solution and want Dozzle to handle logins.                                                                   |
+| [GitHub & OIDC](/guide/authentication/oauth)         | Dozzle, in `users.yml` | You want the same `users.yml` users to sign in with GitHub, Google, Keycloak, Pocket ID, Zitadel or Authentik instead of a password.    |
+| [OpenID Connect](/guide/authentication/oidc)         | Your identity provider | You want Keycloak, Authentik, Zitadel or Pocket ID to own the user list, with roles and filters read from the token and no `users.yml`. |
+| [Forward Proxy](/guide/authentication/forward-proxy) | Your proxy             | You already run Authelia, Authentik, Cloudflare Access or similar, and want it to own authentication entirely.                          |
 
-Simple and OAuth are the same provider: `users.yml` is the user list either way, and OAuth only adds a second way to prove you are one of the users in it. Forward proxy is the separate one, and it is the right choice when you need org-wide or domain-wide access rules, which `users.yml` deliberately does not do.
+Simple and OAuth are the same provider: `users.yml` is the user list either way, and OAuth only adds a second way to prove you are one of the users in it. OpenID Connect and forward proxy are the separate ones, where something outside Dozzle owns the users. Pick `oidc` when your identity provider can put roles in the token, and forward proxy when you need org-wide or domain-wide access rules enforced in front of Dozzle, which `users.yml` deliberately does not do.
 
 ## <Icon icon="mdi:file-document-edit-outline" inline /> Generating users.yml
 

--- a/docs/guide/authentication/oauth.md
+++ b/docs/guide/authentication/oauth.md
@@ -10,6 +10,9 @@ That has one consequence worth stating up front: **`users.yml` is the allowlist.
 
 Password login keeps working alongside it, which matters when an OAuth app breaks and you need to get in to fix it.
 
+> [!TIP]
+> If you would rather have the identity provider own the user list, with roles and filters read from the token and no `users.yml` at all, that is a provider of its own: see [OpenID Connect](/guide/authentication/oidc).
+
 ## Sign in with GitHub
 
 Dozzle can let users sign in with their GitHub account instead of typing a password. This is part of the `simple` provider and not a separate auth provider, so `users.yml` is still read on every request and still decides who gets in. Keep using `--auth-provider simple`. `github` is accepted as an alias if you prefer to spell out what the instance uses.
@@ -140,6 +143,8 @@ The email must be marked verified by your provider. Dozzle rejects a sign-in whe
 
 > [!NOTE]
 > GitHub matches on the login and OIDC matches on the email, and that difference is deliberate. A GitHub login is stable and always present, while a GitHub email can be private or changed. OIDC has no stable human-readable equivalent, so the verified email is the claim operators actually know.
+
+In this mode the provider only proves who you are. Roles and filters still come from `users.yml`, and a user the file does not list cannot sign in however many roles the token carries. To have the provider decide both, use [`--auth-provider oidc`](/guide/authentication/oidc) instead.
 
 ### Google
 

--- a/docs/guide/authentication/oidc.md
+++ b/docs/guide/authentication/oidc.md
@@ -1,0 +1,159 @@
+---
+title: OpenID Connect
+---
+
+# <Icon icon="mdi:shield-account" inline /> OpenID Connect
+
+With `--auth-provider oidc`, your identity provider is the user database. Dozzle never reads `users.yml` in this mode: who a user is, which roles they have and which containers they may see all come from the OpenID Connect token. Add a user in Keycloak, Authentik, Zitadel or Pocket ID and they can sign in; remove their role and they cannot.
+
+This is different from [signing `users.yml` users in with OIDC](/guide/authentication/oauth#sign-in-with-oidc) under the `simple` provider. There the provider only proves who you are and `users.yml` still decides what you get. Pick `simple` when you want to list every user by hand, and `oidc` when the provider should own the list.
+
+## Minimum configuration
+
+Register Dozzle as a confidential client with your provider and set the redirect URI to:
+
+```
+https://your-dozzle-host/api/auth/callback
+```
+
+Include the base path if Dozzle runs under one, for example `https://example.com/dozzle/api/auth/callback`. Then point Dozzle at the issuer:
+
+::: code-group
+
+```sh [cli]
+$ docker run -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/dozzle/data:/data -p 8080:8080 amir20/dozzle --auth-provider oidc --auth-oidc-issuer https://keycloak.example.com/realms/main --auth-oidc-client-id dozzle --auth-oidc-client-secret secret
+```
+
+```yaml [docker-compose.yml]
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /path/to/dozzle/data:/data
+    ports:
+      - 8080:8080
+    environment:
+      DOZZLE_AUTH_PROVIDER: oidc
+      DOZZLE_AUTH_OIDC_ISSUER: https://keycloak.example.com/realms/main
+      DOZZLE_AUTH_OIDC_CLIENT_ID: dozzle
+      DOZZLE_AUTH_OIDC_CLIENT_SECRET: secret
+```
+
+:::
+
+That is all of it. No claim paths need to be set for the common layouts, and `DOZZLE_AUTH_OIDC_NAME` only changes the label on the login button. The client secret also accepts a `_FILE` counterpart, see [Using Docker secrets](/guide/authentication/oauth#using-docker-secrets-for-the-client-secret).
+
+The issuer URL is the one that serves `/.well-known/openid-configuration`. Dozzle fetches that document to find the authorization, token and userinfo endpoints, and refuses to start the flow if the document names a different issuer than the one you configured.
+
+## Roles
+
+A user's roles are read from the token. Dozzle tries these claims in order and takes the first one that exists:
+
+1. `dozzle_roles`
+2. `resource_access.<client-id>.roles`
+3. `roles`
+
+The client id is already configured, so with `DOZZLE_AUTH_OIDC_CLIENT_ID=dozzle` the second path is `resource_access.dozzle.roles`, which is where Keycloak puts client roles. Nothing else needs to be set for that layout.
+
+If your roles live somewhere else, `DOZZLE_AUTH_OIDC_ROLES_CLAIM` replaces the search with the one dot-separated path you give it:
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: realm_access.roles
+```
+
+Each claim is looked for in the ID token first and then in the userinfo response, so it does not matter which of the two your provider puts it in. Three shapes are accepted: an array of strings, a single comma or space separated string, and an object whose keys are the roles, which is how Zitadel encodes project roles.
+
+The role names are the same as in `users.yml`: `shell`, `actions`, `download`, `notifications`, `cloud` and `all`, with `^` to subtract, so `all,^shell` grants everything except shell access. Names prefixed with `dozzle_` are accepted too, which helps when the provider shares one roles claim across several applications. See [roles](/guide/authentication/simple#setting-specific-roles-for-users) for what each one unlocks.
+
+> [!WARNING]
+> `groups` is deliberately not on the list. At Authentik or Google every user belongs to at least one group, so searching it would turn "denied" into "signed in and can read every container". If groups are what you have, map them into a `dozzle_roles` claim at the provider, see the examples below.
+
+### When a login is refused
+
+Sign in is rejected when none of the claims exist, or when the first one that exists is empty. The log names the paths that were tried:
+
+```
+WRN OIDC login rejected: no roles claim found in the ID token or userinfo, or it was empty sub=... tried="dozzle_roles, resource_access.dozzle.roles, roles"
+```
+
+A claim that is present but contains nothing Dozzle recognizes as a role is different. That user signs in with no privileges, the same as `roles: none` in `users.yml`: they can read logs for the containers their filter allows, and nothing more. Keycloak realm roles behave this way, because every user carries `offline_access` and `uma_authorization` there, which is why the examples below use client roles instead.
+
+## Filters
+
+Container filters work the same way, read from the first of `dozzle_filters`, `resource_access.<client-id>.filters` and `filters` that exists, or from the single path in `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`. Each value is one filter in the [same syntax as `users.yml`](/guide/authentication/simple#setting-specific-filters-for-users), for example `label=com.example.app` or `name=web`:
+
+```json
+"resource_access": {
+  "dozzle": {
+    "roles": ["shell", "actions"],
+    "filters": ["label=com.example.app"]
+  }
+}
+```
+
+A user with no filters claim can see every container the Dozzle instance can. A filter that does not parse fails the login rather than being dropped, so a typo at the provider cannot quietly widen what someone sees.
+
+## Identity
+
+The `sub` claim is the user's stable id. It keys the profile directory under `/data`, so settings follow the person even if their username or email changes at the provider. The name shown in the menu is `name`, falling back to `preferred_username`, then `email`, then `sub`. `email` and `picture` feed the avatar, and a `picture` URL is used directly when the provider sends one.
+
+Unlike the `simple` provider, the email does not have to be verified here. It is only displayed, never matched against anything, so an issuer that grants no email scope works fine.
+
+## Sessions
+
+After sign in, Dozzle issues its own session cookie carrying the roles and filters it read from the token. They are applied on every request, but they are not fetched again: a role change at the provider takes effect at the user's next login. If that gap matters, set [`--auth-ttl`](/guide/supported-env-vars) to something like `8h` so sessions expire and are re-established from a fresh token.
+
+## Logout
+
+Logging out clears Dozzle's session. If `--auth-logout-url` is set, the browser is then sent there, so point it at your provider's end session URL to sign the user out of the provider as well:
+
+```yaml
+DOZZLE_AUTH_LOGOUT_URL: https://keycloak.example.com/realms/main/protocol/openid-connect/logout
+```
+
+## What is different from `simple`
+
+Both providers share the `--auth-oidc-*` flags, so the split shows up in behavior:
+
+- `users.yml` is never read. If one exists under `/data`, Dozzle logs that it is ignoring it.
+- There is no password form and no `/api/token` endpoint. The identity provider is the only way in, so a wrong callback URL or an expired client secret locks everyone out until it is fixed.
+- `--auth-github-*` is a startup error. GitHub is not an OpenID Connect issuer and publishes no claims to read roles from.
+- Startup logs the issuer and the claim paths roles will be read from.
+
+## Provider examples
+
+### Keycloak
+
+Create a client `dozzle` in your realm with client authentication on, and add the redirect URI above. Then, under the client's **Roles** tab, create the client roles you want to hand out: `shell`, `actions`, `download`, `notifications`, `cloud`, or `all`. Assign them to users or groups under **Role mapping**.
+
+Keycloak emits client roles as `resource_access.<client-id>.roles`, which Dozzle already searches. Check the client's **Client scopes**, open the dedicated scope and confirm the **client roles** mapper adds the claim to the ID token or to userinfo; Dozzle reads both but not the access token.
+
+For filters, add a user attribute `dozzle_filters` and a **User Attribute** mapper on the dedicated scope with the same token claim name and **Multivalued** on. Each value is one filter, such as `label=com.example.app`.
+
+### Authentik
+
+Add a scope mapping under **Customization** → **Property Mappings** that returns the roles from the user's groups, and attach it to the Dozzle provider:
+
+```python
+roles = []
+if request.user.ak_groups.filter(name="dozzle-admins").exists():
+    roles.append("all")
+elif request.user.ak_groups.filter(name="dozzle-users").exists():
+    roles.append("download")
+return {"dozzle_roles": roles}
+```
+
+A user in neither group gets an empty list and is refused.
+
+### Zitadel
+
+Grant users project roles named after Dozzle roles and enable **Assert Roles on Authentication** on the application. Zitadel's role claim is an object keyed by role name, which Dozzle accepts, so set:
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: urn:zitadel:iam:org:project:roles
+```
+
+### Google
+
+Google's tokens carry no roles claim, so `oidc` cannot be used with it. Use the [`simple` provider with Google sign in](/guide/authentication/oauth#google) instead, where `users.yml` decides who gets in.

--- a/docs/guide/supported-env-vars.md
+++ b/docs/guide/supported-env-vars.md
@@ -27,6 +27,8 @@ Configurations can be done with flags or environment variables. The table below 
 | `--auth-oidc-client-id`       | `DOZZLE_AUTH_OIDC_CLIENT_ID`       | `""`              |
 | `--auth-oidc-client-secret`   | `DOZZLE_AUTH_OIDC_CLIENT_SECRET`   | `""`              |
 | `--auth-oidc-name`            | `DOZZLE_AUTH_OIDC_NAME`            | `SSO`             |
+| `--auth-oidc-roles-claim`     | `DOZZLE_AUTH_OIDC_ROLES_CLAIM`     | `""`              |
+| `--auth-oidc-filters-claim`   | `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`   | `""`              |
 | `--enable-actions`            | `DOZZLE_ENABLE_ACTIONS`            | `false`           |
 | `--enable-shell`              | `DOZZLE_ENABLE_SHELL`              | `false`           |
 | `--enable-mcp`                | `DOZZLE_ENABLE_MCP`                | `false`           |
@@ -45,6 +47,9 @@ Configurations can be done with flags or environment variables. The table below 
 
 > [!TIP]
 > `DOZZLE_AUTH_GITHUB_CLIENT_SECRET` and `DOZZLE_AUTH_OIDC_CLIENT_SECRET` also accept a `_FILE` counterpart naming a file to read the value from, for use with [Docker secrets](/guide/authentication/oauth#using-docker-secrets-for-the-client-secret).
+
+> [!TIP]
+> `DOZZLE_AUTH_OIDC_ROLES_CLAIM` and `DOZZLE_AUTH_OIDC_FILTERS_CLAIM` only apply to [`--auth-provider oidc`](/guide/authentication/oidc), and are only needed when the claims live somewhere the default search does not look.
 
 > [!TIP]
 > Some flags like `--remote-host` or `--remote-agent` can be used multiple times. For example, `--remote-agent 167.99.1.1:7007 --remote-agent 167.99.1.2:7007` or comma-separated `DOZZLE_REMOTE_AGENT=167.99.1.1:7007,167.99.1.2:7007`.

--- a/docs/zh/guide/authentication.md
+++ b/docs/zh/guide/authentication.md
@@ -1,6 +1,6 @@
 ---
 title: 身份验证
-sourceHash: c0e3f963afbe
+sourceHash: 111fbadf1b7a
 ---
 
 # 身份验证
@@ -26,9 +26,10 @@ Dozzle 可以访问 `docker.sock`，除非加以限制，否则这等同于**主
 | -------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | [简单模式](/zh/guide/authentication/simple)        | Dozzle，写在 `users.yml` 里 | 你没有现成的验证方案，希望由 Dozzle 来处理登录。                                                                     |
 | [GitHub 与 OIDC](/zh/guide/authentication/oauth)   | Dozzle，写在 `users.yml` 里 | 你希望 `users.yml` 里的同一批用户用 GitHub、Google、Keycloak、Pocket ID、Zitadel 或 Authentik 登录，而不是输入密码。 |
+| [OpenID Connect](/zh/guide/authentication/oidc)    | 你的身份提供方              | 你希望由 Keycloak、Authentik、Zitadel 或 Pocket ID 掌管用户列表，角色和过滤器从令牌里读取，不再需要 `users.yml`。    |
 | [前置代理](/zh/guide/authentication/forward-proxy) | 你的代理                    | 你已经在运行 Authelia、Authentik、Cloudflare Access 之类的服务，并且希望完全由它来负责身份验证。                     |
 
-简单模式和 OAuth 其实是同一种验证方式：两者的用户列表都是 `users.yml`，OAuth 只是多提供了一种方式来证明你是列表里的某个用户。前置代理才是另一类，当你需要基于组织或域名的访问规则时它才是正确的选择，而这正是 `users.yml` 有意不做的事。
+简单模式和 OAuth 其实是同一种验证方式：两者的用户列表都是 `users.yml`，OAuth 只是多提供了一种方式来证明你是列表里的某个用户。OpenID Connect 和前置代理才是另一类，用户由 Dozzle 之外的东西掌管。当你的身份提供方能把角色放进令牌时选 `oidc`；当你需要在 Dozzle 前面强制执行基于组织或域名的访问规则时选前置代理，而这正是 `users.yml` 有意不做的事。
 
 ## <Icon icon="mdi:file-document-edit-outline" inline /> 生成 users.yml
 

--- a/docs/zh/guide/authentication/oauth.md
+++ b/docs/zh/guide/authentication/oauth.md
@@ -1,6 +1,6 @@
 ---
 title: 使用 GitHub 与 OIDC 登录
-sourceHash: 7e8f4dfb70fa
+sourceHash: cfb7126acb65
 ---
 
 # <Icon icon="mdi:shield-account" inline /> 使用 GitHub 与 OIDC 登录
@@ -10,6 +10,9 @@ Dozzle 可以让用户用外部账号登录，而不必输入密码。这是 [`s
 这里有一点值得先说清楚：**`users.yml` 就是白名单。** 没有任何条目关联到的外部账号无法登录，也不会自动创建任何账号。
 
 密码登录会继续保留，这在 OAuth 应用出问题、你需要登录进去修复时很重要。
+
+> [!TIP]
+> 如果你更希望由身份提供方掌管用户列表，角色和过滤器从令牌里读取，完全不要 `users.yml`，那是一种独立的验证方式：参见 [OpenID Connect](/zh/guide/authentication/oidc)。
 
 ## 使用 GitHub 登录
 
@@ -141,6 +144,8 @@ users:
 
 > [!NOTE]
 > GitHub 按登录名匹配，OIDC 按邮箱匹配，这个区别是有意为之。GitHub 的登录名稳定且始终存在，而 GitHub 邮箱可能被设为私密或被更改。OIDC 没有对应的、稳定又便于阅读的标识，因此已验证的邮箱才是运维人员真正掌握的那个 claim。
+
+在这种模式下，提供方只负责证明你是谁。角色和过滤器仍然来自 `users.yml`，文件里没有列出的用户无论令牌里带了多少角色都无法登录。想让提供方同时决定这两者，请改用 [`--auth-provider oidc`](/zh/guide/authentication/oidc)。
 
 ### Google
 

--- a/docs/zh/guide/authentication/oidc.md
+++ b/docs/zh/guide/authentication/oidc.md
@@ -1,0 +1,160 @@
+---
+title: OpenID Connect
+sourceHash: 9dcc3df4a715
+---
+
+# <Icon icon="mdi:shield-account" inline /> OpenID Connect
+
+使用 `--auth-provider oidc` 时，你的身份提供方就是用户数据库。这种模式下 Dozzle 从不读取 `users.yml`：用户是谁、拥有哪些角色、能看到哪些容器，全部来自 OpenID Connect 令牌。在 Keycloak、Authentik、Zitadel 或 Pocket ID 里添加一个用户，他就能登录；把他的角色移除，他就登不进来。
+
+这和在 `simple` 验证方式下[让 `users.yml` 里的用户用 OIDC 登录](/zh/guide/authentication/oauth#使用-oidc-登录)是两回事。那种情况下提供方只负责证明你是谁，你能得到什么仍由 `users.yml` 决定。想手动列出每一个用户就选 `simple`，想让提供方掌管用户列表就选 `oidc`。
+
+## 最小配置
+
+在你的身份提供方那里把 Dozzle 注册为机密客户端，并把重定向 URI 设为：
+
+```
+https://your-dozzle-host/api/auth/callback
+```
+
+如果 Dozzle 部署在某个基础路径下，这里也要带上它，例如 `https://example.com/dozzle/api/auth/callback`。然后把 Dozzle 指向 issuer：
+
+::: code-group
+
+```sh [cli]
+$ docker run -v /var/run/docker.sock:/var/run/docker.sock -v /path/to/dozzle/data:/data -p 8080:8080 amir20/dozzle --auth-provider oidc --auth-oidc-issuer https://keycloak.example.com/realms/main --auth-oidc-client-id dozzle --auth-oidc-client-secret secret
+```
+
+```yaml [docker-compose.yml]
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /path/to/dozzle/data:/data
+    ports:
+      - 8080:8080
+    environment:
+      DOZZLE_AUTH_PROVIDER: oidc
+      DOZZLE_AUTH_OIDC_ISSUER: https://keycloak.example.com/realms/main
+      DOZZLE_AUTH_OIDC_CLIENT_ID: dozzle
+      DOZZLE_AUTH_OIDC_CLIENT_SECRET: secret
+```
+
+:::
+
+这就是全部配置。对常见的令牌布局来说不需要设置任何 claim 路径，`DOZZLE_AUTH_OIDC_NAME` 也只是改变登录按钮上的文字。client secret 同样接受一个 `_FILE` 形式的对应变量，参见[用 Docker secrets 保存 client secret](/zh/guide/authentication/oauth#用-docker-secrets-保存-client-secret)。
+
+issuer URL 就是提供 `/.well-known/openid-configuration` 的那个地址。Dozzle 会拉取这份文档来找到授权端点、令牌端点和 userinfo 端点；如果文档里声明的 issuer 和你配置的不一致，Dozzle 会拒绝发起登录流程。
+
+## 角色
+
+用户的角色从令牌中读取。Dozzle 会按顺序尝试下面这些 claim，并取第一个存在的：
+
+1. `dozzle_roles`
+2. `resource_access.<client-id>.roles`
+3. `roles`
+
+client id 已经配置过了，所以当 `DOZZLE_AUTH_OIDC_CLIENT_ID=dozzle` 时，第二条路径就是 `resource_access.dozzle.roles`，这正是 Keycloak 存放客户端角色的地方。对这种布局不需要再设置任何东西。
+
+如果你的角色放在别的地方，`DOZZLE_AUTH_OIDC_ROLES_CLAIM` 会用你给出的那一条点分路径取代整个搜索过程：
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: realm_access.roles
+```
+
+每个 claim 都会先在 ID 令牌里查找，再到 userinfo 响应里查找，所以你的提供方把它放在两者中的哪一个并不重要。接受三种形式：字符串数组、用逗号或空格分隔的单个字符串，以及以角色名为键的对象，最后这种是 Zitadel 编码项目角色的方式。
+
+角色名和 `users.yml` 里的一样：`shell`、`actions`、`download`、`notifications`、`cloud` 和 `all`，并且可以用 `^` 做排除，所以 `all,^shell` 授予除 shell 访问之外的全部权限。带 `dozzle_` 前缀的名称同样被接受，这在提供方用同一个角色 claim 服务多个应用时很有用。每个角色解锁什么，参见[角色](/zh/guide/authentication/simple#为用户设置角色)。
+
+> [!WARNING]
+> `groups` 是有意不在这个列表里的。在 Authentik 或 Google 那里，每个用户都至少属于一个组，搜索它会把"拒绝登录"变成"登录成功并能读取所有容器"。如果你手头只有用户组，请在提供方那里把它们映射成一个 `dozzle_roles` claim，参见下面的示例。
+
+### 登录被拒绝时
+
+当这些 claim 一个都不存在，或者第一个存在的 claim 为空时，登录会被拒绝。日志会列出尝试过的路径：
+
+```
+WRN OIDC login rejected: no roles claim found in the ID token or userinfo, or it was empty sub=... tried="dozzle_roles, resource_access.dozzle.roles, roles"
+```
+
+claim 存在但里面没有任何 Dozzle 能识别为角色的内容，则是另一种情况。这样的用户会以无权限的身份登录，和 `users.yml` 里的 `roles: none` 一样：他可以读取过滤器允许的那些容器的日志，仅此而已。Keycloak 的 realm 角色就是这种表现，因为那里的每个用户都带有 `offline_access` 和 `uma_authorization`，所以下面的示例改用客户端角色。
+
+## 过滤器
+
+容器过滤器的工作方式相同，从 `dozzle_filters`、`resource_access.<client-id>.filters` 和 `filters` 中第一个存在的读取，或者从 `DOZZLE_AUTH_OIDC_FILTERS_CLAIM` 指定的那一条路径读取。每个值就是一个过滤器，[语法和 `users.yml` 一样](/zh/guide/authentication/simple#为用户设置过滤器)，例如 `label=com.example.app` 或 `name=web`：
+
+```json
+"resource_access": {
+  "dozzle": {
+    "roles": ["shell", "actions"],
+    "filters": ["label=com.example.app"]
+  }
+}
+```
+
+没有过滤器 claim 的用户可以看到这个 Dozzle 实例能看到的所有容器。无法解析的过滤器会让登录失败，而不是被丢弃，因此提供方那边的一个笔误不会悄悄扩大某人的可见范围。
+
+## 身份
+
+`sub` claim 是用户的稳定标识。它是 `/data` 下配置目录的键，所以即使用户名或邮箱在提供方那里发生了变化，设置也会跟着这个人走。菜单里显示的名字取 `name`，没有则依次回退到 `preferred_username`、`email`、`sub`。`email` 和 `picture` 用于生成头像，如果提供方发来了 `picture` URL，就直接使用它。
+
+和 `simple` 验证方式不同，这里的邮箱不需要经过验证。它只用于显示，从不拿来和任何东西匹配，所以不授予 email scope 的 issuer 也能正常工作。
+
+## 会话
+
+登录之后，Dozzle 会签发自己的会话 cookie，其中带着从令牌里读到的角色和过滤器。它们在每个请求上都会生效，但不会被重新拉取：在提供方那里更改角色，要到用户下次登录才会生效。如果这个间隔对你很重要，把 [`--auth-ttl`](/zh/guide/supported-env-vars) 设成 `8h` 之类的值，让会话过期后从新的令牌重新建立。
+
+## 登出
+
+登出会清除 Dozzle 的会话。如果设置了 `--auth-logout-url`，浏览器接着会被送到那个地址，所以把它指向你的提供方的 end session URL，就能把用户从提供方那里也登出：
+
+```yaml
+DOZZLE_AUTH_LOGOUT_URL: https://keycloak.example.com/realms/main/protocol/openid-connect/logout
+```
+
+## 和 `simple` 有什么不同
+
+两种验证方式共用 `--auth-oidc-*` 这组标志，所以区别体现在行为上：
+
+- 从不读取 `users.yml`。如果 `/data` 下存在这个文件，Dozzle 会在日志里说明它被忽略了。
+- 没有密码表单，也没有 `/api/token` 端点。身份提供方是唯一的入口，所以一个填错的回调 URL 或一个过期的 client secret 会把所有人挡在外面，直到问题被修复。
+- `--auth-github-*` 会在启动时报错。GitHub 不是 OpenID Connect issuer，也不发布任何可以用来读取角色的 claim。
+- 启动时会在日志里打印 issuer 以及将从哪些 claim 路径读取角色。
+
+## 提供方示例
+
+### Keycloak
+
+在你的 realm 里创建一个名为 `dozzle` 的客户端，开启 client authentication，并添加上面的重定向 URI。然后在客户端的 **Roles** 标签页下创建你想分发的客户端角色：`shell`、`actions`、`download`、`notifications`、`cloud` 或 `all`。在 **Role mapping** 下把它们分配给用户或用户组。
+
+Keycloak 以 `resource_access.<client-id>.roles` 的形式输出客户端角色，Dozzle 本来就会搜索这条路径。检查客户端的 **Client scopes**，打开专属 scope，确认 **client roles** 这个 mapper 会把该 claim 加进 ID 令牌或 userinfo；Dozzle 会读这两者，但不读 access token。
+
+至于过滤器，添加一个名为 `dozzle_filters` 的用户属性，并在专属 scope 上添加一个 **User Attribute** mapper，令牌 claim 名称保持一致，并开启 **Multivalued**。每个值就是一个过滤器，例如 `label=com.example.app`。
+
+### Authentik
+
+在 **Customization** → **Property Mappings** 下添加一个 scope mapping，根据用户所属的组返回角色，然后把它挂到 Dozzle 的 provider 上：
+
+```python
+roles = []
+if request.user.ak_groups.filter(name="dozzle-admins").exists():
+    roles.append("all")
+elif request.user.ak_groups.filter(name="dozzle-users").exists():
+    roles.append("download")
+return {"dozzle_roles": roles}
+```
+
+两个组都不属于的用户会得到一个空列表，并被拒绝登录。
+
+### Zitadel
+
+给用户授予以 Dozzle 角色命名的项目角色，并在应用上启用 **Assert Roles on Authentication**。Zitadel 的角色 claim 是一个以角色名为键的对象，Dozzle 能接受这种形式，所以设置：
+
+```yaml
+DOZZLE_AUTH_OIDC_ROLES_CLAIM: urn:zitadel:iam:org:project:roles
+```
+
+### Google
+
+Google 的令牌不带任何角色 claim，所以 `oidc` 无法配合它使用。请改用[带 Google 登录的 `simple` 验证方式](/zh/guide/authentication/oauth#google)，由 `users.yml` 决定谁能进来。

--- a/docs/zh/guide/supported-env-vars.md
+++ b/docs/zh/guide/supported-env-vars.md
@@ -1,6 +1,6 @@
 ---
 title: 环境变量与子命令
-sourceHash: 3b46b35a4f0e
+sourceHash: a9818d761eb6
 ---
 
 # 全局环境变量
@@ -28,6 +28,8 @@ sourceHash: 3b46b35a4f0e
 | `--auth-oidc-client-id`       | `DOZZLE_AUTH_OIDC_CLIENT_ID`       | `""`              |
 | `--auth-oidc-client-secret`   | `DOZZLE_AUTH_OIDC_CLIENT_SECRET`   | `""`              |
 | `--auth-oidc-name`            | `DOZZLE_AUTH_OIDC_NAME`            | `SSO`             |
+| `--auth-oidc-roles-claim`     | `DOZZLE_AUTH_OIDC_ROLES_CLAIM`     | `""`              |
+| `--auth-oidc-filters-claim`   | `DOZZLE_AUTH_OIDC_FILTERS_CLAIM`   | `""`              |
 | `--enable-actions`            | `DOZZLE_ENABLE_ACTIONS`            | `false`           |
 | `--enable-shell`              | `DOZZLE_ENABLE_SHELL`              | `false`           |
 | `--enable-mcp`                | `DOZZLE_ENABLE_MCP`                | `false`           |
@@ -46,6 +48,9 @@ sourceHash: 3b46b35a4f0e
 
 > [!TIP]
 > `DOZZLE_AUTH_GITHUB_CLIENT_SECRET` 和 `DOZZLE_AUTH_OIDC_CLIENT_SECRET` 还接受一个 `_FILE` 形式的对应变量，用来指明从哪个文件读取这个值，方便配合 [Docker secrets](/zh/guide/authentication/oauth#用-docker-secrets-保存-client-secret) 使用。
+
+> [!TIP]
+> `DOZZLE_AUTH_OIDC_ROLES_CLAIM` 和 `DOZZLE_AUTH_OIDC_FILTERS_CLAIM` 只对 [`--auth-provider oidc`](/zh/guide/authentication/oidc) 生效，而且只有当 claim 放在默认搜索不会去找的位置时才需要设置。
 
 > [!TIP]
 > 有些标志（例如 `--remote-host` 或 `--remote-agent`）可以多次使用。例如 `--remote-agent 167.99.1.1:7007 --remote-agent 167.99.1.2:7007`，或者用逗号分隔的 `DOZZLE_REMOTE_AGENT=167.99.1.1:7007,167.99.1.2:7007`。

--- a/internal/auth/claims.go
+++ b/internal/auth/claims.go
@@ -1,0 +1,140 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// claimSet is the claims a provider returned, in the order they should be
+// searched: the ID token first, then userinfo. Keycloak puts resource_access in
+// the ID token and only mirrors it into userinfo when the mapper says so, which
+// is why the two are kept apart rather than merged into one map.
+type claimSet []map[string]any
+
+// claimPath is one dot-separated path, already split. It is a slice rather than
+// a string so a client id with a dot in it can be a single segment.
+type claimPath []string
+
+func (p claimPath) String() string { return strings.Join(p, ".") }
+
+// parseClaimPath splits an operator-supplied path such as
+// "resource_access.dozzle.roles" on dots.
+func parseClaimPath(path string) claimPath {
+	var segments claimPath
+	for segment := range strings.SplitSeq(strings.TrimSpace(path), ".") {
+		if segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+
+	return segments
+}
+
+// lookup walks path through each claim source in turn and returns the first
+// value it finds. A path that reaches a non-object before its last segment does
+// not resolve in that source.
+func (c claimSet) lookup(path claimPath) (any, bool) {
+	if len(path) == 0 {
+		return nil, false
+	}
+
+	for _, source := range c {
+		if value, ok := walk(source, path); ok {
+			return value, true
+		}
+	}
+
+	return nil, false
+}
+
+func walk(source map[string]any, path claimPath) (any, bool) {
+	var current any = source
+	for _, segment := range path {
+		object, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+
+		current, ok = object[segment]
+		if !ok {
+			return nil, false
+		}
+	}
+
+	return current, true
+}
+
+// strings resolves the first of paths that holds a list of strings. The list is
+// returned even when it is empty: a claim that is present and empty is an answer
+// ("this user has no roles"), and searching past it for a broader claim would
+// turn that answer into a grant.
+//
+// Three shapes are accepted, because providers disagree: a JSON array of
+// strings, a single comma or space separated string, and an object whose keys
+// are the values, which is how Zitadel encodes project roles.
+func (c claimSet) strings(paths []claimPath) ([]string, claimPath, bool) {
+	for _, path := range paths {
+		value, ok := c.lookup(path)
+		if !ok {
+			continue
+		}
+
+		if values, ok := claimStrings(value); ok {
+			return values, path, true
+		}
+	}
+
+	return nil, nil, false
+}
+
+func claimStrings(value any) ([]string, bool) {
+	switch v := value.(type) {
+	case []any:
+		values := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok && strings.TrimSpace(s) != "" {
+				values = append(values, strings.TrimSpace(s))
+			}
+		}
+		return values, true
+	case string:
+		values := strings.FieldsFunc(v, func(r rune) bool {
+			return r == ',' || r == ' ' || r == '\t' || r == '\n'
+		})
+		return values, true
+	case map[string]any:
+		values := make([]string, 0, len(v))
+		for key := range v {
+			if strings.TrimSpace(key) != "" {
+				values = append(values, strings.TrimSpace(key))
+			}
+		}
+		return values, true
+	default:
+		return nil, false
+	}
+}
+
+// decodeJWTClaims reads the payload of a compact JWS without checking its
+// signature. See oidcProvider.identity for why the signature is not needed on
+// an ID token that arrived straight from the token endpoint.
+func decodeJWTClaims(token string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("expected 3 segments, got %d", len(parts))
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, err
+	}
+
+	return claims, nil
+}

--- a/internal/auth/claims_test.go
+++ b/internal/auth/claims_test.go
@@ -1,0 +1,109 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClaimSetLookupSearchesSourcesInOrder(t *testing.T) {
+	claims := claimSet{
+		{"resource_access": map[string]any{"dozzle": map[string]any{"roles": []any{"shell"}}}},
+		{"roles": []any{"actions"}, "resource_access": map[string]any{"dozzle": map[string]any{"roles": []any{"ignored"}}}},
+	}
+
+	value, ok := claims.lookup(claimPath{"resource_access", "dozzle", "roles"})
+	require.True(t, ok)
+	require.Equal(t, []any{"shell"}, value, "the ID token is searched before userinfo")
+
+	value, ok = claims.lookup(claimPath{"roles"})
+	require.True(t, ok)
+	require.Equal(t, []any{"actions"}, value, "a claim only userinfo carries is still found")
+
+	_, ok = claims.lookup(claimPath{"resource_access", "other", "roles"})
+	require.False(t, ok)
+
+	// Walking through a non-object does not resolve.
+	_, ok = claims.lookup(claimPath{"roles", "nested"})
+	require.False(t, ok)
+}
+
+func TestClaimStringsAcceptsEveryShape(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+		want  []string
+		ok    bool
+	}{
+		{"array", []any{"shell", " actions "}, []string{"shell", "actions"}, true},
+		{"empty array", []any{}, []string{}, true},
+		{"comma string", "shell,actions", []string{"shell", "actions"}, true},
+		{"space string", "shell actions", []string{"shell", "actions"}, true},
+		{"empty string", "", []string{}, true},
+		{"object keys", map[string]any{"shell": map[string]any{"org": "example"}}, []string{"shell"}, true},
+		{"number", 42.0, nil, false},
+		{"bool", true, nil, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := claimStrings(tc.value)
+			require.Equal(t, tc.ok, ok)
+			if tc.ok {
+				require.ElementsMatch(t, tc.want, got)
+			}
+		})
+	}
+}
+
+// A claim that is present and empty is an answer, not a miss: the search must
+// not fall through to a broader claim and turn "no roles" into a grant.
+func TestClaimSetStringsStopsAtAnEmptyClaim(t *testing.T) {
+	claims := claimSet{{"dozzle_roles": []any{}, "roles": []any{"shell"}}}
+
+	values, path, ok := claims.strings([]claimPath{{"dozzle_roles"}, {"roles"}})
+	require.True(t, ok)
+	require.Empty(t, values)
+	require.Equal(t, "dozzle_roles", path.String())
+}
+
+// A claim of the wrong shape is skipped, so a provider that puts a number at
+// `roles` does not shadow a usable claim further down the list.
+func TestClaimSetStringsSkipsUnusableShapes(t *testing.T) {
+	claims := claimSet{{"dozzle_roles": 7.0, "roles": "shell"}}
+
+	values, path, ok := claims.strings([]claimPath{{"dozzle_roles"}, {"roles"}})
+	require.True(t, ok)
+	require.Equal(t, []string{"shell"}, values)
+	require.Equal(t, "roles", path.String())
+}
+
+func TestParseClaimPath(t *testing.T) {
+	require.Equal(t, claimPath{"resource_access", "dozzle", "roles"}, parseClaimPath(" resource_access.dozzle.roles "))
+	require.Equal(t, claimPath{"roles"}, parseClaimPath("roles"))
+	require.Empty(t, parseClaimPath(""))
+	require.Empty(t, parseClaimPath("."))
+}
+
+func TestDecodeJWTClaims(t *testing.T) {
+	// {"sub":"abc","roles":["shell"]} with a bogus header and signature.
+	claims, err := decodeJWTClaims("eyJhbGciOiJub25lIn0.eyJzdWIiOiJhYmMiLCJyb2xlcyI6WyJzaGVsbCJdfQ.sig")
+	require.NoError(t, err)
+	require.Equal(t, "abc", claims["sub"])
+	require.Equal(t, []any{"shell"}, claims["roles"])
+
+	_, err = decodeJWTClaims("not-a-jwt")
+	require.Error(t, err)
+}
+
+func TestProfileKeyHashesUnsafeSubjects(t *testing.T) {
+	require.Equal(t, "auth0|123", profileKey("auth0|123"))
+	require.Equal(t, "3f2a9c1e-uuid", profileKey("3f2a9c1e-uuid"))
+
+	hashed := profileKey("https://issuer.example.com/users/42")
+	require.True(t, len(hashed) > len("oidc-"))
+	require.NotContains(t, hashed, "/")
+	require.Equal(t, hashed, profileKey("https://issuer.example.com/users/42"), "must be stable across logins")
+
+	require.NotEqual(t, "..", profileKey(".."))
+}

--- a/internal/auth/oauth.go
+++ b/internal/auth/oauth.go
@@ -16,14 +16,21 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// externalIdentity is what a provider tells us about whoever just signed in. It
-// is deliberately not a User: users.yml is the only place a Dozzle user is
-// defined, and this exists only to look one up there.
+// externalIdentity is what a provider tells us about whoever just signed in.
+//
+// Under simple auth it is deliberately not a User: users.yml is the only place a
+// Dozzle user is defined, and this exists only to look one up there. Under the
+// oidc provider there is no users.yml, and Claims is what the user is built from.
 type externalIdentity struct {
-	Sub   string
-	Login string
-	Email string
-	Name  string
+	Sub     string
+	Login   string
+	Email   string
+	Name    string
+	Picture string
+	// Claims is every claim the provider returned, ID token first and userinfo
+	// second, for the oidc provider to read roles and filters out of. Empty for
+	// GitHub, which publishes no claims.
+	Claims claimSet
 }
 
 // userLookup is the locked view of users.yml handed to a provider, so a provider
@@ -64,23 +71,42 @@ type OAuthProviderInfo struct {
 	Icon     string `json:"icon"`
 }
 
+// oauthFlow is the authorization code dance shared by simple auth with OAuth
+// bolted on and by the oidc provider: state cookie, PKCE, code exchange, and
+// reading the identity back. What happens to that identity is the one thing the
+// two disagree on, which is why it is a callback rather than a method.
+type oauthFlow struct {
+	providers []IdentityProvider
+	base      string
+	ttl       time.Duration
+	// login turns a verified identity into a session JWT, or refuses it. A refusal
+	// has already been logged with whatever detail the owner wanted to give.
+	login func(provider IdentityProvider, id externalIdentity) (string, bool)
+}
+
+func newOAuthFlow(base string, ttl time.Duration, login func(IdentityProvider, externalIdentity) (string, bool), providers ...IdentityProvider) *oauthFlow {
+	if base == "/" {
+		base = ""
+	}
+
+	return &oauthFlow{providers: providers, base: base, ttl: ttl, login: login}
+}
+
 // oauthAuthContext is simple auth with OAuth bolted on as a second way to prove
 // you are one of the users already in users.yml. It embeds the simple context so
 // password login, the middleware, and per-request role resolution are untouched.
 type oauthAuthContext struct {
 	*simpleAuthContext
-	providers []IdentityProvider
-	base      string
+	*oauthFlow
 }
 
 // NewOAuthAuth wraps simple auth. base is the router base ("" when Dozzle is
 // mounted at /), used to build the login URLs and the post-login redirect.
 func NewOAuthAuth(simple *simpleAuthContext, base string, providers ...IdentityProvider) *oauthAuthContext {
-	if base == "/" {
-		base = ""
-	}
+	a := &oauthAuthContext{simpleAuthContext: simple}
+	a.oauthFlow = newOAuthFlow(base, simple.ttl, a.loginUser, providers...)
 
-	return &oauthAuthContext{simpleAuthContext: simple, providers: providers, base: base}
+	return a
 }
 
 func (a *oauthAuthContext) byGithubLogin(login string) (User, bool) {
@@ -91,14 +117,37 @@ func (a *oauthAuthContext) byVerifiedEmail(email string) (User, bool) {
 	return a.findByEmail(email)
 }
 
+// loginUser is the simple-auth half of the flow: users.yml is the allowlist. No
+// match means no login, and no account is ever created here.
+func (a *oauthAuthContext) loginUser(provider IdentityProvider, identity externalIdentity) (string, bool) {
+	user, ok := provider.match(a, identity)
+	if !ok {
+		log.Warn().
+			Str("provider", provider.ID()).
+			Str("login", identity.Login).
+			Msg("OAuth login rejected: no user in the user database is linked to this account")
+		return "", false
+	}
+
+	jwt, err := a.issueToken(user)
+	if err != nil {
+		log.Error().Err(err).Msg("Could not create token after OAuth login")
+		return "", false
+	}
+
+	log.Info().Str("user", user.Username).Str("provider", provider.ID()).Msg("Token created")
+
+	return jwt, true
+}
+
 // Providers describes the configured providers to the frontend. The URLs are
 // already base-prefixed, so the login page uses them verbatim.
-func (a *oauthAuthContext) Providers() []OAuthProviderInfo {
-	infos := make([]OAuthProviderInfo, 0, len(a.providers))
-	for _, p := range a.providers {
+func (f *oauthFlow) Providers() []OAuthProviderInfo {
+	infos := make([]OAuthProviderInfo, 0, len(f.providers))
+	for _, p := range f.providers {
 		infos = append(infos, OAuthProviderInfo{
 			Name:     p.DisplayName(),
-			LoginURL: fmt.Sprintf("%s/api/auth/login?provider=%s", a.base, url.QueryEscape(p.ID())),
+			LoginURL: fmt.Sprintf("%s/api/auth/login?provider=%s", f.base, url.QueryEscape(p.ID())),
 			Icon:     p.Icon(),
 		})
 	}
@@ -106,14 +155,14 @@ func (a *oauthAuthContext) Providers() []OAuthProviderInfo {
 	return infos
 }
 
-func (a *oauthAuthContext) provider(id string) IdentityProvider {
+func (f *oauthFlow) provider(id string) IdentityProvider {
 	// Omitting ?provider= is unambiguous when only one is configured, which is
 	// the common single-vendor setup.
-	if id == "" && len(a.providers) == 1 {
-		return a.providers[0]
+	if id == "" && len(f.providers) == 1 {
+		return f.providers[0]
 	}
 
-	for _, p := range a.providers {
+	for _, p := range f.providers {
 		if p.ID() == id {
 			return p
 		}
@@ -148,7 +197,7 @@ type oauthState struct {
 // A spoofed Host cannot leak a code: the provider only honours a redirect_uri
 // that is on the OAuth app's registered list, so a forged value fails the login
 // instead. That is what lets Dozzle work without a base-URL flag.
-func (a *oauthAuthContext) callbackURL(r *http.Request) string {
+func (f *oauthFlow) callbackURL(r *http.Request) string {
 	scheme := "http"
 	if IsHTTPS(r) {
 		scheme = "https"
@@ -160,7 +209,7 @@ func (a *oauthAuthContext) callbackURL(r *http.Request) string {
 		host = strings.TrimSpace(host)
 	}
 
-	return scheme + "://" + host + a.base + "/api/auth/callback"
+	return scheme + "://" + host + f.base + "/api/auth/callback"
 }
 
 func randomString() (string, error) {
@@ -172,7 +221,7 @@ func randomString() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
-func (a *oauthAuthContext) setStateCookie(w http.ResponseWriter, r *http.Request, state oauthState) error {
+func (f *oauthFlow) setStateCookie(w http.ResponseWriter, r *http.Request, state oauthState) error {
 	encoded, err := json.Marshal(state)
 	if err != nil {
 		return err
@@ -182,7 +231,7 @@ func (a *oauthAuthContext) setStateCookie(w http.ResponseWriter, r *http.Request
 		Name:     stateCookieName,
 		Value:    base64.RawURLEncoding.EncodeToString(encoded),
 		HttpOnly: true,
-		Path:     a.base + "/",
+		Path:     f.base + "/",
 		// The callback is a top-level navigation from the provider, which is
 		// cross-site; Lax still sends the cookie on that, Strict would not.
 		SameSite: http.SameSiteLaxMode,
@@ -193,19 +242,19 @@ func (a *oauthAuthContext) setStateCookie(w http.ResponseWriter, r *http.Request
 	return nil
 }
 
-func (a *oauthAuthContext) clearStateCookie(w http.ResponseWriter, r *http.Request) {
+func (f *oauthFlow) clearStateCookie(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     stateCookieName,
 		Value:    "",
 		HttpOnly: true,
-		Path:     a.base + "/",
+		Path:     f.base + "/",
 		SameSite: http.SameSiteLaxMode,
 		Secure:   IsHTTPS(r),
 		MaxAge:   -1,
 	})
 }
 
-func (a *oauthAuthContext) readStateCookie(r *http.Request) (oauthState, bool) {
+func (f *oauthFlow) readStateCookie(r *http.Request) (oauthState, bool) {
 	cookie, err := r.Cookie(stateCookieName)
 	if err != nil {
 		return oauthState{}, false
@@ -230,8 +279,8 @@ func (a *oauthAuthContext) readStateCookie(r *http.Request) (oauthState, bool) {
 
 // LoginHandler starts the flow: it mints state and a PKCE verifier, parks them
 // in a short-lived cookie, and bounces the browser to the provider.
-func (a *oauthAuthContext) LoginHandler(w http.ResponseWriter, r *http.Request) {
-	provider := a.provider(r.URL.Query().Get("provider"))
+func (f *oauthFlow) LoginHandler(w http.ResponseWriter, r *http.Request) {
+	provider := f.provider(r.URL.Query().Get("provider"))
 	if provider == nil {
 		log.Warn().Str("provider", r.URL.Query().Get("provider")).Msg("Unknown OAuth provider requested")
 		http.Error(w, "Unknown provider", http.StatusBadRequest)
@@ -241,23 +290,23 @@ func (a *oauthAuthContext) LoginHandler(w http.ResponseWriter, r *http.Request) 
 	state, err := randomString()
 	if err != nil {
 		log.Error().Err(err).Msg("Could not generate OAuth state")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
 	verifier := oauth2.GenerateVerifier()
-	callbackURI := a.callbackURL(r)
+	callbackURI := f.callbackURL(r)
 
 	// Built before the cookie is set, so a provider that cannot start a login
 	// leaves no half-open state behind for the browser to carry around.
 	config, err := provider.oauth2Config(callbackURI)
 	if err != nil {
 		log.Error().Err(err).Str("provider", provider.ID()).Msg("Could not build the OAuth config")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
-	if err := a.setStateCookie(w, r, oauthState{
+	if err := f.setStateCookie(w, r, oauthState{
 		Provider:    provider.ID(),
 		State:       state,
 		Verifier:    verifier,
@@ -265,7 +314,7 @@ func (a *oauthAuthContext) LoginHandler(w http.ResponseWriter, r *http.Request) 
 		CallbackURI: callbackURI,
 	}); err != nil {
 		log.Error().Err(err).Msg("Could not set OAuth state cookie")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
@@ -280,14 +329,14 @@ func (a *oauthAuthContext) LoginHandler(w http.ResponseWriter, r *http.Request) 
 
 // CallbackHandler finishes the flow. Every failure path lands on the login page
 // with ?error=oauth rather than leaking which step failed.
-func (a *oauthAuthContext) CallbackHandler(w http.ResponseWriter, r *http.Request) {
+func (f *oauthFlow) CallbackHandler(w http.ResponseWriter, r *http.Request) {
 	// The state is single use whatever happens next.
-	a.clearStateCookie(w, r)
+	f.clearStateCookie(w, r)
 
-	state, ok := a.readStateCookie(r)
+	state, ok := f.readStateCookie(r)
 	if !ok {
 		log.Warn().Msg("OAuth callback without a valid state cookie")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
@@ -295,27 +344,27 @@ func (a *oauthAuthContext) CallbackHandler(w http.ResponseWriter, r *http.Reques
 
 	if errCode := query.Get("error"); errCode != "" {
 		log.Warn().Str("error", errCode).Str("description", query.Get("error_description")).Msg("OAuth provider returned an error")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
 	if subtle.ConstantTimeCompare([]byte(state.State), []byte(query.Get("state"))) != 1 {
 		log.Warn().Msg("OAuth callback state did not match the state cookie")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
-	provider := a.provider(state.Provider)
+	provider := f.provider(state.Provider)
 	if provider == nil {
 		log.Warn().Str("provider", state.Provider).Msg("OAuth callback for a provider that is no longer configured")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
 	code := query.Get("code")
 	if code == "" {
 		log.Warn().Msg("OAuth callback without a code")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
@@ -325,54 +374,40 @@ func (a *oauthAuthContext) CallbackHandler(w http.ResponseWriter, r *http.Reques
 	config, err := provider.oauth2Config(state.CallbackURI)
 	if err != nil {
 		log.Error().Err(err).Str("provider", provider.ID()).Msg("Could not build the OAuth config")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
 	token, err := config.Exchange(ctx, code, oauth2.VerifierOption(state.Verifier))
 	if err != nil {
 		log.Error().Err(err).Msg("Could not exchange OAuth code")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
 	identity, err := provider.identity(ctx, token)
 	if err != nil {
 		log.Error().Err(err).Msg("Could not read identity from OAuth provider")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
-	// users.yml is the allowlist. No match means no login, and no account is
-	// ever created here.
-	user, ok := provider.match(a, identity)
+	jwt, ok := f.login(provider, identity)
 	if !ok {
-		log.Warn().
-			Str("provider", provider.ID()).
-			Str("login", identity.Login).
-			Msg("OAuth login rejected: no user in the user database is linked to this account")
-		a.failLogin(w, r)
+		f.failLogin(w, r)
 		return
 	}
 
-	jwt, err := a.issueToken(user)
-	if err != nil {
-		log.Error().Err(err).Msg("Could not create token after OAuth login")
-		a.failLogin(w, r)
-		return
-	}
-
-	SetSessionCookie(w, r, jwt, a.ttl)
-	log.Info().Str("user", user.Username).Str("provider", provider.ID()).Msg("Token created")
+	SetSessionCookie(w, r, jwt, f.ttl)
 
 	target := state.RedirectURL
 	if target == "" {
 		target = "/"
 	}
 
-	http.Redirect(w, r, a.base+target, http.StatusFound)
+	http.Redirect(w, r, f.base+target, http.StatusFound)
 }
 
-func (a *oauthAuthContext) failLogin(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, a.base+"/login?error=oauth", http.StatusFound)
+func (f *oauthFlow) failLogin(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, f.base+"/login?error=oauth", http.StatusFound)
 }

--- a/internal/auth/oauth_oidc.go
+++ b/internal/auth/oauth_oidc.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
 )
 
@@ -22,6 +23,11 @@ type oidcProvider struct {
 	displayName  string
 	scopes       []string
 	client       *http.Client
+
+	// requireVerifiedEmail is set under simple auth, where the email is what
+	// matches the login to a users.yml entry. The oidc provider keys on sub and
+	// only displays the email, so an issuer with no email scope works there.
+	requireVerifiedEmail bool
 
 	// Discovery is fetched once and cached, but a failure is not cached: an IdP
 	// that is down while Dozzle boots must not disable SSO until the next
@@ -53,6 +59,8 @@ func NewOIDCProvider(issuer, clientID, clientSecret, displayName string) *oidcPr
 		displayName:  displayName,
 		scopes:       []string{"openid", "profile", "email"},
 		client:       &http.Client{Timeout: 10 * time.Second},
+
+		requireVerifiedEmail: true,
 	}
 }
 
@@ -151,6 +159,35 @@ type oidcUserInfo struct {
 	EmailVerified     any    `json:"email_verified"`
 	Name              string `json:"name"`
 	PreferredUsername string `json:"preferred_username"`
+	Picture           string `json:"picture"`
+}
+
+// fromClaims fills the standard claims from a decoded ID token, so a field the
+// userinfo response leaves out can still come from the token.
+func (u *oidcUserInfo) fromClaims(claims map[string]any) {
+	str := func(key string) string {
+		s, _ := claims[key].(string)
+		return s
+	}
+
+	if u.Sub == "" {
+		u.Sub = str("sub")
+	}
+	if u.Email == "" {
+		u.Email = str("email")
+		if verified, ok := claims["email_verified"]; ok {
+			u.EmailVerified = verified
+		}
+	}
+	if u.Name == "" {
+		u.Name = str("name")
+	}
+	if u.PreferredUsername == "" {
+		u.PreferredUsername = str("preferred_username")
+	}
+	if u.Picture == "" {
+		u.Picture = str("picture")
+	}
 }
 
 // verified normalizes email_verified, which some issuers send as the string
@@ -166,7 +203,7 @@ func (u oidcUserInfo) verified() bool {
 	}
 }
 
-// identity reads the claims from the userinfo endpoint.
+// identity reads the claims from the ID token and the userinfo endpoint.
 //
 // The id_token's signature is deliberately not checked here, because nothing
 // rests on it: the code was exchanged by this process, directly against the
@@ -185,6 +222,19 @@ func (o *oidcProvider) identity(ctx context.Context, token *oauth2.Token) (exter
 	config, err := o.oauth2Config("")
 	if err != nil {
 		return externalIdentity{}, err
+	}
+
+	// Best effort: a missing or malformed ID token only costs the claims that
+	// live in it, and userinfo is still read. Keycloak puts resource_access in
+	// the ID token and only mirrors it into userinfo when a mapper says so, so
+	// the token is the first place roles are looked for.
+	var claims claimSet
+	if raw, ok := token.Extra("id_token").(string); ok && raw != "" {
+		if idToken, err := decodeJWTClaims(raw); err == nil {
+			claims = append(claims, idToken)
+		} else {
+			log.Debug().Err(err).Msg("Could not decode the OIDC ID token; reading claims from userinfo only")
+		}
 	}
 
 	client := config.Client(ctx, token)
@@ -206,25 +256,44 @@ func (o *oidcProvider) identity(ctx context.Context, token *oauth2.Token) (exter
 		return externalIdentity{}, fmt.Errorf("OIDC userinfo returned %s", resp.Status)
 	}
 
-	var info oidcUserInfo
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+	var userInfo map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&userInfo); err != nil {
 		return externalIdentity{}, err
 	}
+	claims = append(claims, userInfo)
 
-	if info.Email == "" {
-		return externalIdentity{}, fmt.Errorf("OIDC userinfo returned no email; the issuer must grant the email scope")
+	// userinfo is the authoritative profile; the ID token fills in what it left
+	// out. Google, for one, only puts picture in userinfo.
+	var info oidcUserInfo
+	info.fromClaims(userInfo)
+	if len(claims) == 2 {
+		idSub, _ := claims[0]["sub"].(string)
+		// The spec has the client verify this: a userinfo response for a
+		// different subject than the token was issued for is not the same user.
+		if idSub != "" && info.Sub != "" && idSub != info.Sub {
+			return externalIdentity{}, fmt.Errorf("OIDC userinfo sub %q does not match the ID token sub %q", info.Sub, idSub)
+		}
+		info.fromClaims(claims[0])
 	}
 
-	// Matching an unverified address would let anyone who can register at a
-	// sloppy IdP claim a Dozzle account by typing in someone else's email.
-	if !info.verified() {
-		return externalIdentity{}, fmt.Errorf("OIDC userinfo reported email %q as unverified", info.Email)
+	if o.requireVerifiedEmail {
+		if info.Email == "" {
+			return externalIdentity{}, fmt.Errorf("OIDC userinfo returned no email; the issuer must grant the email scope")
+		}
+
+		// Matching an unverified address would let anyone who can register at a
+		// sloppy IdP claim a Dozzle account by typing in someone else's email.
+		if !info.verified() {
+			return externalIdentity{}, fmt.Errorf("OIDC userinfo reported email %q as unverified", info.Email)
+		}
 	}
 
 	return externalIdentity{
-		Sub:   info.Sub,
-		Login: info.PreferredUsername,
-		Email: info.Email,
-		Name:  info.Name,
+		Sub:     info.Sub,
+		Login:   info.PreferredUsername,
+		Email:   info.Email,
+		Name:    info.Name,
+		Picture: info.Picture,
+		Claims:  claims,
 	}, nil
 }

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -1,0 +1,259 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/amir20/dozzle/internal/container"
+	"github.com/go-chi/jwtauth/v5"
+	"github.com/rs/zerolog/log"
+)
+
+// OIDCConfig is everything --auth-provider oidc needs. Unlike simple auth with
+// OIDC bolted on, there is no users.yml behind it: the token is the user
+// database, so the config also says where in the token roles and filters live.
+type OIDCConfig struct {
+	Issuer       string
+	ClientID     string
+	ClientSecret string
+	// DisplayName is the label on the login button.
+	DisplayName string
+	// RolesClaim and FiltersClaim are dot-separated paths that replace the
+	// default search with the one path given. Empty means search the defaults.
+	RolesClaim   string
+	FiltersClaim string
+}
+
+// oidcAuthContext is the oidc provider: the IdP proves who you are and also
+// says what you may do. Nothing about a user is read from disk.
+type oidcAuthContext struct {
+	*oauthFlow
+	provider  *oidcProvider
+	tokenAuth *jwtauth.JWTAuth
+	ttl       time.Duration
+
+	rolesClaims   []claimPath
+	filtersClaims []claimPath
+}
+
+// ErrPasswordLoginUnavailable is what CreateToken returns under the oidc
+// provider. The route is not registered there, so it is only reachable from
+// code, but the Authorizer interface still has to answer.
+var ErrPasswordLoginUnavailable = errors.New("password login is not available with the oidc auth provider")
+
+// NewOIDCAuth builds the oidc provider. base is the router base, secret is the
+// persisted key from SessionSecret.
+func NewOIDCAuth(config OIDCConfig, base string, ttl time.Duration, secret []byte) *oidcAuthContext {
+	provider := NewOIDCProvider(config.Issuer, config.ClientID, config.ClientSecret, config.DisplayName)
+	// sub is the key here and the email is only for display, so an issuer that
+	// grants no email scope, or one that never marks addresses verified, is fine.
+	provider.requireVerifiedEmail = false
+
+	// The issuer and client id are hashed in with the secret so that repointing
+	// Dozzle at a different IdP invalidates every session minted under the old
+	// one: the same sub at a different issuer is a different person.
+	h := sha256.New()
+	h.Write(secret)
+	h.Write([]byte(provider.issuer))
+	h.Write([]byte(config.ClientID))
+
+	a := &oidcAuthContext{
+		provider:      provider,
+		tokenAuth:     jwtauth.New("HS256", h.Sum(nil), nil),
+		ttl:           ttl,
+		rolesClaims:   claimSearch(config.RolesClaim, "roles", config.ClientID),
+		filtersClaims: claimSearch(config.FiltersClaim, "filters", config.ClientID),
+	}
+	a.oauthFlow = newOAuthFlow(base, ttl, a.loginUser, provider)
+
+	return a
+}
+
+// claimSearch is the list of paths tried for a claim, in order. An explicit
+// path replaces the search outright.
+//
+// groups is deliberately absent from the defaults. At Authentik or Google every
+// user has one, so including it would turn "denied" into "signed in and can
+// read every container".
+func claimSearch(explicit, name, clientID string) []claimPath {
+	if path := parseClaimPath(explicit); len(path) > 0 {
+		return []claimPath{path}
+	}
+
+	return []claimPath{
+		{"dozzle_" + name},
+		{"resource_access", clientID, name},
+		{name},
+	}
+}
+
+// RolesClaims describes the paths roles are read from, for the startup log.
+func (a *oidcAuthContext) RolesClaims() string {
+	return describePaths(a.rolesClaims)
+}
+
+func describePaths(paths []claimPath) string {
+	names := make([]string, 0, len(paths))
+	for _, path := range paths {
+		names = append(names, path.String())
+	}
+
+	return strings.Join(names, ", ")
+}
+
+// PasswordLoginEnabled is always false: there is no password to check against.
+func (a *oidcAuthContext) PasswordLoginEnabled() bool { return false }
+
+func (a *oidcAuthContext) CreateToken(username, password string) (string, error) {
+	return "", ErrPasswordLoginUnavailable
+}
+
+// loginUser is where the token becomes a user. A token with no roles claim, or
+// an empty one, is refused: the IdP has not said this person may use Dozzle.
+// A claim that is present but names no Dozzle role signs in with no
+// privileges, the same as roles: none in users.yml.
+func (a *oidcAuthContext) loginUser(provider IdentityProvider, identity externalIdentity) (string, bool) {
+	if identity.Sub == "" {
+		log.Warn().Msg("OIDC login rejected: the issuer returned no sub claim")
+		return "", false
+	}
+
+	roles, rolesPath, ok := identity.Claims.strings(a.rolesClaims)
+	if !ok || len(roles) == 0 {
+		log.Warn().
+			Str("sub", identity.Sub).
+			Str("login", identity.Login).
+			Str("tried", describePaths(a.rolesClaims)).
+			Msg("OIDC login rejected: no roles claim found in the ID token or userinfo, or it was empty")
+		return "", false
+	}
+
+	var filters []string
+	if values, path, ok := identity.Claims.strings(a.filtersClaims); ok {
+		filters = values
+		log.Debug().Str("claim", path.String()).Strs("filters", filters).Msg("Resolved OIDC filters claim")
+	}
+
+	rolesRaw := strings.Join(roles, ",")
+	filtersRaw := strings.Join(filters, ",")
+
+	// Validated here so a typo in the IdP fails the login loudly rather than
+	// every request quietly.
+	if _, err := container.ParseContainerFilter(filtersRaw); err != nil {
+		log.Warn().Err(err).Str("sub", identity.Sub).Str("filters", filtersRaw).Msg("OIDC login rejected: the filters claim is not a valid container filter")
+		return "", false
+	}
+
+	user := a.newUser(identity.Sub, identity.Login, identity.Email, identity.Name, identity.Picture, rolesRaw, filtersRaw)
+
+	// Roles and filters ride in the session as the raw claim strings and are
+	// parsed again on every request. There is no users.yml to re-read, so the
+	// session is the only copy; a change at the IdP lands at the next login.
+	claims := map[string]any{
+		"sub":      identity.Sub,
+		"username": identity.Login,
+		"email":    identity.Email,
+		"name":     identity.Name,
+		"picture":  identity.Picture,
+		"roles":    rolesRaw,
+		"filters":  filtersRaw,
+	}
+	jwtauth.SetIssuedNow(claims)
+	if a.ttl > 0 {
+		jwtauth.SetExpiryIn(claims, a.ttl)
+	}
+
+	_, token, err := a.tokenAuth.Encode(claims)
+	if err != nil {
+		log.Error().Err(err).Msg("Could not create token after OIDC login")
+		return "", false
+	}
+
+	log.Info().
+		Str("user", user.Username).
+		Str("login", identity.Login).
+		Str("claim", rolesPath.String()).
+		Strs("roles", roles).
+		Msg("Token created")
+
+	return token, true
+}
+
+// newUser builds the request-scoped user from what the session carries.
+//
+// sub keys the user, and with it the profile directory, because it is the one
+// claim the spec guarantees stable and unique. preferred_username is not: an
+// IdP may let it change or be reused. The display name falls back through
+// preferred_username and email so the menu never shows a bare UUID unless the
+// issuer gave nothing else.
+func (a *oidcAuthContext) newUser(sub, login, email, name, picture, rolesRaw, filtersRaw string) User {
+	if name == "" {
+		name = login
+	}
+	if name == "" {
+		name = email
+	}
+	if name == "" {
+		name = sub
+	}
+
+	labels, _ := container.ParseContainerFilter(filtersRaw)
+
+	user := newUser(profileKey(sub), email, name, labels, ParseRole(rolesRaw))
+	user.Picture = picture
+
+	return user
+}
+
+// profileKey is the directory name under /data for a subject. sub is opaque
+// and some issuers put a slash in it, which the profile store rightly refuses
+// as a path, so such a value is hashed instead of written as is.
+func profileKey(sub string) string {
+	if filepath.Base(sub) == sub && sub != "." && sub != ".." {
+		return sub
+	}
+
+	sum := sha256.Sum256([]byte(sub))
+
+	return "oidc-" + hex.EncodeToString(sum[:8])
+}
+
+func (a *oidcAuthContext) AuthMiddleware(next http.Handler) http.Handler {
+	return jwtauth.Verifier(a.tokenAuth)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if user := a.userFromToken(r.Context()); user != nil {
+			r = r.WithContext(WithUser(r.Context(), *user))
+		}
+
+		next.ServeHTTP(w, r)
+	}))
+}
+
+// userFromToken rebuilds the user from the verified session. It returns nil for
+// a missing or invalid token so the request falls through to
+// RequireAuthentication as unauthenticated.
+func (a *oidcAuthContext) userFromToken(ctx context.Context) *User {
+	_, claims, err := jwtauth.FromContext(ctx)
+	if err != nil {
+		return nil
+	}
+
+	str := func(key string) string {
+		s, _ := claims[key].(string)
+		return s
+	}
+
+	sub := str("sub")
+	if sub == "" {
+		return nil
+	}
+
+	user := a.newUser(sub, str("username"), str("email"), str("name"), str("picture"), str("roles"), str("filters"))
+
+	return &user
+}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -150,7 +150,8 @@ func (a *oidcAuthContext) loginUser(provider IdentityProvider, identity external
 		return "", false
 	}
 
-	user := a.newUser(identity.Sub, identity.Login, identity.Email, identity.Name, identity.Picture, rolesRaw, filtersRaw)
+	picture := sessionPicture(identity.Picture)
+	user := a.newUser(identity.Sub, identity.Login, identity.Email, identity.Name, picture, rolesRaw, filtersRaw)
 
 	// Roles and filters ride in the session as the raw claim strings and are
 	// parsed again on every request. There is no users.yml to re-read, so the
@@ -160,7 +161,7 @@ func (a *oidcAuthContext) loginUser(provider IdentityProvider, identity external
 		"username": identity.Login,
 		"email":    identity.Email,
 		"name":     identity.Name,
-		"picture":  identity.Picture,
+		"picture":  picture,
 		"roles":    rolesRaw,
 		"filters":  filtersRaw,
 	}
@@ -175,6 +176,16 @@ func (a *oidcAuthContext) loginUser(provider IdentityProvider, identity external
 		return "", false
 	}
 
+	// Browsers drop a cookie past ~4KB without telling anyone, so the user just
+	// lands back on the login page. Refuse here instead, where it can be logged.
+	if len(token) > maxSessionCookieBytes {
+		log.Warn().
+			Str("sub", identity.Sub).
+			Int("bytes", len(token)).
+			Msg("OIDC login rejected: the session token is too large for a browser cookie, check for oversized name, email, roles or filters claims")
+		return "", false
+	}
+
 	log.Info().
 		Str("user", user.Username).
 		Str("login", identity.Login).
@@ -183,6 +194,25 @@ func (a *oidcAuthContext) loginUser(provider IdentityProvider, identity external
 		Msg("Token created")
 
 	return token, true
+}
+
+// maxSessionCookieBytes leaves room under the browser's 4096 byte cookie limit
+// for the name and attributes.
+const maxSessionCookieBytes = 3900
+
+// maxPictureBytes caps the picture carried in the session. Some issuers send a
+// data: URL of the image itself, several KB, which would overflow the cookie.
+const maxPictureBytes = 1024
+
+// sessionPicture keeps only a picture the avatar handler would actually serve,
+// so a data: URL or an oversized link never reaches the session cookie.
+func sessionPicture(picture string) string {
+	picture = User{Picture: picture}.PictureURL()
+	if len(picture) > maxPictureBytes {
+		return ""
+	}
+
+	return picture
 }
 
 // newUser builds the request-scoped user from what the session carries.

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -323,6 +324,29 @@ func TestOIDCAuthPictureFeedsTheAvatar(t *testing.T) {
 		user.Picture = picture
 		require.Empty(t, user.PictureURL(), picture)
 	}
+}
+
+// Keycloak can put the image itself in picture as a data: URL. It must not end
+// up in the session cookie, where it pushes past the browser's 4KB limit.
+func TestOIDCAuthDropsADataURLPictureFromTheSession(t *testing.T) {
+	claims := keycloakClaims("shell")
+	claims["picture"] = "data:image/png;base64," + strings.Repeat("A", 6000)
+	a := oidcUserAuth(t, oidcUserServer{idToken: claims}, OIDCConfig{})
+
+	jwt := sessionCookie(signIn(t, a))
+	require.Less(t, len(jwt.Value), maxSessionCookieBytes)
+
+	user := userFor(t, a, signIn(t, a))
+	require.Empty(t, user.Picture)
+	require.Contains(t, user.AvatarURL(), "gravatar.com")
+}
+
+func TestOIDCAuthRejectsASessionTooLargeForACookie(t *testing.T) {
+	claims := keycloakClaims("shell")
+	claims["name"] = strings.Repeat("a", 5000)
+	a := oidcUserAuth(t, oidcUserServer{idToken: claims}, OIDCConfig{})
+
+	requireRejected(t, signIn(t, a))
 }
 
 // Roles and filters ride in the session and are re-parsed per request, so the

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,0 +1,413 @@
+package auth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// oidcUserServer is a fake issuer for the oidc provider. idToken and userInfo
+// are the claim maps it serves, so a test can put roles in either.
+type oidcUserServer struct {
+	idToken  map[string]any
+	userInfo map[string]any
+}
+
+func (s oidcUserServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"issuer": %q, "authorization_endpoint": %q, "token_endpoint": %q, "userinfo_endpoint": %q}`,
+			server.URL, server.URL+"/authorize", server.URL+"/token", server.URL+"/userinfo")
+	})
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := map[string]any{"access_token": "at", "token_type": "bearer"}
+		if s.idToken != nil {
+			body["id_token"] = unsignedJWT(t, s.idToken)
+		}
+		json.NewEncoder(w).Encode(body)
+	})
+
+	mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		info := s.userInfo
+		if info == nil {
+			info = map[string]any{"sub": "abc-123"}
+		}
+		json.NewEncoder(w).Encode(info)
+	})
+
+	return server
+}
+
+func unsignedJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	payload, err := json.Marshal(claims)
+	require.NoError(t, err)
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
+
+	return header + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+func oidcUserAuth(t *testing.T, server oidcUserServer, config OIDCConfig) *oidcAuthContext {
+	t.Helper()
+
+	issuer := server.start(t)
+	config.Issuer = issuer.URL
+	if config.ClientID == "" {
+		config.ClientID = "dozzle"
+	}
+	config.ClientSecret = "secret"
+
+	return NewOIDCAuth(config, "", 0, testSecret)
+}
+
+// signIn runs the whole flow against the fake issuer and returns the callback
+// response.
+func signIn(t *testing.T, a *oidcAuthContext) *http.Response {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/login", nil)
+	req.Host = "dozzle.example.com"
+	w := httptest.NewRecorder()
+	a.LoginHandler(w, req)
+
+	res := w.Result()
+	require.Equal(t, http.StatusFound, res.StatusCode)
+
+	redirect, err := url.Parse(res.Header.Get("Location"))
+	require.NoError(t, err)
+	state := redirect.Query().Get("state")
+	require.NotEmpty(t, state)
+
+	var cookie *http.Cookie
+	for _, c := range res.Cookies() {
+		if c.Name == stateCookieName {
+			cookie = c
+		}
+	}
+	require.NotNil(t, cookie)
+
+	cb := httptest.NewRequest(http.MethodGet, "/api/auth/callback?code=the-code&state="+state, nil)
+	cb.AddCookie(cookie)
+	cw := httptest.NewRecorder()
+	a.CallbackHandler(cw, cb)
+
+	return cw.Result()
+}
+
+// userFor runs the session cookie back through the middleware and returns the
+// user it resolves, which is what every authenticated request sees.
+func userFor(t *testing.T, a *oidcAuthContext, res *http.Response) *User {
+	t.Helper()
+
+	jwt := sessionCookie(res)
+	require.NotNil(t, jwt, "expected a session cookie")
+
+	var user *User
+	handler := a.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user = UserFromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(jwt)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	return user
+}
+
+func keycloakClaims(roles ...any) map[string]any {
+	return map[string]any{
+		"sub":                "abc-123",
+		"preferred_username": "amir",
+		"name":               "Amir",
+		"email":              "amir@example.com",
+		"resource_access": map[string]any{
+			"dozzle": map[string]any{"roles": roles},
+		},
+	}
+}
+
+// The Keycloak shape from the issue signs in with nothing configured beyond
+// the issuer and client: resource_access.<client-id>.roles is on the default
+// search list.
+func TestOIDCAuthSignsInFromClientRolesInIDToken(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: keycloakClaims("shell", "actions")}, OIDCConfig{})
+
+	res := signIn(t, a)
+	require.Equal(t, http.StatusFound, res.StatusCode)
+	require.Equal(t, "/", res.Header.Get("Location"))
+
+	user := userFor(t, a, res)
+	require.NotNil(t, user)
+	require.Equal(t, "abc-123", user.Username, "sub keys the user and the profile directory")
+	require.Equal(t, "Amir", user.Name)
+	require.Equal(t, "amir@example.com", user.Email)
+	require.True(t, user.Roles.Has(Shell))
+	require.True(t, user.Roles.Has(Actions))
+	require.False(t, user.Roles.Has(Download))
+	require.False(t, user.ContainerLabels.Exists())
+}
+
+// Keycloak only mirrors resource_access into userinfo when a mapper says so,
+// but a provider that puts roles only there has to work too.
+func TestOIDCAuthReadsRolesFromUserInfoWhenIDTokenLacksThem(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{
+		idToken:  map[string]any{"sub": "abc-123"},
+		userInfo: map[string]any{"sub": "abc-123", "roles": []any{"download"}},
+	}, OIDCConfig{})
+
+	user := userFor(t, a, signIn(t, a))
+	require.NotNil(t, user)
+	require.Equal(t, Download, user.Roles)
+}
+
+func TestOIDCAuthRejectsWhenNoRolesClaimResolves(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: map[string]any{
+		"sub": "abc-123",
+		// groups is deliberately not searched: every user has one.
+		"groups": []any{"admins"},
+	}}, OIDCConfig{})
+
+	requireRejected(t, signIn(t, a))
+}
+
+func TestOIDCAuthRejectsAnEmptyRolesClaim(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: keycloakClaims()}, OIDCConfig{})
+
+	requireRejected(t, signIn(t, a))
+}
+
+// Present but meaningless is roles: none, not a refusal. Realm roles carry
+// offline_access and friends for everyone, which is exactly this case.
+func TestOIDCAuthSignsInWithNoPrivilegesWhenNoRoleMaps(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: keycloakClaims("offline_access", "uma_authorization")}, OIDCConfig{})
+
+	user := userFor(t, a, signIn(t, a))
+	require.NotNil(t, user)
+	require.Equal(t, None, user.Roles)
+}
+
+func TestOIDCAuthRejectsATokenWithoutSub(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{
+		idToken:  map[string]any{"roles": []any{"shell"}},
+		userInfo: map[string]any{"roles": []any{"shell"}},
+	}, OIDCConfig{})
+
+	requireRejected(t, signIn(t, a))
+}
+
+func TestOIDCAuthExplicitClaimReplacesTheSearch(t *testing.T) {
+	claims := keycloakClaims("shell")
+	claims["custom"] = map[string]any{"dozzle": map[string]any{"perms": "actions"}}
+
+	a := oidcUserAuth(t, oidcUserServer{idToken: claims}, OIDCConfig{RolesClaim: "custom.dozzle.perms"})
+
+	user := userFor(t, a, signIn(t, a))
+	require.NotNil(t, user)
+	require.Equal(t, Actions, user.Roles, "the explicit path wins and the defaults are not consulted")
+
+	// And when the explicit path is missing, the defaults do not rescue it.
+	b := oidcUserAuth(t, oidcUserServer{idToken: keycloakClaims("shell")}, OIDCConfig{RolesClaim: "custom.dozzle.perms"})
+	requireRejected(t, signIn(t, b))
+}
+
+func TestOIDCAuthFiltersFromClaim(t *testing.T) {
+	claims := keycloakClaims("shell")
+	claims["resource_access"].(map[string]any)["dozzle"].(map[string]any)["filters"] = []any{"label=com.example.app", "name=web"}
+
+	a := oidcUserAuth(t, oidcUserServer{idToken: claims}, OIDCConfig{})
+
+	user := userFor(t, a, signIn(t, a))
+	require.NotNil(t, user)
+	require.Equal(t, []string{"com.example.app"}, user.ContainerLabels["label"])
+	require.Equal(t, []string{"web"}, user.ContainerLabels["name"])
+}
+
+// A filter the IdP got wrong must fail the login rather than grant every
+// container, which is what silently dropping it would do.
+func TestOIDCAuthRejectsAnInvalidFilter(t *testing.T) {
+	claims := keycloakClaims("shell")
+	claims["dozzle_filters"] = []any{"not-a-filter"}
+
+	a := oidcUserAuth(t, oidcUserServer{idToken: claims}, OIDCConfig{})
+
+	requireRejected(t, signIn(t, a))
+}
+
+// Zitadel encodes project roles as an object keyed by role name.
+func TestOIDCAuthAcceptsObjectShapedRoles(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: map[string]any{
+		"sub":          "abc-123",
+		"dozzle_roles": map[string]any{"shell": map[string]any{"org": "example.com"}},
+	}}, OIDCConfig{})
+
+	user := userFor(t, a, signIn(t, a))
+	require.NotNil(t, user)
+	require.Equal(t, Shell, user.Roles)
+}
+
+func TestOIDCAuthNegatedRolesWork(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: keycloakClaims("all", "^shell")}, OIDCConfig{})
+
+	user := userFor(t, a, signIn(t, a))
+	require.NotNil(t, user)
+	require.Equal(t, All&^Shell, user.Roles)
+}
+
+// An unverified or missing email is fine here: sub is the key and the email is
+// only display.
+func TestOIDCAuthDoesNotRequireAVerifiedEmail(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: map[string]any{
+		"sub":            "abc-123",
+		"email":          "amir@example.com",
+		"email_verified": false,
+		"roles":          []any{"shell"},
+	}}, OIDCConfig{})
+
+	user := userFor(t, a, signIn(t, a))
+	require.NotNil(t, user)
+	require.Equal(t, "amir@example.com", user.Email)
+
+	b := oidcUserAuth(t, oidcUserServer{idToken: map[string]any{"sub": "abc-123", "roles": []any{"shell"}}}, OIDCConfig{})
+	user = userFor(t, b, signIn(t, b))
+	require.NotNil(t, user)
+	require.Equal(t, "abc-123", user.Name, "with nothing else to show, the name falls back to sub")
+}
+
+func TestOIDCAuthDisplayNameFallsBackThroughUsernameAndEmail(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: map[string]any{
+		"sub":                "abc-123",
+		"preferred_username": "amir",
+		"roles":              []any{"shell"},
+	}}, OIDCConfig{})
+	require.Equal(t, "amir", userFor(t, a, signIn(t, a)).Name)
+
+	b := oidcUserAuth(t, oidcUserServer{idToken: map[string]any{
+		"sub":   "abc-123",
+		"email": "amir@example.com",
+		"roles": []any{"shell"},
+	}}, OIDCConfig{})
+	require.Equal(t, "amir@example.com", userFor(t, b, signIn(t, b)).Name)
+}
+
+func TestOIDCAuthPictureFeedsTheAvatar(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: map[string]any{
+		"sub":     "abc-123",
+		"picture": "https://cdn.example.com/amir.png",
+		"roles":   []any{"shell"},
+	}}, OIDCConfig{})
+
+	user := userFor(t, a, signIn(t, a))
+	require.Equal(t, "https://cdn.example.com/amir.png", user.PictureURL())
+	require.Contains(t, user.AvatarURL(), "gravatar.com", "the gravatar fallback is untouched")
+
+	// Anything but an https URL is dropped rather than handed to the browser.
+	for _, picture := range []string{"javascript:alert(1)", "http://cdn.example.com/amir.png", "/relative.png", "https://"} {
+		user.Picture = picture
+		require.Empty(t, user.PictureURL(), picture)
+	}
+}
+
+// Roles and filters ride in the session and are re-parsed per request, so the
+// middleware needs nothing but the cookie.
+func TestOIDCAuthSessionCarriesRolesAndFilters(t *testing.T) {
+	claims := keycloakClaims("shell")
+	claims["dozzle_filters"] = "label=team=a"
+	a := oidcUserAuth(t, oidcUserServer{idToken: claims}, OIDCConfig{})
+
+	jwt := sessionCookie(signIn(t, a))
+	decoded, err := a.tokenAuth.Decode(jwt.Value)
+	require.NoError(t, err)
+
+	var roles, filters, sub string
+	require.NoError(t, decoded.Get("roles", &roles))
+	require.NoError(t, decoded.Get("filters", &filters))
+	require.NoError(t, decoded.Get("sub", &sub))
+	require.Equal(t, "shell", roles)
+	require.Equal(t, "label=team=a", filters)
+	require.Equal(t, "abc-123", sub)
+}
+
+func TestOIDCAuthSessionExpiresWithTTL(t *testing.T) {
+	issuer := oidcUserServer{idToken: keycloakClaims("shell")}.start(t)
+	a := NewOIDCAuth(OIDCConfig{Issuer: issuer.URL, ClientID: "dozzle", ClientSecret: "secret"}, "", time.Hour, testSecret)
+
+	res := signIn(t, a)
+	jwt := sessionCookie(res)
+	require.NotNil(t, jwt)
+	require.WithinDuration(t, time.Now().Add(time.Hour), jwt.Expires, time.Minute)
+
+	decoded, err := a.tokenAuth.Decode(jwt.Value)
+	require.NoError(t, err)
+	exp, ok := decoded.Expiration()
+	require.True(t, ok)
+	require.WithinDuration(t, time.Now().Add(time.Hour), exp, time.Minute)
+}
+
+// Repointing Dozzle at another issuer must invalidate sessions minted under the
+// old one: the same sub at a different issuer is a different person.
+func TestOIDCAuthSessionsDoNotSurviveAnIssuerChange(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{idToken: keycloakClaims("shell")}, OIDCConfig{})
+	jwt := sessionCookie(signIn(t, a))
+
+	b := NewOIDCAuth(OIDCConfig{Issuer: "https://other.example.com", ClientID: "dozzle", ClientSecret: "secret"}, "", 0, testSecret)
+
+	var user *User
+	handler := b.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user = UserFromContext(r.Context())
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.AddCookie(jwt)
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Nil(t, user)
+}
+
+func TestOIDCAuthHasNoPasswordLogin(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{}, OIDCConfig{DisplayName: "Keycloak"})
+
+	require.False(t, a.PasswordLoginEnabled())
+	_, err := a.CreateToken("amir", "password")
+	require.ErrorIs(t, err, ErrPasswordLoginUnavailable)
+
+	providers := a.Providers()
+	require.Len(t, providers, 1)
+	require.Equal(t, "Keycloak", providers[0].Name)
+	require.Equal(t, "/api/auth/login?provider=oidc", providers[0].LoginURL)
+}
+
+func TestOIDCAuthDescribesItsClaimSearch(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{}, OIDCConfig{ClientID: "my-client"})
+	require.Equal(t, "dozzle_roles, resource_access.my-client.roles, roles", a.RolesClaims())
+
+	b := oidcUserAuth(t, oidcUserServer{}, OIDCConfig{RolesClaim: "realm_access.roles"})
+	require.Equal(t, "realm_access.roles", b.RolesClaims())
+}
+
+// A userinfo response for a different subject than the ID token is not the
+// same user, and the spec has the client check that.
+func TestOIDCAuthRejectsUserInfoSubMismatch(t *testing.T) {
+	a := oidcUserAuth(t, oidcUserServer{
+		idToken:  keycloakClaims("shell"),
+		userInfo: map[string]any{"sub": "someone-else"},
+	}, OIDCConfig{})
+
+	requireRejected(t, signIn(t, a))
+}

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -30,6 +30,29 @@ type User struct {
 	RolesConfigured string                    `json:"-" yaml:"roles"`
 	ContainerLabels container.ContainerLabels `json:"-" yaml:"-"`
 	Roles           Role                      `json:"-" yaml:"-"`
+	// Picture is an avatar URL the identity provider asserted, set only by the
+	// oidc provider. See PictureURL for why it is not proxied like the gravatar.
+	Picture string `json:"-" yaml:"-"`
+}
+
+// PictureURL is the provider-asserted avatar, or "" when there is none or it is
+// not an https URL. The avatar handler redirects the browser to it rather than
+// fetching it the way it fetches the gravatar: at many providers a user can
+// edit their own picture, so fetching it server-side would let anyone who can
+// sign in point Dozzle at an internal address and read the response back.
+// https only, because a Dozzle served over TLS cannot show an http image anyway.
+func (u User) PictureURL() string {
+	picture := strings.TrimSpace(u.Picture)
+	if picture == "" {
+		return ""
+	}
+
+	parsed, err := url.Parse(picture)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return ""
+	}
+
+	return picture
 }
 
 func (u User) AvatarURL() string {

--- a/internal/support/cli/args.go
+++ b/internal/support/cli/args.go
@@ -21,20 +21,22 @@ type Args struct {
 	Hostname               string              `arg:"env:DOZZLE_HOSTNAME" help:"sets the hostname for display. This is useful with multiple Dozzle instances."`
 	HostID                 string              `arg:"--host-id,env:DOZZLE_HOST_ID" help:"overrides the id Dozzle derives for this host. Only needed when the derived id collides with another host."`
 	Level                  string              `arg:"env:DOZZLE_LEVEL" default:"info" help:"set Dozzle log level. Use debug for more logging."`
-	AuthProvider           string              `arg:"--auth-provider,env:DOZZLE_AUTH_PROVIDER" default:"none" help:"sets the auth provider to use: none, simple or forward-proxy. github and google are aliases for simple."`
+	AuthProvider           string              `arg:"--auth-provider,env:DOZZLE_AUTH_PROVIDER" default:"none" help:"sets the auth provider to use: none, simple, oidc or forward-proxy. github and google are aliases for simple."`
 	AuthTTL                string              `arg:"--auth-ttl,env:DOZZLE_AUTH_TTL" default:"session" help:"sets the TTL for the auth token. Accepts duration values like 12h. Valid time units are s, m, h"`
 	AuthHeaderUser         string              `arg:"--auth-header-user,env:DOZZLE_AUTH_HEADER_USER" default:"Remote-User" help:"sets the HTTP Header to use for username in Forward Proxy configuration."`
 	AuthHeaderEmail        string              `arg:"--auth-header-email,env:DOZZLE_AUTH_HEADER_EMAIL" default:"Remote-Email" help:"sets the HTTP Header to use for email in Forward Proxy configuration."`
 	AuthHeaderName         string              `arg:"--auth-header-name,env:DOZZLE_AUTH_HEADER_NAME" default:"Remote-Name" help:"sets the HTTP Header to use for name in Forward Proxy configuration."`
 	AuthHeaderFilter       string              `arg:"--auth-header-filter,env:DOZZLE_AUTH_HEADER_FILTER" default:"Remote-Filter" help:"sets the HTTP Header to use for filtering in Forward Proxy configuration."`
 	AuthHeaderRoles        string              `arg:"--auth-header-roles,env:DOZZLE_AUTH_HEADER_ROLES" default:"Remote-Roles" help:"sets the HTTP Header to use for roles in Forward Proxy configuration."`
-	AuthLogoutUrl          string              `arg:"--auth-logout-url,env:DOZZLE_AUTH_LOGOUT_URL" help:"sets the Logout URL used with Forward Proxy."`
+	AuthLogoutUrl          string              `arg:"--auth-logout-url,env:DOZZLE_AUTH_LOGOUT_URL" help:"sets the Logout URL used with Forward Proxy, and where the browser is sent after logout with the oidc auth provider."`
 	AuthGithubClientID     string              `arg:"--auth-github-client-id,env:DOZZLE_AUTH_GITHUB_CLIENT_ID" help:"sets the GitHub OAuth app client id, enabling Sign in with GitHub for simple auth."`
 	AuthGithubClientSecret string              `arg:"--auth-github-client-secret,env:DOZZLE_AUTH_GITHUB_CLIENT_SECRET" help:"sets the GitHub OAuth app client secret."`
 	AuthOidcIssuer         string              `arg:"--auth-oidc-issuer,env:DOZZLE_AUTH_OIDC_ISSUER" help:"sets the OpenID Connect issuer URL, enabling SSO for simple auth. Works with Google, Keycloak, Pocket ID, Zitadel and Authentik."`
 	AuthOidcClientID       string              `arg:"--auth-oidc-client-id,env:DOZZLE_AUTH_OIDC_CLIENT_ID" help:"sets the OpenID Connect client id."`
 	AuthOidcClientSecret   string              `arg:"--auth-oidc-client-secret,env:DOZZLE_AUTH_OIDC_CLIENT_SECRET" help:"sets the OpenID Connect client secret."`
 	AuthOidcName           string              `arg:"--auth-oidc-name,env:DOZZLE_AUTH_OIDC_NAME" default:"SSO" help:"sets the label shown on the OpenID Connect login button."`
+	AuthOidcRolesClaim     string              `arg:"--auth-oidc-roles-claim,env:DOZZLE_AUTH_OIDC_ROLES_CLAIM" help:"sets the dot-separated claim path roles are read from with the oidc auth provider, replacing the default search of dozzle_roles, resource_access.<client-id>.roles and roles."`
+	AuthOidcFiltersClaim   string              `arg:"--auth-oidc-filters-claim,env:DOZZLE_AUTH_OIDC_FILTERS_CLAIM" help:"sets the dot-separated claim path container filters are read from with the oidc auth provider, replacing the default search of dozzle_filters, resource_access.<client-id>.filters and filters."`
 	EnableActions          bool                `arg:"--enable-actions,env:DOZZLE_ENABLE_ACTIONS" default:"false" help:"enables essential actions on containers from the web interface."`
 	EnableShell            bool                `arg:"--enable-shell,env:DOZZLE_ENABLE_SHELL" default:"false" help:"enables shell access to containers from the web interface."`
 	EnableMCP              bool                `arg:"--enable-mcp,env:DOZZLE_ENABLE_MCP" default:"false" help:"enables the MCP (Model Context Protocol) endpoint for LLM integration."`

--- a/internal/web/auth_oidc_test.go
+++ b/internal/web/auth_oidc_test.go
@@ -1,0 +1,115 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/amir20/dozzle/internal/auth"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func oidcHandler(t *testing.T) http.Handler {
+	t.Helper()
+
+	// The fixture renders the injected config so the login page's inputs can be
+	// asserted on.
+	fs := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fs, "index.html", []byte(`<script>window.__CONFIG__ = {{ marshal .Config }};</script>`), 0644))
+
+	// The issuer is never contacted by these tests: discovery is lazy and only
+	// the login start would trigger it.
+	authorizer := auth.NewOIDCAuth(auth.OIDCConfig{
+		Issuer:       "http://127.0.0.1:1",
+		ClientID:     "dozzle",
+		ClientSecret: "secret",
+		DisplayName:  "Keycloak",
+	}, "", 0, testSecret)
+
+	return createHandler(nil, afero.NewIOFS(fs), Config{Base: "/", Authorization: Authorization{
+		Provider:   OIDC,
+		Authorizer: authorizer,
+		LogoutUrl:  "https://id.example.com/logout",
+	}})
+}
+
+func Test_createRoutes_oidc_redirects_to_login(t *testing.T) {
+	handler := oidcHandler(t)
+
+	req, err := http.NewRequest("GET", "/containers/abc", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusTemporaryRedirect, rr.Code)
+	assert.Equal(t, "/login?redirectUrl=%2Fcontainers%2Fabc", rr.Header().Get("Location"))
+}
+
+func Test_createRoutes_oidc_login_page_offers_only_the_provider(t *testing.T) {
+	handler := oidcHandler(t)
+
+	req, err := http.NewRequest("GET", "/login", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	body := rr.Body.String()
+	assert.Contains(t, body, `"passwordLogin":false`)
+	assert.Contains(t, body, `"name":"Keycloak"`)
+	assert.Contains(t, body, `/api/auth/login?provider=oidc`)
+}
+
+// There is no password to check under oidc, so the password endpoint does not
+// exist, while logout and the OAuth legs do.
+func Test_createRoutes_oidc_has_no_password_login(t *testing.T) {
+	handler := oidcHandler(t)
+
+	req, err := http.NewRequest("POST", "/api/token", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code, "POST /api/token must not be registered")
+
+	req, err = http.NewRequest("DELETE", "/api/token", nil)
+	require.NoError(t, err)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code, "logout must clear the session")
+	assert.Contains(t, rr.Header().Get("Set-Cookie"), "jwt=;")
+
+	// A callback with no state cookie is rejected, which proves the route exists.
+	req, err = http.NewRequest("GET", "/api/auth/callback?code=x&state=y", nil)
+	require.NoError(t, err)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, "/login?error=oauth", rr.Header().Get("Location"))
+}
+
+func Test_createRoutes_oidc_requires_auth_for_api(t *testing.T) {
+	handler := oidcHandler(t)
+
+	req, err := http.NewRequest("GET", "/api/version", nil)
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+// A provider-asserted picture is served by redirect, so Dozzle never fetches a
+// URL a user may have typed into their own profile.
+func Test_avatar_redirects_to_provider_picture(t *testing.T) {
+	h := &handler{config: &Config{}}
+
+	req := httptest.NewRequest("GET", "/api/profile/avatar", nil)
+	req = req.WithContext(auth.WithUser(req.Context(), auth.User{Username: "abc", Picture: "https://cdn.example.com/a.png"}))
+	rr := httptest.NewRecorder()
+	h.avatar(rr, req)
+
+	assert.Equal(t, http.StatusFound, rr.Code)
+	assert.Equal(t, "https://cdn.example.com/a.png", rr.Header().Get("Location"))
+}

--- a/internal/web/index.go
+++ b/internal/web/index.go
@@ -81,7 +81,7 @@ func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
 			}
 			http.Error(w, "Unauthorized user", http.StatusUnauthorized)
 			return
-		case SIMPLE:
+		case SIMPLE, OIDC:
 			if req.URL.Path != "login" {
 				log.Debug().Str("url", req.URL.String()).Msg("Redirecting to login page")
 				// The login page navigates to whatever comes back in redirectUrl, so
@@ -150,8 +150,13 @@ func (h *handler) executeTemplate(w http.ResponseWriter, req *http.Request) {
 			config["user"] = user
 		}
 
-		if h.config.Authorization.Provider == FORWARD_PROXY && strings.TrimSpace(h.config.Authorization.LogoutUrl) != "" {
-			config["logoutUrl"] = strings.TrimSpace(h.config.Authorization.LogoutUrl)
+		// Forward proxy has no session of its own to clear, so the URL is the
+		// whole logout. Under oidc it is where the browser goes after Dozzle's
+		// session is cleared, typically the issuer's end_session_endpoint.
+		if provider := h.config.Authorization.Provider; provider == FORWARD_PROXY || provider == OIDC {
+			if logoutURL := strings.TrimSpace(h.config.Authorization.LogoutUrl); logoutURL != "" {
+				config["logoutUrl"] = logoutURL
+			}
 		}
 	}
 

--- a/internal/web/profile.go
+++ b/internal/web/profile.go
@@ -31,6 +31,12 @@ func (h *handler) avatar(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A provider-asserted picture is served by redirect, never fetched here.
+	if picture := user.PictureURL(); picture != "" {
+		http.Redirect(w, r, picture, http.StatusFound)
+		return
+	}
+
 	url := user.AvatarURL()
 
 	if url == "" {

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -39,6 +39,9 @@ const (
 	NONE          AuthProvider = "none"
 	SIMPLE        AuthProvider = "simple"
 	FORWARD_PROXY AuthProvider = "forward-proxy"
+	// OIDC is the provider where the identity provider is also the user
+	// database: no users.yml, no password form.
+	OIDC AuthProvider = "oidc"
 )
 
 // Config is a struct for configuring the web service
@@ -298,8 +301,13 @@ func createRouter(h *handler) *chi.Mux {
 			})
 
 			// Public API routes
-			if h.config.Authorization.Provider == SIMPLE {
-				r.Post("/token", h.createToken)
+			switch h.config.Authorization.Provider {
+			case SIMPLE, OIDC:
+				// No POST /token under oidc: there is no password to check, and
+				// not registering the route is what makes that verifiable.
+				if h.config.Authorization.Provider == SIMPLE {
+					r.Post("/token", h.createToken)
+				}
 				r.Delete("/token", h.deleteToken)
 
 				// Both have to stay unauthenticated: they are how a session is

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	case "github", "google":
 		log.Debug().Str("alias", args.AuthProvider).Msg("Auth provider is an alias for simple")
 		args.AuthProvider = "simple"
-	case "none", "forward-proxy", "simple":
+	case "none", "forward-proxy", "simple", "oidc":
 	default:
 		log.Fatal().Str("provider", args.AuthProvider).Msg("Invalid auth provider")
 	}
@@ -250,6 +250,56 @@ func oauthProviders(args cli.Args) []auth.IdentityProvider {
 	return providers
 }
 
+// oidcAuth builds the oidc provider, where the token is the user database.
+//
+// It shares the --auth-oidc-* flags with simple auth, so the split between the
+// two has to show up in behavior: this mode never opens users.yml, refuses the
+// GitHub flags, and says at startup which claims it will read roles from.
+func oidcAuth(args cli.Args) web.OAuthAuthorizer {
+	if args.AuthOidcIssuer == "" || args.AuthOidcClientID == "" || args.AuthOidcClientSecret == "" {
+		log.Fatal().Msg("--auth-oidc-issuer, --auth-oidc-client-id and --auth-oidc-client-secret are required with --auth-provider oidc")
+	}
+
+	// GitHub is not an OpenID Connect issuer and publishes no claims to read
+	// roles from, so it cannot be a user database. Failing here beats a button
+	// that signs nobody in.
+	if args.AuthGithubClientID != "" || args.AuthGithubClientSecret != "" {
+		log.Fatal().Msg("--auth-github-client-id and --auth-github-client-secret cannot be used with --auth-provider oidc; use --auth-provider simple to sign users.yml users in with GitHub")
+	}
+
+	dataDir := "./data"
+	for _, name := range []string{"users.yml", "users.yaml"} {
+		if fileExists(filepath.Join(dataDir, name)) {
+			log.Warn().Str("file", name).Msg("Ignoring the user database: with --auth-provider oidc every user comes from the token")
+		}
+	}
+
+	ttl := time.Duration(0)
+	if args.AuthTTL != "session" {
+		var err error
+		ttl, err = time.ParseDuration(args.AuthTTL)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Could not parse auth ttl")
+		}
+	}
+
+	authorizer := auth.NewOIDCAuth(auth.OIDCConfig{
+		Issuer:       args.AuthOidcIssuer,
+		ClientID:     args.AuthOidcClientID,
+		ClientSecret: args.AuthOidcClientSecret,
+		DisplayName:  args.AuthOidcName,
+		RolesClaim:   args.AuthOidcRolesClaim,
+		FiltersClaim: args.AuthOidcFiltersClaim,
+	}, args.Base, ttl, auth.SessionSecret(dataDir))
+
+	log.Info().
+		Str("issuer", args.AuthOidcIssuer).
+		Str("rolesClaim", authorizer.RolesClaims()).
+		Msg("Using OpenID Connect authentication; users and roles come from the token")
+
+	return authorizer
+}
+
 func fileExists(filename string) bool {
 	_, err := os.Stat(filename)
 	if os.IsNotExist(err) {
@@ -314,6 +364,9 @@ func createServer(args cli.Args, hostService web.HostService, cloudHooks web.Clo
 		if providers := oauthProviders(args); len(providers) > 0 {
 			authorizer = auth.NewOAuthAuth(simpleAuth, args.Base, providers...)
 		}
+	} else if args.AuthProvider == "oidc" {
+		provider = web.OIDC
+		authorizer = oidcAuth(args)
 	}
 
 	authTTL := time.Duration(0)


### PR DESCRIPTION
Adds --auth-provider oidc, where the identity provider is the user database
and users.yml is never read. Roles come from the first of dozzle_roles,
resource_access.<client-id>.roles and roles that exists in the ID token or
userinfo, filters from the matching filters claims, and both can be
overridden with --auth-oidc-roles-claim and --auth-oidc-filters-claim.

A login with no roles claim, or an empty one, is refused and the log names
the paths tried. A claim that names no Dozzle role signs in with no
privileges, like roles: none. sub keys the user and the profile directory,
the email does not have to be verified, and a picture claim feeds the
avatar by redirect. Roles and filters ride in Dozzle's session JWT and are
re-parsed per request, so a change at the IdP lands at the next login.

The OAuth code exchange is shared with simple auth through oauthFlow, so
the two providers differ only in what happens to the identity. Under oidc
there is no password form or POST /api/token, the GitHub flags are a
startup error, and --auth-logout-url is honored after the session is
cleared.

Docs get a new OpenID Connect page and updates to the authentication
overview, the GitHub & OIDC page and the env var table, translated into
de, fr, es and zh.

Closes #5121

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014X3D6uNjy6WjMU849WfRxm